### PR TITLE
Added support for multiple KZG backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            backend: blst
+          - os: windows-latest
+            backend: zkcrypto,constantine
+          - os: macos-latest
+            backend: arkworks,mcl
 
     runs-on: ${{ matrix.os }}
 
@@ -24,7 +31,7 @@ jobs:
     # Running `rustc` or Cargo should automatically install the toolchain specified in `rust-toolchain.toml`.
     - uses: Swatinem/rust-cache@v2
     - name: Run cargo build
-      run: cargo build --release --features default-networks
+      run: cargo build --release --no-default-features --features default-networks,${{ matrix.backend }}
     - name: Check if code is formatted (Linux)
       if: runner.os == 'Linux'
       run: cargo fmt --check
@@ -34,10 +41,10 @@ jobs:
     # It's a known issue that networking tests randomly fails on Macos
     - name: Run tests
       if: runner.os == 'Macos'
-      run: cargo test --release --no-fail-fast -- --skip behaviour --skip common
+      run: cargo test --release --no-fail-fast --no-default-features --features ${{ matrix.backend }} -- --skip behaviour --skip common
     - name: Run tests
       if: runner.os != 'Macos'
-      run: cargo test --release --no-fail-fast --no-default-features --features bls/zkcrypto
+      run: cargo test --release --no-fail-fast --no-default-features --features ${{ matrix.backend }}
     - name: Check consensus-spec-tests coverage (Linux)
       if: runner.os == 'Linux'
       run: scripts/ci/consensus-spec-tests-coverage.rb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "addchain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +218,131 @@ version = "0.0.0"
 dependencies = [
  "easy-ext",
  "typenum",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote 1.0.37",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -982,7 +1118,7 @@ name = "bls-zkcrypto"
 version = "0.0.0"
 dependencies = [
  "bls-core",
- "bls12_381",
+ "bls12_381 0.8.0 (git+https://github.com/zkcrypto/bls12_381.git)",
  "derivative",
  "derive_more 1.0.0",
  "ff",
@@ -999,6 +1135,18 @@ dependencies = [
  "static_assertions",
  "typenum",
  "zeroize",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1418,6 +1566,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "constantine-core"
+version = "0.1.0"
+source = "git+https://github.com/mratsim/constantine.git?branch=constantine-public-sys#3ed6eeac4f0a9b0092bb4234b61768dfde25cdbe"
+dependencies = [
+ "constantine-sys",
+]
+
+[[package]]
+name = "constantine-ethereum-kzg"
+version = "0.1.0"
+source = "git+https://github.com/mratsim/constantine.git?branch=constantine-public-sys#3ed6eeac4f0a9b0092bb4234b61768dfde25cdbe"
+dependencies = [
+ "constantine-core",
+ "constantine-sys",
+]
+
+[[package]]
+name = "constantine-sys"
+version = "0.1.0"
+source = "git+https://github.com/mratsim/constantine.git?branch=constantine-public-sys#3ed6eeac4f0a9b0092bb4234b61768dfde25cdbe"
+
+[[package]]
 name = "conv"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +1983,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2087,6 +2257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "eip_2335"
 version = "0.0.0"
 dependencies = [
@@ -2239,6 +2421,26 @@ name = "enum-map-derive"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.37",
@@ -2618,8 +2820,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec",
+ "byteorder",
+ "ff_derive",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f54704be45ed286151c5e11531316eaef5b8f5af7d597b806fdb8af108d84a"
+dependencies = [
+ "addchain",
+ "cfg-if",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3141,6 +3361,7 @@ dependencies = [
  "http_api_utils",
  "itertools 0.13.0",
  "keymanager",
+ "kzg_utils",
  "log",
  "logging",
  "metrics",
@@ -4151,7 +4372,7 @@ dependencies = [
  "hashing",
  "helper_functions",
  "hex-literal",
- "num-bigint",
+ "num-bigint 0.4.6",
  "ssz",
  "types",
 ]
@@ -4371,9 +4592,8 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/grandinetech/rust-kzg.git#cb71d62a55e015758fd0277e67246fce2850340b"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
 dependencies = [
- "blst",
  "sha2 0.10.8",
  "siphasher 1.0.1",
 ]
@@ -4385,7 +4605,11 @@ dependencies = [
  "anyhow",
  "hex",
  "kzg",
+ "rust-kzg-arkworks5",
  "rust-kzg-blst",
+ "rust-kzg-constantine",
+ "rust-kzg-mcl",
+ "rust-kzg-zkcrypto",
  "serde",
  "serde_yaml",
  "spec_test_utils",
@@ -5064,6 +5288,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "mcl_rust"
+version = "1.0.2"
+source = "git+https://github.com/herumi/mcl-rust.git#db8e9a639d27fffb167bc48159ef2e3178b347dc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "mediatype"
 version = "0.19.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,6 +5632,17 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -6823,9 +7066,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-kzg-arkworks5"
+version = "0.1.0"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "hex",
+ "kzg",
+ "libc",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rust-kzg-blst"
 version = "0.1.0"
-source = "git+https://github.com/grandinetech/rust-kzg.git#cb71d62a55e015758fd0277e67246fce2850340b"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
 dependencies = [
  "blst",
  "hex",
@@ -6834,6 +7094,53 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "smallvec",
+]
+
+[[package]]
+name = "rust-kzg-constantine"
+version = "0.1.0"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
+dependencies = [
+ "blst",
+ "constantine-core",
+ "constantine-ethereum-kzg",
+ "constantine-sys",
+ "hex",
+ "kzg",
+ "libc",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-kzg-mcl"
+version = "0.1.0"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
+dependencies = [
+ "blst",
+ "hex",
+ "kzg",
+ "libc",
+ "mcl_rust",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-kzg-zkcrypto"
+version = "0.1.0"
+source = "git+https://github.com/grandinetech/rust-kzg.git#09e1b73f25726977b5ab231559562173a5267de4"
+dependencies = [
+ "bls12_381 0.8.0 (git+https://github.com/grandinetech/rust-kzg.git)",
+ "byteorder",
+ "ff",
+ "hex",
+ "kzg",
+ "libc",
+ "rand 0.8.5",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,11 @@ regex = '1'
 replace_with = '0.1'
 reqwest = { version = '0.12', features = ['json', 'native-tls-vendored'] }
 rusqlite = { version = '0.32', features = ['bundled'] }
+rust-kzg-arkworks5 = { git = 'https://github.com/grandinetech/rust-kzg.git' }
 rust-kzg-blst = { git = 'https://github.com/grandinetech/rust-kzg.git' }
+rust-kzg-constantine = { git = 'https://github.com/grandinetech/rust-kzg.git' }
+rust-kzg-mcl = { git = 'https://github.com/grandinetech/rust-kzg.git' }
+rust-kzg-zkcrypto = { git = 'https://github.com/grandinetech/rust-kzg.git' }
 scrypt = '0.11'
 semver = '1'
 serde = { version = '1', features = ['derive', 'rc'] }

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -1836,6 +1836,7 @@ impl<P: Preset> Store<P> {
                 &blob_sidecar.blob,
                 blob_sidecar.kzg_commitment,
                 blob_sidecar.kzg_proof,
+                self.store_config.kzg_backend,
             )
             .unwrap_or(false),
             Error::BlobSidecarInvalid { blob_sidecar }

--- a/fork_choice_store/src/store_config.rs
+++ b/fork_choice_store/src/store_config.rs
@@ -1,6 +1,7 @@
 use core::{ops::Mul as _, time::Duration};
 
 use derivative::Derivative;
+use kzg_utils::{KzgBackend, DEFAULT_KZG_BACKEND};
 use types::config::Config as ChainConfig;
 
 pub const DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS: u64 = 1500;
@@ -16,6 +17,8 @@ pub struct StoreConfig {
     pub state_cache_lock_timeout: Duration,
     #[derivative(Default(value = "128"))]
     pub unfinalized_states_in_memory: u64,
+    #[derivative(Default(value = "DEFAULT_KZG_BACKEND"))]
+    pub kzg_backend: KzgBackend,
 }
 
 impl StoreConfig {

--- a/grandine/Cargo.toml
+++ b/grandine/Cargo.toml
@@ -39,6 +39,7 @@ http_api_utils = { workspace = true }
 itertools = { workspace = true }
 libmdbx = { workspace = true }
 keymanager = { workspace = true }
+kzg_utils = { workspace = true }
 log = { workspace = true }
 logging = { workspace = true }
 metrics = { workspace = true }
@@ -73,7 +74,8 @@ tempfile = { workspace = true }
 test-case = { workspace = true }
 
 [features]
-default = ["bls/blst"]
+default = ["bls/blst", "kzg_utils/blst"]
+
 logger-always-write-style = []
 
 # `preset-any` and `network-any` should not be passed to Cargo.

--- a/grandine/src/grandine_args.rs
+++ b/grandine/src/grandine_args.rs
@@ -36,6 +36,7 @@ use grandine_version::{APPLICATION_NAME, APPLICATION_NAME_AND_VERSION, APPLICATI
 use http_api::HttpApiConfig;
 use http_api_utils::DEFAULT_MAX_EVENTS;
 use itertools::{EitherOrBoth, Itertools as _};
+use kzg_utils::{KzgBackend, DEFAULT_KZG_BACKEND};
 use log::warn;
 use metrics::{MetricsServerConfig, MetricsServiceConfig};
 use p2p::{Enr, Multiaddr, NetworkConfig};
@@ -393,6 +394,9 @@ struct BeaconNodeOptions {
     /// [default: disabled]
     #[clap(long)]
     in_memory: bool,
+
+    #[clap(long, default_value_t = DEFAULT_KZG_BACKEND)]
+    kzg_backend: KzgBackend,
 }
 
 #[expect(
@@ -931,6 +935,7 @@ impl GrandineArgs {
             track_liveness,
             detect_doppelgangers,
             in_memory,
+            kzg_backend,
         } = beacon_node_options;
 
         // let SlasherOptions {
@@ -1310,6 +1315,7 @@ impl GrandineArgs {
             slashing_protection_history_limit,
             in_memory,
             validator_api_config,
+            kzg_backend,
         })
     }
 

--- a/grandine/src/grandine_config.rs
+++ b/grandine/src/grandine_config.rs
@@ -6,6 +6,7 @@ use eth1_api::AuthOptions;
 use features::Feature;
 use http_api::HttpApiConfig;
 use itertools::Itertools as _;
+use kzg_utils::KzgBackend;
 use log::info;
 use p2p::NetworkConfig;
 use runtime::{MetricsConfig, StorageConfig};
@@ -67,6 +68,7 @@ pub struct GrandineConfig {
     pub slashing_protection_history_limit: u64,
     pub in_memory: bool,
     pub validator_api_config: Option<ValidatorApiConfig>,
+    pub kzg_backend: KzgBackend,
 }
 
 impl GrandineConfig {

--- a/grandine/src/main.rs
+++ b/grandine/src/main.rs
@@ -392,6 +392,7 @@ fn try_main() -> Result<()> {
         slashing_protection_history_limit,
         in_memory,
         validator_api_config,
+        kzg_backend,
     } = config;
 
     features.into_iter().for_each(Feature::enable);
@@ -434,6 +435,7 @@ fn try_main() -> Result<()> {
         max_epochs_to_retain_states_in_cache,
         state_cache_lock_timeout,
         unfinalized_states_in_memory,
+        kzg_backend,
     };
 
     let eth1_auth = Arc::new(Auth::new(auth_options)?);

--- a/kzg_utils/Cargo.toml
+++ b/kzg_utils/Cargo.toml
@@ -7,7 +7,11 @@ authors = ["Grandine <info@grandine.io>"]
 [dependencies]
 anyhow = { workspace = true }
 kzg = { workspace = true }
-rust-kzg-blst = { workspace = true }
+rust-kzg-arkworks5 = { workspace = true, optional = true }
+rust-kzg-blst = { workspace = true, optional = true }
+rust-kzg-constantine = { workspace = true, optional = true }
+rust-kzg-mcl = { workspace = true, optional = true }
+rust-kzg-zkcrypto = { workspace = true, optional = true }
 thiserror = { workspace = true }
 types = { workspace = true }
 
@@ -20,3 +24,14 @@ test-generator = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+# `bls-backend-any` should not be passed to Cargo.
+# It only exist to avoid duplicating lists of features.
+bls-backend-any = []
+
+arkworks = ["bls-backend-any", "dep:rust-kzg-arkworks5"]
+blst = ["bls-backend-any", "dep:rust-kzg-blst"]
+constantine = ["bls-backend-any", "dep:rust-kzg-constantine"]
+mcl = ["bls-backend-any", "dep:rust-kzg-mcl"]
+zkcrypto = ["bls-backend-any", "dep:rust-kzg-zkcrypto"]

--- a/kzg_utils/src/bls.rs
+++ b/kzg_utils/src/bls.rs
@@ -1,0 +1,100 @@
+use core::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy)]
+pub enum KzgBackend {
+    #[cfg(feature = "arkworks")]
+    Arkworks,
+    #[cfg(feature = "blst")]
+    Blst,
+    #[cfg(feature = "constantine")]
+    Constantine,
+    #[cfg(feature = "mcl")]
+    Mcl,
+    #[cfg(feature = "zkcrypto")]
+    Zkcrypto,
+}
+
+impl Display for KzgBackend {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(feature = "arkworks")]
+            Self::Arkworks => f.write_str("arkworks"),
+            #[cfg(feature = "blst")]
+            Self::Blst => f.write_str("blst"),
+            #[cfg(feature = "constantine")]
+            Self::Constantine => f.write_str("constantine"),
+            #[cfg(feature = "mcl")]
+            Self::Mcl => f.write_str("mcl"),
+            #[cfg(feature = "zkcrypto")]
+            Self::Zkcrypto => f.write_str("zkcrypto"),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum KzgBackendParseError {
+    #[error("unknown backend {0} - valid values are arkworks, blst, constantine, zkcrypto")]
+    InvalidBackend(String),
+    #[error("backend is not compiled - please specify feature flag when compiling grandine")]
+    BackendNotCompiled,
+}
+
+impl FromStr for KzgBackend {
+    type Err = KzgBackendParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            #[cfg(feature = "arkworks")]
+            "arkworks" => Ok(Self::Arkworks),
+            #[cfg(not(feature = "arkworks"))]
+            "arkworks" => Err(KzgBackendParseError::BackendNotCompiled),
+            #[cfg(feature = "blst")]
+            "blst" => Ok(Self::Blst),
+            #[cfg(not(feature = "blst"))]
+            "blst" => Err(KzgBackendParseError::BackendNotCompiled),
+            #[cfg(feature = "constantine")]
+            "constantine" => Ok(Self::Constantine),
+            #[cfg(not(feature = "constantine"))]
+            "constantine" => Err(KzgBackendParseError::BackendNotCompiled),
+            #[cfg(feature = "mcl")]
+            "mcl" => Ok(Self::Mcl),
+            #[cfg(not(feature = "mcl"))]
+            "mcl" => Err(KzgBackendParseError::BackendNotCompiled),
+            #[cfg(feature = "zkcrypto")]
+            "zkcrypto" => Ok(Self::Zkcrypto),
+            #[cfg(not(feature = "zkcrypto"))]
+            "zkcrypto" => Err(KzgBackendParseError::BackendNotCompiled),
+            unknown => Err(KzgBackendParseError::InvalidBackend(unknown.to_owned())),
+        }
+    }
+}
+
+#[cfg(feature = "blst")]
+pub const DEFAULT_KZG_BACKEND: KzgBackend = KzgBackend::Blst;
+#[cfg(all(not(feature = "blst"), feature = "zkcrypto"))]
+pub const DEFAULT_KZG_BACKEND: KzgBackend = KzgBackend::Zkcrypto;
+#[cfg(all(
+    not(feature = "blst"),
+    not(feature = "zkcrypto"),
+    feature = "constantine"
+))]
+pub const DEFAULT_KZG_BACKEND: KzgBackend = KzgBackend::Constantine;
+#[cfg(all(
+    not(feature = "blst"),
+    not(feature = "zkcrypto"),
+    not(feature = "constantine"),
+    feature = "arkworks"
+))]
+pub const DEFAULT_KZG_BACKEND: KzgBackend = KzgBackend::Arkworks;
+#[cfg(all(
+    not(feature = "blst"),
+    not(feature = "zkcrypto"),
+    not(feature = "constantine"),
+    not(feature = "arkworks"),
+    feature = "mcl"
+))]
+pub const DEFAULT_KZG_BACKEND: KzgBackend = KzgBackend::Mcl;

