### PR TITLE
Add standard storage mode and improve back-sync handling (30):

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2 1.0.92",
@@ -4132,15 +4132,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -5562,6 +5553,7 @@ dependencies = [
  "eth2_libp2p",
  "features",
  "fork_choice_control",
+ "fork_choice_store",
  "futures",
  "genesis",
  "helper_functions",
@@ -5569,6 +5561,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "logging",
+ "lru",
  "operation_pools",
  "prometheus-client",
  "prometheus_metrics",
@@ -5585,6 +5578,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "transition_functions",
  "tynm",
  "typenum",
  "types",

--- a/benches/benches/fork_choice_store.rs
+++ b/benches/benches/fork_choice_store.rs
@@ -69,6 +69,7 @@ impl Criterion {
                     anchor_block,
                     anchor_state,
                     false,
+                    false,
                 );
 
                 for slot in (anchor_slot + 1)..=last_attestation_slot {

--- a/features/src/lib.rs
+++ b/features/src/lib.rs
@@ -41,7 +41,6 @@ pub enum Feature {
     SubscribeToAllAttestationSubnets,
     SubscribeToAllSyncCommitteeSubnets,
     TrackMetrics,
-    TrustBackSyncBlocks,
     // By default we fully validate objects produced by the current instance of the application.
     // This costs some resources but may help in case of bugs.
     TrustOwnAttestationSignatures,

--- a/fork_choice_control/src/lib.rs
+++ b/fork_choice_control/src/lib.rs
@@ -21,14 +21,16 @@ pub use crate::{
         AttestationVerifierMessage, P2pMessage, PoolMessage, SubnetMessage, SyncMessage,
         ValidatorMessage,
     },
-    misc::{MutatorRejectionReason, VerifyAggregateAndProofResult, VerifyAttestationResult},
+    misc::{
+        MutatorRejectionReason, StorageMode, VerifyAggregateAndProofResult, VerifyAttestationResult,
+    },
     queries::{BlockWithRoot, ForkChoiceContext, ForkTip, Snapshot},
     specialized::{AdHocBenchController, BenchController},
     storage::{
-        BlobSidecarByBlobId, BlockCheckpoint, BlockRootBySlot, FinalizedBlockByRoot, PrefixableKey,
-        SlotBlobId, SlotByStateRoot, StateByBlockRoot, StateCheckpoint, UnfinalizedBlockByRoot,
+        get, save, BlobSidecarByBlobId, BlockCheckpoint, BlockRootBySlot, FinalizedBlockByRoot,
+        PrefixableKey, SlotBlobId, SlotByStateRoot, StateByBlockRoot, StateCheckpoint,
+        StateLoadStrategy, Storage, UnfinalizedBlockByRoot, DEFAULT_ARCHIVAL_EPOCH_INTERVAL,
     },
-    storage::{StateLoadStrategy, Storage, DEFAULT_ARCHIVAL_EPOCH_INTERVAL},
     storage_tool::{export_state_and_blocks, replay_blocks},
     wait::Wait,
 };

--- a/fork_choice_control/src/messages.rs
+++ b/fork_choice_control/src/messages.rs
@@ -67,6 +67,10 @@ pub enum MutatorMessage<P: Preset, W> {
         wait_group: W,
         tick: Tick,
     },
+    BackSyncStatus {
+        wait_group: W,
+        is_back_synced: bool,
+    },
     Block {
         wait_group: W,
         result: Result<BlockAction<P>>,

--- a/fork_choice_control/src/misc.rs
+++ b/fork_choice_control/src/misc.rs
@@ -120,3 +120,22 @@ pub enum MutatorRejectionReason {
     InvalidBlock,
     InvalidBlobSidecar,
 }
+
+#[derive(Clone, Copy, Debug)]
+pub enum StorageMode {
+    Prune,
+    Standard,
+    Archive,
+}
+
+impl StorageMode {
+    #[must_use]
+    pub const fn is_prune(self) -> bool {
+        matches!(self, Self::Prune)
+    }
+
+    #[must_use]
+    pub const fn is_archive(self) -> bool {
+        matches!(self, Self::Archive)
+    }
+}

--- a/fork_choice_control/src/specialized.rs
+++ b/fork_choice_control/src/specialized.rs
@@ -23,6 +23,7 @@ use crate::{
     messages::{AttestationVerifierMessage, P2pMessage},
     storage::{Storage, DEFAULT_ARCHIVAL_EPOCH_INTERVAL},
     unbounded_sink::UnboundedSink,
+    StorageMode,
 };
 
 #[cfg(test)]
@@ -102,7 +103,7 @@ where
             chain_config.clone_arc(),
             Database::in_memory(),
             DEFAULT_ARCHIVAL_EPOCH_INTERVAL,
-            false,
+            StorageMode::Standard,
         ));
 
         let event_channels = Arc::new(EventChannels::default());
@@ -124,6 +125,7 @@ where
             futures::sink::drain(),
             storage,
             core::iter::empty(),
+            true,
         )
         .expect("Controller::new should not fail in tests and benchmarks")
     }

