### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The documentation is available [here](https://docs.grandine.io/). Feel free to r
 
 ## Performance
 
-Grandine is a optimised and parallelised client. There aren't many published performance comparisions, but a previous [research](https://arxiv.org/abs/2311.05252) by MigaLabs may give some insight. We run 50,000 Holesky validators on one of our developer's machine.
+Grandine is an optimised and parallelised client. There aren't many published performance comparisions, but a previous [research](https://arxiv.org/abs/2311.05252) by MigaLabs may give some insight. We run 50,000 Holesky validators on one of our developer's machine.
 
 ## Memory Usage
 

--- a/book/src/cli_options.md
+++ b/book/src/cli_options.md
@@ -70,7 +70,7 @@ The list of command line options:
       --jwt-id <JWT_ID>
           Optional CL unique identifier to send to EL in the JWT token claim [default: None]
       --jwt-secret <JWT_SECRET>
-          Path to a file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens
+          Path to a file containing the hex-encoded 256-bit secret key to be used for verifying/generating JWT tokens
       --jwt-version <JWT_VERSION>
           Optional CL node type/version to send to EL in the JWT token claim [default: None]
       --back-sync


### PR DESCRIPTION
- Corrected the article usage in `README.md` by changing "a optimised" to "an optimised."
- Added a hyphen in "256-bit" in `cli_options.md` to maintain proper spelling and formatting.

This PR improves the grammar and formatting for better readability and consistency.
