### PR TITLE
Set max amount of epochs for state cache to retain states

### DIFF
--- a/fork_choice_control/src/queries.rs
+++ b/fork_choice_control/src/queries.rs
@@ -6,7 +6,7 @@ use arc_swap::Guard;
 use eth2_libp2p::GossipId;
 use execution_engine::ExecutionEngine;
 use fork_choice_store::{
-    AggregateAndProofOrigin, AttestationItem, ChainLink, Segment, StateCacheProcessor, Store,
+    AggregateAndProofOrigin, AttestationItem, ChainLink, StateCacheProcessor, Store,
 };
 use helper_functions::misc;
 use itertools::Itertools as _;
@@ -35,7 +35,7 @@ use crate::{
 };
 
 #[cfg(test)]
-use ::{clock::Tick, types::phase0::consts::GENESIS_SLOT};
+use ::{clock::Tick, fork_choice_store::Segment, types::phase0::consts::GENESIS_SLOT};
 
 // TODO(Grandine Team): There is currently no way to persist payload statuses.
 //                      We previously treated blocks loaded from the database as optimistic.
@@ -182,15 +182,8 @@ where
         }
 
         store
-            .unfinalized()
-            .values()
-            .filter_map(Segment::last_non_invalid_block)
-            .map(|unfinalized_block| {
-                (
-                    &unfinalized_block.chain_link,
-                    unfinalized_block.is_optimistic(),
-                )
-            })
+            .unfinalized_fork_tips()
+            .map(|chain_link| (chain_link, chain_link.is_optimistic()))
             .map_into()
             .collect_vec()
     }

--- a/fork_choice_store/src/state_cache_processor.rs
+++ b/fork_choice_store/src/state_cache_processor.rs
@@ -1,5 +1,5 @@
 use core::time::Duration;
-use std::{backtrace::Backtrace, sync::Arc};
+use std::{backtrace::Backtrace, collections::HashSet, sync::Arc};
 
 use anyhow::{bail, Result};
 use features::Feature;
@@ -65,8 +65,8 @@ impl<P: Preset> StateCacheProcessor<P> {
             .get_or_insert_with(block_root, slot, ignore_missing_rewards, f)
     }
 
-    pub fn prune(&self, last_pruned_slot: Slot) -> Result<()> {
-        self.state_cache.prune(last_pruned_slot)
+    pub fn prune(&self, last_pruned_slot: Slot, preserved_states: &HashSet<H256>) -> Result<()> {
+        self.state_cache.prune(last_pruned_slot, preserved_states)
     }
 
     pub fn try_state_at_slot(

--- a/fork_choice_store/src/store_config.rs
+++ b/fork_choice_store/src/store_config.rs
@@ -10,6 +10,8 @@ pub const DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS: u64 = 1500;
 pub struct StoreConfig {
     #[derivative(Default(value = "32"))]
     pub max_empty_slots: u64,
+    #[derivative(Default(value = "64"))]
+    pub max_epochs_to_retain_states_in_cache: u64,
     #[derivative(Default(value = "Duration::from_millis(DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS)"))]
     pub state_cache_lock_timeout: Duration,
     #[derivative(Default(value = "128"))]

--- a/grandine/src/grandine_args.rs
+++ b/grandine/src/grandine_args.rs
@@ -306,6 +306,10 @@ struct BeaconNodeOptions {
     #[clap(long, default_value_t = DEFAULT_REQUEST_TIMEOUT)]
     request_timeout: u64,
 
+    /// Max amount of epochs to retain beacon states in state cache
+    #[clap(long, default_value_t = StoreConfig::default().max_epochs_to_retain_states_in_cache)]
+    max_epochs_to_retain_states_in_cache: u64,
+
     /// Default state cache lock timeout in milliseconds
     #[clap(long, default_value_t = DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS)]
     state_cache_lock_timeout: u64,
@@ -896,6 +900,7 @@ impl GrandineArgs {
             prune_storage,
             unfinalized_states_in_memory,
             request_timeout,
+            max_epochs_to_retain_states_in_cache,
             state_cache_lock_timeout,
             state_slot,
             subscribe_all_subnets,
@@ -1259,6 +1264,7 @@ impl GrandineArgs {
             storage_config,
             unfinalized_states_in_memory,
             request_timeout: Duration::from_millis(request_timeout),
+            max_epochs_to_retain_states_in_cache,
             state_cache_lock_timeout: Duration::from_millis(state_cache_lock_timeout),
             command,
             slashing_enabled,

--- a/grandine/src/grandine_config.rs
+++ b/grandine/src/grandine_config.rs
@@ -48,6 +48,7 @@ pub struct GrandineConfig {
     pub storage_config: StorageConfig,
     pub unfinalized_states_in_memory: u64,
     pub request_timeout: Duration,
+    pub max_epochs_to_retain_states_in_cache: u64,
     pub state_cache_lock_timeout: Duration,
     pub command: Option<GrandineCommand>,
     pub slashing_enabled: bool,

--- a/grandine/src/main.rs
+++ b/grandine/src/main.rs
@@ -371,6 +371,7 @@ fn try_main() -> Result<()> {
         network_config,
         storage_config,
         request_timeout,
+        max_epochs_to_retain_states_in_cache,
         state_cache_lock_timeout,
         unfinalized_states_in_memory,
         command,
@@ -429,6 +430,7 @@ fn try_main() -> Result<()> {
 
     let store_config = StoreConfig {
         max_empty_slots,
+        max_epochs_to_retain_states_in_cache,
         state_cache_lock_timeout,
         unfinalized_states_in_memory,
     };


### PR DESCRIPTION
Set max amount of epochs for state cache to retain states, in order to avoid high memory usage during long non-finalization periods.

This is related to #59