--- a/fork_choice_store/src/misc.rs
+++ b/fork_choice_store/src/misc.rs
@@ -494,6 +494,7 @@ impl AttesterSlashingOrigin {
 #[derive(Debug)]
 pub enum BlobSidecarOrigin {
     Api(Option<OneshotSender<Result<ValidationOutcome>>>),
+    BackSync,
     ExecutionLayer,
     Gossip(SubnetId, GossipId),
     Requested(PeerId),
@@ -511,7 +512,7 @@ impl BlobSidecarOrigin {
         match self {
             Self::Gossip(_, gossip_id) => (Some(gossip_id), None),
             Self::Api(sender) => (None, sender),
-            Self::ExecutionLayer | Self::Own | Self::Requested(_) => (None, None),
+            Self::BackSync | Self::ExecutionLayer | Self::Own | Self::Requested(_) => (None, None),
         }
     }
 
@@ -519,7 +520,11 @@ impl BlobSidecarOrigin {
     pub fn gossip_id(self) -> Option<GossipId> {
         match self {
             Self::Gossip(_, gossip_id) => Some(gossip_id),
-            Self::Api(_) | Self::ExecutionLayer | Self::Own | Self::Requested(_) => None,
+            Self::Api(_)
+            | Self::BackSync
+            | Self::ExecutionLayer
+            | Self::Own
+            | Self::Requested(_) => None,
         }
     }
 
@@ -528,7 +533,7 @@ impl BlobSidecarOrigin {
         match self {
             Self::Gossip(_, gossip_id) => Some(gossip_id.source),
             Self::Requested(peer_id) => Some(*peer_id),
-            Self::Api(_) | Self::ExecutionLayer | Self::Own => None,
+            Self::Api(_) | Self::BackSync | Self::ExecutionLayer | Self::Own => None,
         }
     }
 
@@ -536,13 +541,22 @@ impl BlobSidecarOrigin {
     pub const fn subnet_id(&self) -> Option<SubnetId> {
         match self {
             Self::Gossip(subnet_id, _) => Some(*subnet_id),
-            Self::Api(_) | Self::ExecutionLayer | Self::Own | Self::Requested(_) => None,
+            Self::Api(_)
+            | Self::BackSync
+            | Self::ExecutionLayer
+            | Self::Own
+            | Self::Requested(_) => None,
         }
     }
 
     #[must_use]
     pub const fn is_from_el(&self) -> bool {
         matches!(self, Self::ExecutionLayer)
+    }
+
+    #[must_use]
+    pub const fn is_from_back_sync(&self) -> bool {
+        matches!(self, Self::BackSync)
     }
 }
 
@@ -601,11 +615,19 @@ impl<P: Preset, I> AttestationAction<P, I> {
     }
 }
 
+#[derive(Debug)]
 pub enum BlobSidecarAction<P: Preset> {
     Accept(Arc<BlobSidecar<P>>),
     Ignore(Publishable),
     DelayUntilParent(Arc<BlobSidecar<P>>),
     DelayUntilSlot(Arc<BlobSidecar<P>>),
+}
+
+impl<P: Preset> BlobSidecarAction<P> {
+    #[must_use]
+    pub const fn accepted(&self) -> bool {
+        matches!(self, Self::Accept(_))
+    }
 }
 
 pub enum PartialBlockAction {

--- a/grandine/src/commands.rs
+++ b/grandine/src/commands.rs
@@ -1,15 +1,36 @@
 use std::path::PathBuf;
 
 use clap::Subcommand;
+use strum::EnumString;
 use types::phase0::primitives::Slot;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum AppDatabase {
+    Sync,
+}
 
 #[derive(Clone, Subcommand)]
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
 pub enum GrandineCommand {
+    /// Show information about database records
+    /// (example: grandine db-info --database sync)
+    DbInfo {
+        /// Type of the database
+        #[clap(short, long)]
+        database: AppDatabase,
+        /// Path to a custom directory where database files are stored
+        /// (example: grandine --network holesky db-info -d sync -p ~/.grandine/holesky/beacon/sync)
+        #[clap(short, long)]
+        path: Option<PathBuf>,
+    },
+
     /// Show `beacon_fork_choice` database element sizes
     /// (example: grandine db-stats)
     DbStats {
-        /// Custom database path
+        /// Path to a custom directory where `beacon_fork_choice` database files are stored
+        #[expect(clippy::doc_markdown)]
+        /// (example: grandine --network holesky db-stats -p ~/.grandine/holesky/beacon/beacon_fork_choice)
         #[clap(short, long)]
         path: Option<PathBuf>,
     },

--- a/grandine/src/db_info.rs
+++ b/grandine/src/db_info.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use database::DatabaseMode;
+use runtime::StorageConfig;
+
+use crate::commands::AppDatabase;
+
+pub fn print(
+    storage_config: &StorageConfig,
+    database: AppDatabase,
+    custom_path: Option<PathBuf>,
+) -> Result<()> {
+    match database {
+        AppDatabase::Sync => {
+            let database = storage_config.sync_database(custom_path, DatabaseMode::ReadOnly)?;
+            p2p::print_sync_database_info(&database)?;
+        }
+    };
+
+    Ok(())
+}

--- a/grandine/src/db_stats.rs
+++ b/grandine/src/db_stats.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use bytesize::ByteSize;
+use database::DatabaseMode;
 use fork_choice_control::{
     BlobSidecarByBlobId, BlockCheckpoint, BlockRootBySlot, FinalizedBlockByRoot,
     PrefixableKey as _, SlotBlobId, SlotByStateRoot, StateByBlockRoot, StateCheckpoint,
@@ -55,7 +56,8 @@ pub fn print<P: Preset>(
     storage_config: &StorageConfig,
     custom_path: Option<PathBuf>,
 ) -> Result<()> {
-    let storage_database = storage_config.beacon_fork_choice_database(custom_path, true)?;
+    let storage_database =
+        storage_config.beacon_fork_choice_database(custom_path, DatabaseMode::ReadOnly)?;
 
     let mut total_size = 0;
     let mut finalized_block_root_entries = EntriesInfo::new("finalized_block_roots");

--- a/grandine/src/grandine_config.rs
+++ b/grandine/src/grandine_config.rs
@@ -108,6 +108,7 @@ impl GrandineConfig {
             ),
         }
 
+        info!("storage mode: {:?}", storage_config.storage_mode);
         info!("data directory: {data_dir:?}");
 
         self.storage_config.print_db_sizes();
@@ -170,7 +171,7 @@ impl GrandineConfig {
         }
 
         info!("suggested fee recipient: {suggested_fee_recipient}");
-        info!("back sync enabled: {back_sync_enabled}");
+        info!("back-sync enabled: {back_sync_enabled}");
 
         if *use_validator_key_cache {
             info!("using validator key cache");

--- a/grandine/src/predefined_network.rs
+++ b/grandine/src/predefined_network.rs
@@ -15,6 +15,7 @@ use types::{
     nonstandard::{FinalizedCheckpoint, WithOrigin},
     preset::Preset,
     redacting_url::RedactingUrl,
+    traits::BeaconState as _,
 };
 
 #[cfg(any(feature = "network-mainnet", test))]
@@ -307,6 +308,8 @@ async fn load_or_download_genesis_checkpoint<P: Preset>(
 
     let state = Arc::from_ssz(config, ssz_bytes)?;
     let block = Arc::new(genesis::beacon_block(&state));
+
+    info!("genesis state loaded at slot: {}", state.slot());
 
     Ok(WithOrigin::new_from_genesis(FinalizedCheckpoint {
         block,

--- a/helper_functions/src/misc.rs
+++ b/helper_functions/src/misc.rs
@@ -124,7 +124,8 @@ pub fn compute_fork_digest(current_version: Version, genesis_validators_root: H2
     ForkDigest::from_slice(&root[..ForkDigest::len_bytes()])
 }
 
-pub(crate) fn compute_domain(
+#[must_use]
+pub fn compute_domain(
     config: &Config,
     domain_type: DomainType,
     fork_version: Option<Version>,

--- a/http_api/src/context.rs
+++ b/http_api/src/context.rs
@@ -16,7 +16,7 @@ use eth1_api::{Eth1Api, Eth1ExecutionEngine, ExecutionService};
 use eth2_cache_utils::mainnet;
 use features::Feature;
 use fork_choice_control::{
-    Controller, StateLoadStrategy, Storage, DEFAULT_ARCHIVAL_EPOCH_INTERVAL,
+    Controller, StateLoadStrategy, Storage, StorageMode, DEFAULT_ARCHIVAL_EPOCH_INTERVAL,
 };
 use fork_choice_store::StoreConfig;
 use futures::{future::FutureExt as _, lock::Mutex, select_biased};
@@ -147,7 +147,7 @@ impl<P: Preset> Context<P> {
             chain_config.clone_arc(),
             Database::in_memory(),
             DEFAULT_ARCHIVAL_EPOCH_INTERVAL,
-            false,
+            StorageMode::Standard,
         ));
 
         let state_load_strategy = StateLoadStrategy::Anchor {
@@ -190,6 +190,7 @@ impl<P: Preset> Context<P> {
             fc_to_validator_tx,
             storage,
             core::iter::empty(),
+            true,
         )?;
 
         for block in extra_blocks {
@@ -385,7 +386,6 @@ impl<P: Preset> Context<P> {
         let submit_requests = case.run(should_update_responses(), actual_address);
 
         SyncToApi::SyncStatus(true).send(&sync_to_api_tx);
-        SyncToApi::BackSyncStatus(true).send(&sync_to_api_tx);
 
         // Poll the HTTP API first to ensure it handles the messages sent above before any requests.
         // This could also be done by polling it once using `core::future::poll_fn`.

--- a/http_api/src/misc.rs
+++ b/http_api/src/misc.rs
@@ -59,19 +59,6 @@ impl SyncedStatus {
     }
 }
 
-#[derive(Default)]
-pub struct BackSyncedStatus(AtomicBool);
-
-impl BackSyncedStatus {
-    pub fn get(&self) -> bool {
-        self.0.load(ORDERING)
-    }
-
-    pub fn set(&self, value: bool) {
-        self.0.store(value, ORDERING);
-    }
-}
-
 pub type SignedBeaconBlockWithBlobsAndProofs<P> = (
     SignedBeaconBlock<P>,
     ContiguousList<KzgProof, <P as Preset>::MaxBlobsPerBlock>,

--- a/http_api/src/routing.rs
+++ b/http_api/src/routing.rs
@@ -26,7 +26,7 @@ use validator::{ApiToValidator, ValidatorConfig};
 use crate::{
     error::Error,
     gui, middleware,
-    misc::{BackSyncedStatus, SyncedStatus},
+    misc::SyncedStatus,
     standard::{
         beacon_events, beacon_heads, beacon_state, blob_sidecars, block, block_attestations,
         block_headers, block_id_headers, block_rewards, block_root, config_spec, debug_fork_choice,
@@ -76,7 +76,6 @@ pub struct NormalState<P: Preset, W: Wait> {
     pub sync_committee_agg_pool: Arc<SyncCommitteeAggPool<P, W>>,
     pub bls_to_execution_change_pool: Arc<BlsToExecutionChangePool>,
     pub is_synced: Arc<SyncedStatus>,
-    pub is_back_synced: Arc<BackSyncedStatus>,
     pub event_channels: Arc<EventChannels>,
     pub api_to_liveness_tx: Option<UnboundedSender<ApiToLiveness>>,
     pub api_to_p2p_tx: UnboundedSender<ApiToP2p<P>>,
@@ -155,12 +154,6 @@ impl<P: Preset, W: Wait> FromRef<NormalState<P, W>> for Arc<BlsToExecutionChange
 impl<P: Preset, W: Wait> FromRef<NormalState<P, W>> for Arc<SyncedStatus> {
     fn from_ref(state: &NormalState<P, W>) -> Self {
         state.is_synced.clone_arc()
-    }
-}
-
-impl<P: Preset, W: Wait> FromRef<NormalState<P, W>> for Arc<BackSyncedStatus> {
-    fn from_ref(state: &NormalState<P, W>) -> Self {
-        state.is_back_synced.clone_arc()
     }
 }
 

--- a/keymanager/src/proposer_configs.rs
+++ b/keymanager/src/proposer_configs.rs
@@ -3,7 +3,7 @@ use std::{path::Path, str};
 use anyhow::{ensure, Result};
 use bls::PublicKeyBytes;
 use bytesize::ByteSize;
-use database::Database;
+use database::{Database, DatabaseMode};
 use derive_more::Display;
 use serde::{de::DeserializeOwned, Serialize};
 use types::{
@@ -45,8 +45,12 @@ impl ProposerConfigs {
         default_gas_limit: Gas,
         default_graffiti: H256,
     ) -> Result<Self> {
-        let database =
-            Database::persistent("proposer-configs", validator_directory, DB_MAX_SIZE, false)?;
+        let database = Database::persistent(
+            "proposer-configs",
+            validator_directory,
+            DB_MAX_SIZE,
+            DatabaseMode::ReadWrite,
+        )?;
 
         Ok(Self {
             database,

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -19,6 +19,7 @@ eth1_api = { workspace = true }
 eth2_libp2p = { workspace = true }
 features = { workspace = true }
 fork_choice_control = { workspace = true }
+fork_choice_store = { workspace = true }
 futures = { workspace = true }
 genesis = { workspace = true }
 helper_functions = { workspace = true }
@@ -26,6 +27,7 @@ igd-next = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 logging = { workspace = true }
+lru = { workspace = true }
 operation_pools = { workspace = true }
 prometheus_metrics = { workspace = true }
 prometheus-client = { workspace = true }
@@ -41,6 +43,7 @@ strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+transition_functions = { workspace = true }
 tynm = { workspace = true }
 typenum = { workspace = true }
 types = { workspace = true }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,7 +1,9 @@
 pub use eth2_libp2p::{metrics, Enr, ListenAddr, Multiaddr, NetworkConfig};
 
 pub use crate::{
-    block_sync_service::{BlockSyncService, Channels as BlockSyncServiceChannels},
+    block_sync_service::{
+        print_sync_database_info, BlockSyncService, Channels as BlockSyncServiceChannels,
+    },
     messages::{
         ApiToP2p, P2pToSlasher, P2pToValidator, SubnetServiceToP2p, SyncToApi, SyncToMetrics,
         ToSubnetService, ValidatorToP2p,

--- a/p2p/src/misc.rs
+++ b/p2p/src/misc.rs
@@ -7,6 +7,12 @@ use types::phase0::primitives::{CommitteeIndex, Epoch, Slot, SubnetId, Validator
 
 pub type RequestId = usize;
 
+#[derive(PartialEq, Eq)]
+pub enum RPCRequestType {
+    Range,
+    Root,
+}
+
 #[derive(Debug, Serialize)]
 pub struct AttestationSubnetActions {
     pub discoveries: Vec<SubnetPeerDiscovery>,

--- a/types/src/nonstandard.rs
+++ b/types/src/nonstandard.rs
@@ -188,6 +188,17 @@ pub struct BlobSidecarWithId<P: Preset> {
     pub blob_id: BlobIdentifier,
 }
 
+impl<P: Preset> From<Arc<BlobSidecar<P>>> for BlobSidecarWithId<P> {
+    fn from(blob_sidecar: Arc<BlobSidecar<P>>) -> Self {
+        let blob_id = blob_sidecar.as_ref().into();
+
+        Self {
+            blob_sidecar,
+            blob_id,
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub struct BlockRewards {
     pub total: Gwei,


### PR DESCRIPTION
Store modes and back-sync:

- Back-sync blocks to `Config::min_epochs_for_block_requests` in standard storage mode
- Back-sync blob sidecars to `Config::min_epochs_for_blob_sidecars_requests`
- Track & filter peers that don't serve blocks prior to `Config::min_epochs_for_block_requests` when performing full back-sync
- Remove `Feature::TrustBackSyncBlocks`
- Verify signatures of back-synced blocks
- Move back-sync status to `Store`
- Relocate `received_blob_sidecars` and `received_block_roots` caches from `p2p::Network` to `p2p::BlockSyncService`
- Extend `SyncBatch` with `retry_count` and `responses_received` fields
- Use smaller back-sync batches when syncing with blobs
- Don't validate signature of genesis block
- Track state archival progress in database to be able to resume it after restart
- Don't request data from busy peers

DB:

- Add `db-info` command to inspect the Sync database
- Replace read-only boolean flag with more descriptive `DatabaseMode` enum

Other:

- Panic to trigger app-restart if network thread is down
- Handle exit signal in an archiver thread & batch archiver updates to db
- Rename `RequestType` to `RPCRequestType` as it conflicts with updated `eth2_libp2p`
- Log peer reporting in debug log
- Log minimal back-sync info when starting back-sync
- Don't log RPC received blocks to info logs (too much output during syncing)