--- a/kzg_utils/src/eip_4844.rs
+++ b/kzg_utils/src/eip_4844.rs
@@ -11,64 +11,195 @@ use types::{
     preset::Preset,
 };
 
-use crate::{error::KzgError, trusted_setup::settings};
+use crate::{error::KzgError, trusted_setup, KzgBackend};
 
-pub fn blob_to_kzg_commitment<P: Preset>(blob: &Blob<P>) -> Result<KzgCommitment> {
+pub fn blob_to_kzg_commitment<P: Preset>(
+    blob: &Blob<P>,
+    backend: KzgBackend,
+) -> Result<KzgCommitment> {
     let blob_bytes = blob.as_bytes().try_into()?;
 
-    let commitment = blob_to_kzg_commitment_raw(blob_bytes, settings())
-        .map_err(KzgError::KzgError)?
-        .to_bytes()
-        .into();
+    let commitment = match backend {
+        #[cfg(feature = "arkworks")]
+        KzgBackend::Arkworks => {
+            blob_to_kzg_commitment_raw(blob_bytes, trusted_setup::arkworks_settings())
+                .map_err(KzgError::KzgError)?
+                .to_bytes()
+        }
+        #[cfg(feature = "blst")]
+        KzgBackend::Blst => blob_to_kzg_commitment_raw(blob_bytes, trusted_setup::blst_settings())
+            .map_err(KzgError::KzgError)?
+            .to_bytes(),
+        #[cfg(feature = "constantine")]
+        KzgBackend::Constantine => {
+            blob_to_kzg_commitment_raw(blob_bytes, trusted_setup::constantine_settings())
+                .map_err(KzgError::KzgError)?
+                .to_bytes()
+        }
+        #[cfg(feature = "mcl")]
+        KzgBackend::Mcl => blob_to_kzg_commitment_raw(blob_bytes, trusted_setup::mcl_settings())
+            .map_err(KzgError::KzgError)?
+            .to_bytes(),
+        #[cfg(feature = "zkcrypto")]
+        KzgBackend::Zkcrypto => {
+            blob_to_kzg_commitment_raw(blob_bytes, trusted_setup::zkcrypto_settings())
+                .map_err(KzgError::KzgError)?
+                .to_bytes()
+        }
+    };
 
-    Ok(commitment)
+    Ok(commitment.into())
 }
 
 pub fn compute_blob_kzg_proof<P: Preset>(
     blob: &Blob<P>,
     commitment: KzgCommitment,
+    backend: KzgBackend,
 ) -> Result<KzgProof> {
     let blob_bytes = blob.as_bytes().try_into()?;
     let commitment_bytes = commitment.to_fixed_bytes();
 
-    let proof = compute_blob_kzg_proof_raw(blob_bytes, commitment_bytes, settings())
+    let proof = match backend {
+        #[cfg(feature = "arkworks")]
+        KzgBackend::Arkworks => compute_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            trusted_setup::arkworks_settings(),
+        )
         .map_err(KzgError::KzgError)?
-        .to_bytes()
-        .into();
+        .to_bytes(),
+        #[cfg(feature = "blst")]
+        KzgBackend::Blst => {
+            compute_blob_kzg_proof_raw(blob_bytes, commitment_bytes, trusted_setup::blst_settings())
+                .map_err(KzgError::KzgError)?
+                .to_bytes()
+        }
+        #[cfg(feature = "constantine")]
+        KzgBackend::Constantine => compute_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            trusted_setup::constantine_settings(),
+        )
+        .map_err(KzgError::KzgError)?
+        .to_bytes(),
+        #[cfg(feature = "mcl")]
+        KzgBackend::Mcl => {
+            compute_blob_kzg_proof_raw(blob_bytes, commitment_bytes, trusted_setup::mcl_settings())
+                .map_err(KzgError::KzgError)?
+                .to_bytes()
+        }
+        #[cfg(feature = "zkcrypto")]
+        KzgBackend::Zkcrypto => compute_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            trusted_setup::zkcrypto_settings(),
+        )
+        .map_err(KzgError::KzgError)?
+        .to_bytes(),
+    };
 
