### PR TITLE
Increase preferred execution gas limit to 36M

### DIFF
--- a/builder_api/src/consts.rs
+++ b/builder_api/src/consts.rs
@@ -16,13 +16,5 @@ pub const DOMAIN_APPLICATION_BUILDER: DomainType = H32(hex!("00000001"));
 
 pub const EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION: u64 = 1;
 
-// From <https://github.com/ethereum/builder-specs/issues/17>:
-//
-// > 30M is the value "we" currently feel comfortable running as a balance between how
-// > big blocks are and how expensive they are for the network to validate. When I say "we",
-// > I mean the collective community of client devs, miners and others in the community --
-// > rough consensus across many participating entities.
-//
-// > For this reason, I think it is currently a sensible default if the validator operator
-// > does not provide another option.
-pub const PREFERRED_EXECUTION_GAS_LIMIT: Gas = 30_000_000;
+// [Pump the Gas](https://pumpthegas.org)
+pub const PREFERRED_EXECUTION_GAS_LIMIT: Gas = 36_000_000;

--- a/keymanager/src/proposer_configs.rs
+++ b/keymanager/src/proposer_configs.rs
@@ -172,7 +172,7 @@ mod tests {
 
     const DEFAULT_GRAFFITI: &str = "Grandine";
     const DEFAULT_FEE_RECIPIENT: ExecutionAddress = ExecutionAddress::repeat_byte(1);
-    const DEFAULT_GAS_LIMIT: Gas = 30_000_000;
+    const DEFAULT_GAS_LIMIT: Gas = 36_000_000;
     const TEST_FEE_RECIPIENT: ExecutionAddress = ExecutionAddress::repeat_byte(2);
     const PUBKEY: PublicKeyBytes = PublicKeyBytes::repeat_byte(1);
 


### PR DESCRIPTION
Update preferred gas limit to 36M in response to [Pump the Gas](https://pumpthegas.org/)