### PR TITLE
Initial partial support for 32-bit architectures.

### DIFF
--- a/arithmetic/src/lib.rs
+++ b/arithmetic/src/lib.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 // Having `#[expect(clippy::wrong_self_convention)]` declared directly on violating attributes
 // results in `unfulfilled_lint_expectations` false positive warning.
 // Declaring this for the whole module as a temporary workaround.
@@ -92,6 +94,15 @@ pub impl u64 {
     #[must_use]
     fn prev_power_of_two(self) -> Self {
         1 << self.ilog2()
+    }
+
+    #[inline]
+    #[must_use]
+    fn ilog2_ceil(self) -> u8 {
+        self.checked_next_power_of_two()
+            .map_or(Self::BITS, Self::trailing_zeros)
+            .try_into()
+            .expect("number of bits in u64 should fit in u8")
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 channel = 'stable-2024-10-17'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
+targets = ['i686-unknown-linux-gnu', 'x86_64-unknown-linux-gnu']

--- a/ssz/src/bit_list.rs
+++ b/ssz/src/bit_list.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 use core::{
     fmt::{Debug, Formatter, Result as FmtResult},
     marker::PhantomData,

--- a/ssz/src/bit_vector.rs
+++ b/ssz/src/bit_vector.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 use core::{
     fmt::{Debug, Formatter, Result as FmtResult},
     iter::FusedIterator,

--- a/ssz/src/byte_vector.rs
+++ b/ssz/src/byte_vector.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 use core::fmt::{Debug, Formatter, Result as FmtResult};
 
 use derivative::Derivative;

--- a/ssz/src/contiguous_list.rs
+++ b/ssz/src/contiguous_list.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 #![expect(
     clippy::allow_attributes,
     reason = "clippy::allow_attributes lint triggers from some derive macros. \
@@ -151,7 +153,7 @@ impl<T, N> ContiguousList<T, N> {
     where
         N: Unsigned,
     {
-        let maximum = N::USIZE;
+        let maximum = shared::saturating_usize::<N>();
 
         if actual > maximum {
             return Err(ReadError::ListTooLong { maximum, actual });

--- a/ssz/src/contiguous_vector.rs
+++ b/ssz/src/contiguous_vector.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 #![expect(
     clippy::allow_attributes,
     reason = "clippy::allow_attributes lint triggers from some derive macros. \

--- a/ssz/src/merkle_tree.rs
+++ b/ssz/src/merkle_tree.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 // Here's a visual aid to help understand the algorithms used here:
 // ```text
 //                                                  ┊
@@ -118,7 +120,9 @@ impl<D: ArrayLength<H256>> MerkleTree<D> {
     }
 
     pub fn push(&mut self, index: usize, chunk: H256) -> (usize, H256) {
-        assert!(index < 1 << D::USIZE);
+        // TODO(32-bit support): either remove `assert!` or change index type to `u64`
+        let index_u64: u64 = index.try_into().expect("usize should fit in u64");
+        assert!(index_u64 < 1 << D::U64);
 
         let sibling_to_update = binary_carry_sequence(index);
 

--- a/ssz/src/persistent_vector.rs
+++ b/ssz/src/persistent_vector.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 use core::{
     fmt::{Debug, Formatter, Result as FmtResult},
     iter::{Flatten, FusedIterator},

--- a/ssz/src/shared.rs
+++ b/ssz/src/shared.rs
@@ -1,3 +1,5 @@
+// TODO(32-bit support): Review all uses of `typenum::Unsigned::USIZE`.
+
 // <https://notes.ethereum.org/ruKvDXl6QOW3gnqVYb8ezA> describes some of the validations that SSZ
 // decoders need to perform.
 //
@@ -15,6 +17,18 @@ use crate::{
     porcelain::{SszRead, SszReadDefault as _, SszWrite},
     size::Size,
 };
+
+// TODO(32-bit support): Rethink the new code.
+//                       Try to avoid referring to `Unsigned::U64` or `Unsigned::U128`.
+// The associated constants in `typenum::Unsigned` are computed using the `<<` operator,
+// which silently discards set bits that are shifted out of range.
+pub const fn saturating_usize<N: Unsigned>() -> usize {
+    if N::U64 > usize::MAX as u64 {
+        usize::MAX
+    } else {
+        N::USIZE
+    }
+}
 
 #[inline]
 pub fn subslice(bytes: &[u8], range: Range<usize>) -> Result<&[u8], ReadError> {

--- a/transition_functions/src/altair/epoch_intermediates.rs
+++ b/transition_functions/src/altair/epoch_intermediates.rs
@@ -8,7 +8,6 @@ use helper_functions::{
 };
 use itertools::izip;
 use serde::Serialize;
-use static_assertions::assert_eq_size;
 use types::{
     altair::{
         beacon_state::BeaconState,
@@ -27,6 +26,9 @@ use types::{
 };
 
 use crate::unphased::{EpochDeltas, ValidatorSummary};
+
+#[cfg(target_arch = "x86_64")]
+use static_assertions::assert_eq_size;
 
 pub trait AltairEpochDeltas: Default {
     fn add_source_reward(&mut self, value: Gwei);
@@ -49,6 +51,7 @@ pub struct AltairValidatorSummary {
     pub eligible_for_penalties: bool,
 }
 
+#[cfg(target_arch = "x86_64")]
 assert_eq_size!(AltairValidatorSummary, [u64; 3]);
 
 impl ValidatorSummary for AltairValidatorSummary {

--- a/transition_functions/src/phase0/epoch_intermediates.rs
+++ b/transition_functions/src/phase0/epoch_intermediates.rs
@@ -14,6 +14,7 @@ use helper_functions::{
 use itertools::{izip, Itertools as _};
 use num_integer::Roots as _;
 use serde::Serialize;
+#[cfg(target_arch = "x86_64")]
 use static_assertions::assert_eq_size;
 use types::{
     nonstandard::{AttestationEpoch, AttestationOutcome, Outcome},
@@ -88,6 +89,7 @@ pub struct Phase0ValidatorSummary {
     pub eligible_for_penalties: bool,
 }
 
+#[cfg(target_arch = "x86_64")]
 assert_eq_size!(Phase0ValidatorSummary, [u64; 3]);
 
 impl ValidatorSummary for Phase0ValidatorSummary {


### PR DESCRIPTION
With this, `types`, `helper_functions` and `transition_functions` pass all tests on `i686-unknown-linux-gnu`