-    Ok(proof)
+    Ok(proof.into())
 }
 
 pub fn compute_kzg_proof<P: Preset>(
     blob: &Blob<P>,
     z_bytes: [u8; 32],
+    backend: KzgBackend,
 ) -> Result<(KzgProof, [u8; 32])> {
     let blob_bytes = blob.as_bytes().try_into()?;
 
-    let (proof, y) =
-        compute_kzg_proof_raw(blob_bytes, z_bytes, settings()).map_err(KzgError::KzgError)?;
+    let (proof, y) = match backend {
+        #[cfg(feature = "arkworks")]
+        KzgBackend::Arkworks => {
+            compute_kzg_proof_raw(blob_bytes, z_bytes, trusted_setup::arkworks_settings())
+                .map_err(KzgError::KzgError)
+                .map(|(proof, y)| (proof.to_bytes(), y.to_bytes()))?
+        }
+        #[cfg(feature = "blst")]
+        KzgBackend::Blst => {
+            compute_kzg_proof_raw(blob_bytes, z_bytes, trusted_setup::blst_settings())
+                .map_err(KzgError::KzgError)
+                .map(|(proof, y)| (proof.to_bytes(), y.to_bytes()))?
+        }
+        #[cfg(feature = "constantine")]
+        KzgBackend::Constantine => {
+            compute_kzg_proof_raw(blob_bytes, z_bytes, trusted_setup::constantine_settings())
+                .map_err(KzgError::KzgError)
+                .map(|(proof, y)| (proof.to_bytes(), y.to_bytes()))?
+        }
+        #[cfg(feature = "mcl")]
+        KzgBackend::Mcl => {
+            compute_kzg_proof_raw(blob_bytes, z_bytes, trusted_setup::mcl_settings())
+                .map_err(KzgError::KzgError)
+                .map(|(proof, y)| (proof.to_bytes(), y.to_bytes()))?
+        }
+        #[cfg(feature = "zkcrypto")]
+        KzgBackend::Zkcrypto => {
+            compute_kzg_proof_raw(blob_bytes, z_bytes, trusted_setup::zkcrypto_settings())
+                .map_err(KzgError::KzgError)
+                .map(|(proof, y)| (proof.to_bytes(), y.to_bytes()))?
+        }
+    };
 
-    Ok((proof.to_bytes().into(), y.to_bytes()))
+    Ok((proof.into(), y))
 }
 
 pub fn verify_blob_kzg_proof<P: Preset>(
     blob: &Blob<P>,
     commitment: KzgCommitment,
     proof: KzgProof,
+    backend: KzgBackend,
 ) -> Result<bool> {
     let blob_bytes = blob.as_bytes().try_into()?;
     let commitment_bytes = commitment.to_fixed_bytes();
     let proof_bytes = proof.to_fixed_bytes();
 
-    verify_blob_kzg_proof_raw(blob_bytes, commitment_bytes, proof_bytes, settings())
-        .map_err(KzgError::KzgError)
-        .map_err(Into::into)
+    let result = match backend {
+        #[cfg(feature = "arkworks")]
+        KzgBackend::Arkworks => verify_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            proof_bytes,
+            trusted_setup::arkworks_settings(),
+        ),
+        #[cfg(feature = "blst")]
+        KzgBackend::Blst => verify_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            proof_bytes,
+            trusted_setup::blst_settings(),
+        ),
+        #[cfg(feature = "constantine")]
+        KzgBackend::Constantine => verify_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            proof_bytes,
+            trusted_setup::constantine_settings(),
+        ),
+        #[cfg(feature = "mcl")]
+        KzgBackend::Mcl => verify_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            proof_bytes,
+            trusted_setup::mcl_settings(),
+        ),
+        #[cfg(feature = "zkcrypto")]
+        KzgBackend::Zkcrypto => verify_blob_kzg_proof_raw(
+            blob_bytes,
+            commitment_bytes,
+            proof_bytes,
+            trusted_setup::zkcrypto_settings(),
+        ),
+    };
+
+    result.map_err(KzgError::KzgError).map_err(Into::into)
 }
 
 pub fn verify_blob_kzg_proof_batch<'blob, P: Preset>(
     blobs: impl IntoIterator<Item = &'blob Blob<P>>,
     commitments: impl IntoIterator<Item = KzgCommitment>,
     proofs: impl IntoIterator<Item = KzgProof>,
