### PR TITLE
Fetch blobs from EL via `engine_getBlobsV1`:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,9 @@ name = "eth1_api"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bls",
+ "dedicated_executor",
  "derive_more 1.0.0",
  "either",
  "enum-iterator",
@@ -2280,9 +2282,11 @@ dependencies = [
  "fork_choice_control",
  "fs-err",
  "futures",
+ "helper_functions",
  "hex",
  "hex-literal",
  "httpmock",
+ "itertools 0.13.0",
  "jwt-simple",
  "log",
  "memoffset",

--- a/eth1_api/Cargo.toml
+++ b/eth1_api/Cargo.toml
@@ -8,7 +8,9 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 bls = { workspace = true }
+dedicated_executor = { workspace = true }
 derive_more = { workspace = true }
 either = { workspace = true }
 enum-iterator = { workspace = true }
@@ -18,8 +20,10 @@ features = { workspace = true }
 fork_choice_control = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
+helper_functions = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
+itertools = { workspace = true }
 jwt-simple = { workspace = true }
 log = { workspace = true }
 memoffset = { workspace = true }

--- a/eth1_api/src/eth1_execution_engine.rs
+++ b/eth1_api/src/eth1_execution_engine.rs
@@ -8,8 +8,9 @@ use futures::channel::{mpsc::UnboundedSender, oneshot::Sender};
 use log::{info, warn};
 use tokio::runtime::{Builder, Handle};
 use types::{
-    combined::{ExecutionPayload, ExecutionPayloadParams},
+    combined::{ExecutionPayload, ExecutionPayloadParams, SignedBeaconBlock},
     config::Config,
+    deneb::primitives::BlobIndex,
     nonstandard::{Phase, TimedPowBlock, WithBlobsAndMev},
     phase0::primitives::{ExecutionBlockHash, H256},
     preset::Preset,
@@ -30,6 +31,18 @@ impl<P: Preset> ExecutionEngine<P> for Eth1ExecutionEngine<P> {
 
     fn allow_optimistic_merge_block_validation(&self) -> bool {
         true
+    }
+
+    fn exchange_capabilities(&self) {
+        ExecutionServiceMessage::ExchangeCapabilities.send(&self.execution_service_tx);
+    }
+
+    fn get_blobs(&self, block: Arc<SignedBeaconBlock<P>>, blob_indices: Vec<BlobIndex>) {
+        ExecutionServiceMessage::GetBlobs {
+            block,
+            blob_indices,
+        }
+        .send(&self.execution_service_tx);
     }
 
     fn notify_forkchoice_updated(

--- a/eth1_api/src/lib.rs
+++ b/eth1_api/src/lib.rs
@@ -7,6 +7,7 @@ pub use crate::{
     execution_service::ExecutionService,
     messages::{Eth1ApiToMetrics, Eth1ConnectionData, Eth1Metrics, ExecutionServiceMessage},
     misc::{ApiController, RealController},
+    tasks::{spawn_blobs_download_task, spawn_exchange_capabilities_task},
 };
 
 mod auth;
@@ -18,3 +19,4 @@ mod eth1_execution_engine;
 mod execution_service;
 mod messages;
 mod misc;
+mod tasks;

--- a/eth1_api/src/messages.rs
+++ b/eth1_api/src/messages.rs
@@ -1,16 +1,24 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use either::Either;
 use execution_engine::{PayloadAttributes, PayloadId, PayloadStatusV1};
 use futures::channel::{mpsc::UnboundedSender, oneshot::Sender};
 use log::debug;
 use types::{
-    combined::{ExecutionPayload, ExecutionPayloadParams},
+    combined::{ExecutionPayload, ExecutionPayloadParams, SignedBeaconBlock},
+    deneb::primitives::BlobIndex,
     nonstandard::Phase,
     phase0::primitives::{ExecutionBlockHash, H256},
     preset::Preset,
 };
 
 pub enum ExecutionServiceMessage<P: Preset> {
+    ExchangeCapabilities,
+    GetBlobs {
+        block: Arc<SignedBeaconBlock<P>>,
+        blob_indices: Vec<BlobIndex>,
+    },
     NotifyForkchoiceUpdated {
         head_eth1_block_hash: ExecutionBlockHash,
         safe_eth1_block_hash: ExecutionBlockHash,

--- a/eth1_api/src/tasks.rs
+++ b/eth1_api/src/tasks.rs
@@ -1,0 +1,140 @@
+use core::time::Duration;
+use std::{collections::HashSet, sync::Arc};
+
+use anyhow::Result;
+use dedicated_executor::DedicatedExecutor;
+use execution_engine::BlobAndProofV1;
+use fork_choice_control::Wait;
+use helper_functions::misc;
+use log::{info, warn};
+use types::{
+    combined::SignedBeaconBlock, deneb::primitives::BlobIndex, preset::Preset,
+    traits::SignedBeaconBlock as _,
+};
+use web3::{api::Namespace as _, helpers::CallFuture, Error, Transport as _};
+
+use crate::{eth1_api::ENGINE_GET_EL_BLOBS_V1, ApiController, Eth1Api};
+
+const ENGINE_EXCHANGE_CAPABILITIES_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub fn spawn_blobs_download_task<P: Preset, W: Wait>(
+    eth1_api: Arc<Eth1Api>,
+    controller: ApiController<P, W>,
+    dedicated_executor: &DedicatedExecutor,
+    block: Arc<SignedBeaconBlock<P>>,
+    blob_indices: Vec<BlobIndex>,
+) {
+    dedicated_executor
+        .spawn(async move { download_blobs(&eth1_api, controller, block, blob_indices).await })
+        .detach();
+}
+
+pub fn spawn_exchange_capabilities_task(
+    eth1_api: Arc<Eth1Api>,
+    dedicated_executor: &DedicatedExecutor,
+) {
+    dedicated_executor
+        .spawn(async move {
+            if let Err(error) = exchange_capabilities(&eth1_api).await {
+                warn!("exhcange capabilities task failed: {error:?}");
+            }
+        })
+        .detach();
+}
+
+async fn download_blobs<P: Preset, W: Wait>(
+    eth1_api: &Eth1Api,
+    controller: ApiController<P, W>,
+    block: Arc<SignedBeaconBlock<P>>,
+    blob_indices: Vec<BlobIndex>,
+) {
+    if let Some(body) = block.message().body().post_deneb() {
+        let kzg_commitments = body
+            .blob_kzg_commitments()
+            .iter()
+            .zip(0..)
+            .filter(|(_, index)| blob_indices.contains(index))
+            .collect::<Vec<_>>();
+
+        let versioned_hashes = kzg_commitments
+            .iter()
+            .copied()
+            .map(|(commitment, _)| misc::kzg_commitment_to_versioned_hash(*commitment))
+            .collect();
+
+        match eth1_api.get_blobs::<P>(versioned_hashes).await {
+            Ok(blobs_and_proofs) => {
+                let block_header = block.to_header();
+
+                for (blob_and_proof, kzg_commitment, index) in blobs_and_proofs
+                    .into_iter()
+                    .zip(kzg_commitments.into_iter())
+                    .filter_map(|(blob_and_proof, (kzg_commitment, index))| {
+                        blob_and_proof.map(|blob_and_proof| (blob_and_proof, kzg_commitment, index))
+                    })
+                {
+                    let BlobAndProofV1 { blob, proof } = blob_and_proof;
+
+                    match misc::construct_blob_sidecar(
+                        &block,
+                        block_header,
+                        index,
+                        blob,
+                        *kzg_commitment,
+                        proof,
+                    ) {
+                        Ok(blob_sidecar) => {
+                            controller.on_el_blob_sidecar(Arc::new(blob_sidecar));
+                        }
+                        Err(error) => warn!(
+                            "failed to construct blob sidecar with blob and proof \
+                            received from execution layer: {error:?}"
+                        ),
+                    }
+                }
+            }
+            Err(error) => warn!("engine_getBlobsV1 call failed: {error}"),
+        }
+    }
+}
+
+async fn exchange_capabilities(eth1_api: &Eth1Api) -> Result<()> {
+    let params = vec![serde_json::to_value([ENGINE_GET_EL_BLOBS_V1])?];
+    let method = "engine_exchangeCapabilities";
+
+    for endpoint in eth1_api.endpoints.endpoints_for_request(None) {
+        let _timer = eth1_api.metrics.as_ref().map(|metrics| {
+            prometheus_metrics::start_timer_vec(&metrics.eth1_api_request_times, method)
+        });
+
+        let api = eth1_api.build_api_for_request(endpoint);
+
+        let response: Result<HashSet<String>, Error> =
+            CallFuture::new(api.transport().execute_with_headers(
+                method,
+                params.clone(),
+                eth1_api.auth.headers()?,
+                Some(ENGINE_EXCHANGE_CAPABILITIES_TIMEOUT),
+            ))
+            .await;
+
+        match response {
+            Ok(response) => {
+                eth1_api.on_ok_response(endpoint);
+                endpoint.set_capabilities(response);
+
+                info!("updated capabilities for eth1 endpoint: {}", endpoint.url());
+            }
+            Err(error) => {
+                eth1_api.on_error_response(endpoint);
+
+                warn!(
+                    "unable to update capabilities for eth1 endpoint: {} {error:?}",
+                    endpoint.url(),
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,11 +1,12 @@
 pub use crate::{
     execution_engine::{ExecutionEngine, MockExecutionEngine, NullExecutionEngine},
     types::{
-        EngineGetPayloadV1Response, EngineGetPayloadV2Response, EngineGetPayloadV3Response,
-        EngineGetPayloadV4Response, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
-        ForkChoiceStateV1, ForkChoiceUpdatedResponse, PayloadAttributes, PayloadAttributesV1,
-        PayloadAttributesV2, PayloadAttributesV3, PayloadId, PayloadStatus, PayloadStatusV1,
-        PayloadStatusWithBlockHash, PayloadValidationStatus, RawExecutionRequests, WithdrawalV1,
+        BlobAndProofV1, EngineGetPayloadV1Response, EngineGetPayloadV2Response,
+        EngineGetPayloadV3Response, EngineGetPayloadV4Response, ExecutionPayloadV1,
+        ExecutionPayloadV2, ExecutionPayloadV3, ForkChoiceStateV1, ForkChoiceUpdatedResponse,
+        PayloadAttributes, PayloadAttributesV1, PayloadAttributesV2, PayloadAttributesV3,
+        PayloadId, PayloadStatus, PayloadStatusV1, PayloadStatusWithBlockHash,
+        PayloadValidationStatus, RawExecutionRequests, WithdrawalV1,
     },
 };
 

--- a/execution_engine/src/types.rs
+++ b/execution_engine/src/types.rs
@@ -723,6 +723,13 @@ impl<P: Preset> From<RawExecutionRequests<P>> for ExecutionRequests<P> {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(bound = "")]
+pub struct BlobAndProofV1<P: Preset> {
+    pub blob: Blob<P>,
+    pub proof: KzgProof,
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -399,6 +399,10 @@ where
         })
     }
 
+    pub fn on_el_blob_sidecar(&self, blob_sidecar: Arc<BlobSidecar<P>>) {
+        self.spawn_blob_sidecar_task(blob_sidecar, true, BlobSidecarOrigin::ExecutionLayer)
+    }
+
     pub fn on_gossip_blob_sidecar(
         &self,
         blob_sidecar: Arc<BlobSidecar<P>>,

--- a/fork_choice_control/src/messages.rs
+++ b/fork_choice_control/src/messages.rs
@@ -21,7 +21,7 @@ use log::debug;
 use serde::Serialize;
 use types::{
     combined::{Attestation, BeaconState, SignedAggregateAndProof, SignedBeaconBlock},
-    deneb::containers::BlobIdentifier,
+    deneb::containers::{BlobIdentifier, BlobSidecar},
     phase0::{
         containers::Checkpoint,
         primitives::{DepositIndex, ExecutionBlockHash, Slot, ValidatorIndex, H256},
@@ -165,6 +165,7 @@ pub enum P2pMessage<P: Preset> {
     Slot(Slot),
     Accept(GossipId),
     Ignore(GossipId),
+    PublishBlobSidecar(Arc<BlobSidecar<P>>),
     Reject(GossipId, MutatorRejectionReason),
     BlockNeeded(H256, Option<PeerId>),
     BlobsNeeded(Vec<BlobIdentifier>, Slot, Option<PeerId>),

--- a/fork_choice_store/src/misc.rs
+++ b/fork_choice_store/src/misc.rs
@@ -494,6 +494,7 @@ impl AttesterSlashingOrigin {
 #[derive(Debug)]
 pub enum BlobSidecarOrigin {
     Api(Option<OneshotSender<Result<ValidationOutcome>>>),
+    ExecutionLayer,
     Gossip(SubnetId, GossipId),
     Requested(PeerId),
     Own,
@@ -510,7 +511,7 @@ impl BlobSidecarOrigin {
         match self {
             Self::Gossip(_, gossip_id) => (Some(gossip_id), None),
             Self::Api(sender) => (None, sender),
-            Self::Own | Self::Requested(_) => (None, None),
+            Self::ExecutionLayer | Self::Own | Self::Requested(_) => (None, None),
         }
     }
 
@@ -518,7 +519,7 @@ impl BlobSidecarOrigin {
     pub fn gossip_id(self) -> Option<GossipId> {
         match self {
             Self::Gossip(_, gossip_id) => Some(gossip_id),
-            Self::Api(_) | Self::Own | Self::Requested(_) => None,
+            Self::Api(_) | Self::ExecutionLayer | Self::Own | Self::Requested(_) => None,
         }
     }
 
@@ -527,7 +528,7 @@ impl BlobSidecarOrigin {
         match self {
             Self::Gossip(_, gossip_id) => Some(gossip_id.source),
             Self::Requested(peer_id) => Some(*peer_id),
-            Self::Api(_) | Self::Own => None,
+            Self::Api(_) | Self::ExecutionLayer | Self::Own => None,
         }
     }
 
@@ -535,8 +536,13 @@ impl BlobSidecarOrigin {
     pub const fn subnet_id(&self) -> Option<SubnetId> {
         match self {
             Self::Gossip(subnet_id, _) => Some(*subnet_id),
-            Self::Api(_) | Self::Own | Self::Requested(_) => None,
+            Self::Api(_) | Self::ExecutionLayer | Self::Own | Self::Requested(_) => None,
         }
+    }
+
+    #[must_use]
+    pub const fn is_from_el(&self) -> bool {
+        matches!(self, Self::ExecutionLayer)
     }
 }
 

--- a/helper_functions/src/error.rs
+++ b/helper_functions/src/error.rs
@@ -1,5 +1,7 @@
 use parse_display::Display;
+use ssz::H256;
 use thiserror::Error;
+use types::phase0::primitives::Slot;
 
 #[derive(Debug, Error)]
 pub(crate) enum Error {
@@ -9,6 +11,10 @@ pub(crate) enum Error {
     AttestationSourceMismatch,
     #[error("attesting indices are not sorted and unique")]
     AttestingIndicesNotSortedAndUnique,
+    #[error(
+        "attempted to construct a blob sidecar for pre-Deneb block: slot: {slot}, root: {root:?}"
+    )]
+    BlobsForPreDenebBlock { root: H256, slot: Slot },
     #[error("committee index is out of bounds")]
     CommitteeIndexOutOfBounds,
     #[error("aggregation bitlist length {aggregation_bitlist_length} does not match committee length {committee_length}")]

--- a/http_api/src/context.rs
+++ b/http_api/src/context.rs
@@ -198,9 +198,17 @@ impl<P: Preset> Context<P> {
             controller.on_requested_block(block, None);
         }
 
+        let dedicated_executor = Arc::new(DedicatedExecutor::new(
+            "dedicated-executor",
+            num_cpus::get(),
+            None,
+            None,
+        ));
+
         let execution_service = ExecutionService::new(
             eth1_api.clone_arc(),
             controller.clone_arc(),
+            dedicated_executor.clone_arc(),
             execution_service_rx,
         );
 
@@ -231,13 +239,6 @@ impl<P: Preset> Context<P> {
             validator_config.suggested_fee_recipient,
             validator_config.default_gas_limit,
             H256::default(),
-        ));
-
-        let dedicated_executor = Arc::new(DedicatedExecutor::new(
-            "dedicated-executor",
-            num_cpus::get(),
-            None,
-            None,
         ));
 
         let attestation_verifier = AttestationVerifier::new(

--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -1706,7 +1706,7 @@ pub async fn node_syncing_status<P: Preset, W: Wait>(
     let head_slot = snapshot.head_slot();
     let is_synced = is_synced.get();
     let is_back_synced = is_back_synced.get();
-    let el_offline = eth1_api.el_offline().await;
+    let el_offline = eth1_api.el_offline();
 
     EthResponse::json(NodeSyncingResponse {
         head_slot,

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -312,6 +312,9 @@ impl<P: Preset> Network<P> {
                         P2pMessage::Ignore(gossip_id) => {
                             self.report_outcome(gossip_id, MessageAcceptance::Ignore);
                         }
+                        P2pMessage::PublishBlobSidecar(blob_sidecar) => {
+                            self.publish_blob_sidecar(blob_sidecar);
+                        },
                         P2pMessage::Reject(gossip_id, mutator_rejection_reason) => {
                             self.report_outcome(gossip_id.clone(), MessageAcceptance::Reject);
                             self.report_peer(


### PR DESCRIPTION
- Add 'engine_exchangeCapabilities' request to be able to tell if EL serves blobs.
- Fetch capabilities on startup and on every epoch start.
- Rewrite `eth1_api::Endpoints` not to use mutexes.