+    backend: KzgBackend,
 ) -> Result<bool> {
     let raw_blobs = blobs
         .into_iter()
@@ -85,9 +216,45 @@ pub fn verify_blob_kzg_proof_batch<'blob, P: Preset>(
         .map(KzgProof::to_fixed_bytes)
         .collect::<Vec<_>>();
 
-    verify_blob_kzg_proof_batch_raw(&raw_blobs, &raw_commitments, &raw_proofs, settings())
-        .map_err(KzgError::KzgError)
-        .map_err(Into::into)
+    let result = match backend {
+        #[cfg(feature = "arkworks")]
+        KzgBackend::Arkworks => verify_blob_kzg_proof_batch_raw(
+            &raw_blobs,
+            &raw_commitments,
+            &raw_proofs,
+            trusted_setup::arkworks_settings(),
+        ),
+        #[cfg(feature = "blst")]
+        KzgBackend::Blst => verify_blob_kzg_proof_batch_raw(
+            &raw_blobs,
+            &raw_commitments,
+            &raw_proofs,
+            trusted_setup::blst_settings(),
+        ),
+        #[cfg(feature = "constantine")]
+        KzgBackend::Constantine => verify_blob_kzg_proof_batch_raw(
+            &raw_blobs,
+            &raw_commitments,
+            &raw_proofs,
+            trusted_setup::constantine_settings(),
+        ),
+        #[cfg(feature = "mcl")]
+        KzgBackend::Mcl => verify_blob_kzg_proof_batch_raw(
+            &raw_blobs,
+            &raw_commitments,
+            &raw_proofs,
+            trusted_setup::mcl_settings(),
+        ),
+        #[cfg(feature = "zkcrypto")]
+        KzgBackend::Zkcrypto => verify_blob_kzg_proof_batch_raw(
+            &raw_blobs,
+            &raw_commitments,
+            &raw_proofs,
+            trusted_setup::zkcrypto_settings(),
+        ),
+    };
+
+    result.map_err(KzgError::KzgError).map_err(Into::into)
 }
 
 pub fn verify_kzg_proof(
@@ -95,11 +262,53 @@ pub fn verify_kzg_proof(
     z_bytes: [u8; 32],
     y_bytes: [u8; 32],
     proof: KzgProof,
+    backend: KzgBackend,
 ) -> Result<bool> {
     let commitment_bytes = commitment.to_fixed_bytes();
     let proof_bytes = proof.to_fixed_bytes();
 
-    verify_kzg_proof_raw(commitment_bytes, z_bytes, y_bytes, proof_bytes, settings())
-        .map_err(KzgError::KzgError)
-        .map_err(Into::into)
+    let result = match backend {
+        #[cfg(feature = "arkworks")]
+        KzgBackend::Arkworks => verify_kzg_proof_raw(
+            commitment_bytes,
+            z_bytes,
+            y_bytes,
+            proof_bytes,
+            trusted_setup::arkworks_settings(),
+        ),
+        #[cfg(feature = "blst")]
+        KzgBackend::Blst => verify_kzg_proof_raw(
+            commitment_bytes,
+            z_bytes,
+            y_bytes,
+            proof_bytes,
+            trusted_setup::blst_settings(),
+        ),
+        #[cfg(feature = "constantine")]
+        KzgBackend::Constantine => verify_kzg_proof_raw(
+            commitment_bytes,
+            z_bytes,
+            y_bytes,
+            proof_bytes,
+            trusted_setup::constantine_settings(),
+        ),
+        #[cfg(feature = "mcl")]
+        KzgBackend::Mcl => verify_kzg_proof_raw(
+            commitment_bytes,
+            z_bytes,
+            y_bytes,
+            proof_bytes,
+            trusted_setup::mcl_settings(),
+        ),
+        #[cfg(feature = "zkcrypto")]
+        KzgBackend::Zkcrypto => verify_kzg_proof_raw(
+            commitment_bytes,
+            z_bytes,
+            y_bytes,
+            proof_bytes,
+            trusted_setup::zkcrypto_settings(),
+        ),
+    };
+
+    result.map_err(KzgError::KzgError).map_err(Into::into)
 }

--- a/kzg_utils/src/lib.rs
+++ b/kzg_utils/src/lib.rs
@@ -1,11 +1,17 @@
-pub use trusted_setup::settings;
-
 pub mod eip_4844;
 
+mod bls;
 mod error;
 mod trusted_setup;
 
 #[cfg(test)]
 mod spec_tests;
 
-pub type KZGSettings = rust_kzg_blst::types::kzg_settings::FsKZGSettings;
+#[cfg(not(any(feature = "bls-backend-any", test, doc)))]
+compile_error! {
+    "at least one backend must be enabled; \
+     pass --features … to Cargo; \
+     see kzg_utils/Cargo.toml for a list of features"
+}
+
+pub use bls::{KzgBackend, KzgBackendParseError, DEFAULT_KZG_BACKEND};

--- a/kzg_utils/src/spec_tests/containers/compute_blob_kzg_proof.rs
+++ b/kzg_utils/src/spec_tests/containers/compute_blob_kzg_proof.rs
@@ -1,17 +1,9 @@
-#![expect(clippy::string_slice)]
-
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct Input {
     pub blob: String,
     pub commitment: String,
-}
-
-impl Input {
-    pub fn get_commitment_bytes(&self) -> Vec<u8> {
-        hex::decode(&self.commitment[2..]).expect("should decode commitment bytes")
-    }
 }
 
 #[derive(Deserialize)]

--- a/kzg_utils/src/spec_tests/containers/compute_kzg_proof.rs
+++ b/kzg_utils/src/spec_tests/containers/compute_kzg_proof.rs
@@ -10,18 +10,12 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blob_bytes(&self) -> Vec<u8> {
-        hex::decode(&self.blob[2..]).expect("should decode blob bytes")
-    }
-
     pub fn get_z_bytes(&self) -> Vec<u8> {
         hex::decode(&self.z[2..]).expect("should decode z bytes")
     }
 
-    pub fn get_z_bytes_fixed(&self) -> [u8; 32] {
-        self.get_z_bytes()
-            .try_into()
-            .expect("test input z bytes should fit into 32 byte array")
+    pub fn get_z_bytes_fixed(&self) -> Result<[u8; 32], Vec<u8>> {
+        self.get_z_bytes().try_into()
     }
 }
 

--- a/kzg_utils/src/spec_tests/containers/verify_blob_kzg_proof.rs
+++ b/kzg_utils/src/spec_tests/containers/verify_blob_kzg_proof.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::string_slice)]
-
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -7,16 +5,6 @@ pub struct Input {
     pub blob: String,
     pub commitment: String,
     pub proof: String,
-}
-
-impl Input {
-    pub fn get_commitment_bytes(&self) -> Vec<u8> {
-        hex::decode(&self.commitment[2..]).expect("should decode commitment bytes")
-    }
-
-    pub fn get_proof_bytes(&self) -> Vec<u8> {
-        hex::decode(&self.proof[2..]).expect("should decode proof bytes")
-    }
 }
 
 #[derive(Deserialize)]

--- a/kzg_utils/src/spec_tests/containers/verify_blob_kzg_proof_batch.rs
+++ b/kzg_utils/src/spec_tests/containers/verify_blob_kzg_proof_batch.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::string_slice)]
-
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -7,24 +5,6 @@ pub struct Input {
     pub blobs: Vec<String>,
     pub commitments: Vec<String>,
     pub proofs: Vec<String>,
-}
-
-impl Input {
-    pub fn get_commitments_bytes(&self) -> Vec<Vec<u8>> {
-        self.commitments
-            .iter()
-            .map(|commitment| {
-                hex::decode(&commitment[2..]).expect("should decode commitment bytes")
-            })
-            .collect()
-    }
-
-    pub fn get_proofs_bytes(&self) -> Vec<Vec<u8>> {
-        self.proofs
-            .iter()
-            .map(|proof| hex::decode(&proof[2..]).expect("should decode proof bytes"))
-            .collect()
-    }
 }
 
 #[derive(Deserialize)]

--- a/kzg_utils/src/spec_tests/containers/verify_kzg_proof.rs
+++ b/kzg_utils/src/spec_tests/containers/verify_kzg_proof.rs
@@ -11,32 +11,20 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_commitment_bytes(&self) -> Vec<u8> {
-        hex::decode(&self.commitment[2..]).expect("should decode commitment bytes")
-    }
-
     pub fn get_z_bytes(&self) -> Vec<u8> {
         hex::decode(&self.z[2..]).expect("should decode z bytes")
     }
 
-    pub fn get_z_bytes_fixed(&self) -> [u8; 32] {
-        self.get_z_bytes()
-            .try_into()
-            .expect("test input z bytes should fit into 32 byte array")
+    pub fn get_z_bytes_fixed(&self) -> Result<[u8; 32], Vec<u8>> {
+        self.get_z_bytes().try_into()
     }
 
     pub fn get_y_bytes(&self) -> Vec<u8> {
         hex::decode(&self.y[2..]).expect("should decode y bytes")
     }
 
-    pub fn get_y_bytes_fixed(&self) -> [u8; 32] {
-        self.get_y_bytes()
-            .try_into()
-            .expect("test input y bytes should fit into 32 byte array")
-    }
-
-    pub fn get_proof_bytes(&self) -> Vec<u8> {
-        hex::decode(&self.proof[2..]).expect("should decode proof bytes")
+    pub fn get_y_bytes_fixed(&self) -> Result<[u8; 32], Vec<u8>> {
+        self.get_y_bytes().try_into()
     }
 }
 

--- a/kzg_utils/src/spec_tests/mod.rs
+++ b/kzg_utils/src/spec_tests/mod.rs
@@ -1,8 +1,3 @@
-use rust_kzg_blst::types::{fr::FsFr, g1::FsG1};
-
 mod containers;
 mod tests;
 mod utils;
-
-type Fr = FsFr;
-type G1 = FsG1;

--- a/kzg_utils/src/trusted_setup.rs
+++ b/kzg_utils/src/trusted_setup.rs
@@ -3,29 +3,64 @@ use std::sync::OnceLock;
 use anyhow::{anyhow, Result};
 use kzg::eip_4844::{load_trusted_setup_rust, load_trusted_setup_string};
 
-use crate::KZGSettings;
+fn load_trusted_setup() -> Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+    static CONTENTS: &str = include_str!("trusted_setup.txt");
 
-pub fn settings() -> &'static KZGSettings {
-    static KZG_SETTINGS: OnceLock<KZGSettings> = OnceLock::new();
+    load_trusted_setup_string(CONTENTS).map_err(|error| anyhow!(error))
+}
 
-    KZG_SETTINGS.get_or_init(|| match load_settings() {
-        Ok(settings) => settings,
-        Err(error) => {
-            panic!("failed to load kzg trusted setup: {error:?}");
+macro_rules! impl_settings {
+    ($backend:ident, $settings_type:ty) => {
+        pub fn $backend() -> &'static $settings_type {
+            static KZG_SETTINGS: OnceLock<$settings_type> = OnceLock::new();
+
+            KZG_SETTINGS.get_or_init(|| {
+                let output = load_trusted_setup().and_then(
+                    |(g1_monomial_bytes, g1_lagrange_bytes, g2_monomial_bytes)| {
+                        load_trusted_setup_rust(
+                            g1_monomial_bytes.as_slice(),
+                            g1_lagrange_bytes.as_slice(),
+                            g2_monomial_bytes.as_slice(),
+                        )
+                        .map_err(|err| anyhow!(err))
+                    },
+                );
+
+                match output {
+                    Ok(settings) => settings,
+                    Err(error) => panic!("failed to load kzg trusted setup: {error}"),
+                }
+            })
         }
-    })
+    };
 }
 
-fn load_settings() -> Result<KZGSettings> {
-    let contents = include_str!("trusted_setup.txt");
+#[cfg(feature = "arkworks")]
+impl_settings!(
+    arkworks_settings,
+    rust_kzg_arkworks5::kzg_proofs::KZGSettings
+);
 
-    let (g1_monomial_bytes, g1_lagrange_bytes, g2_monomial_bytes) =
-        load_trusted_setup_string(contents).map_err(|error| anyhow!(error))?;
+#[cfg(feature = "blst")]
+impl_settings!(
+    blst_settings,
+    rust_kzg_blst::types::kzg_settings::FsKZGSettings
+);
 
-    load_trusted_setup_rust(
-        g1_monomial_bytes.as_slice(),
-        g1_lagrange_bytes.as_slice(),
-        g2_monomial_bytes.as_slice(),
-    )
-    .map_err(|error| anyhow!(error))
-}
+#[cfg(feature = "constantine")]
+impl_settings!(
+    constantine_settings,
+    rust_kzg_constantine::types::kzg_settings::CtKZGSettings
+);
+
+#[cfg(feature = "zkcrypto")]
+impl_settings!(
+    zkcrypto_settings,
+    rust_kzg_zkcrypto::kzg_proofs::KZGSettings
+);
+
+#[cfg(feature = "mcl")]
+impl_settings!(
+    mcl_settings,
+    rust_kzg_mcl::types::kzg_settings::MclKZGSettings
+);


### PR DESCRIPTION
In this PR:
* Added possibility to optionally compile `blst` or `zkcrypto` backends for kzg_utils package. Both can be included at the same time, and then selected at the runtime.
* Added option to `fork_choice_store::StoreConfig` - `kzg_backend`
* Added CLI option `--kzg-backend`.

Closes #74.