### PR TITLE
Feat: add more `bls` backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,9 +1068,36 @@ dependencies = [
 name = "bls"
 version = "0.0.0"
 dependencies = [
+ "bls-arkworks",
  "bls-blst",
  "bls-core",
  "bls-zkcrypto",
+]
+
+[[package]]
+name = "bls-arkworks"
+version = "0.0.0"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "bls-core",
+ "derivative",
+ "derive_more 1.0.0",
+ "fixed-hash",
+ "hex",
+ "impl-serde",
+ "itertools 0.13.0",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_utils",
+ "sha2 0.10.8",
+ "ssz",
+ "static_assertions",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     'binary_utils',
     'block_producer',
     'bls',
+    'bls/bls-arkworks',
     'bls/bls-blst',
     'bls/bls-core',
     'bls/bls-zkcrypto',
@@ -284,6 +285,10 @@ aes = { version = '0.8', features = ['zeroize'] }
 alloy-rlp = '0.3.9'
 anyhow = { version = '1', features = ['backtrace'] }
 arc-swap = '1'
+ark-bls12-381 = { version = '0.5.0', default-features = false, features = [ "curve" ] }
+ark-ec = '0.5.0'
+ark-ff = '0.5.0'
+ark-serialize = '0.5.0'
 assert-json-diff = '2'
 async-channel = '1'
 async-trait = '0.1'
@@ -294,7 +299,7 @@ base64 = '0.22'
 bincode = '1'
 bit_field = '0.10'
 bitvec = '1'
-bls12_381 = { git = "https://github.com/zkcrypto/bls12_381.git" }
+bls12_381 = { git = 'https://github.com/zkcrypto/bls12_381.git' }
 blst = { version = '0.3', features = ['portable'] }
 bstr = '1'
 build-time = '0.1'
@@ -470,6 +475,7 @@ attestation_verifier = { path = 'attestation_verifier' }
 binary_utils = { path = 'binary_utils' }
 block_producer = { path = 'block_producer' }
 bls = { path = 'bls' }
+bls-arkworks = { path = 'bls/bls-arkworks' }
 bls-blst = { path = 'bls/bls-blst' }
 bls-core = { path = 'bls/bls-core' }
 bls-zkcrypto = { path = 'bls/bls-zkcrypto' }

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -7,10 +7,12 @@ authors = ["Grandine <info@grandine.io>"]
 workspace = true
 
 [features]
+arkworks = ["dep:bls-arkworks"]
 blst = ["dep:bls-blst"]
 zkcrypto = ["dep:bls-zkcrypto"]
 
 [dependencies]
 bls-core = { workspace = true }
+bls-arkworks = { workspace = true, optional = true }
 bls-blst = { workspace = true, optional = true }
 bls-zkcrypto = { workspace = true, optional = true }

--- a/bls/bls-arkworks/Cargo.toml
+++ b/bls/bls-arkworks/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bls-arkworks"
+edition = { workspace = true }
+
+[dependencies]
+ark-bls12-381 = { workspace = true }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-serialize = { workspace = true }
+bls-core = { workspace = true }
+derivative = { workspace = true }
+derive_more = { workspace = true }
+hex = { workspace = true }
+once_cell = { workspace = true }
+fixed-hash = { workspace = true }
+itertools = { workspace = true }
+impl-serde = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_utils = { workspace = true }
+sha2 = { workspace = true }
+ssz = { workspace = true }
+static_assertions = { workspace = true }
+typenum = { workspace = true }
+zeroize = { workspace = true }

--- a/bls/bls-arkworks/src/cached_public_key.rs
+++ b/bls/bls-arkworks/src/cached_public_key.rs
@@ -1,0 +1,10 @@
+use bls_core::{impl_cached_public_key, CachedPublicKey as CachedPublicKeyTrait};
+
+use super::{public_key::PublicKey, public_key_bytes::PublicKeyBytes};
+
+impl_cached_public_key!(
+    CachedPublicKeyTrait,
+    CachedPublicKey,
+    PublicKeyBytes,
+    PublicKey
+);

--- a/bls/bls-arkworks/src/lib.rs
+++ b/bls/bls-arkworks/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod cached_public_key;
+pub mod public_key;
+pub mod public_key_bytes;
+pub mod secret_key;
+pub mod secret_key_bytes;
+pub mod signature;
+pub mod signature_bytes;

--- a/bls/bls-arkworks/src/public_key.rs
+++ b/bls/bls-arkworks/src/public_key.rs
@@ -1,0 +1,53 @@
+use ark_bls12_381::{G1Affine, G1Projective};
+use ark_ec::AffineRepr;
+use ark_serialize::CanonicalDeserialize;
+use derive_more::From;
+
+use bls_core::{error::Error, traits::PublicKey as PublicKeyTrait};
+
+use super::public_key_bytes::PublicKeyBytes;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, From)]
+pub struct PublicKey(G1Projective);
+
+impl Default for PublicKey {
+    #[inline]
+    fn default() -> Self {
+        Self(G1Projective::default())
+    }
+}
+
+impl TryFrom<PublicKeyBytes> for PublicKey {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(bytes: PublicKeyBytes) -> Result<Self, Self::Error> {
+        let point = G1Affine::deserialize_compressed::<&[u8]>(bytes.as_ref())
+            .map_err(|_| Error::DecompressionFailed)?;
+
+        if bool::from(point.is_zero()) {
+            return Err(Error::InvalidPublicKey);
+        }
+
+        if !bool::from(point.is_on_curve()) {
+            return Err(Error::DecompressionFailed);
+        }
+
+        Ok(Self(point.into()))
+    }
+}
+
+impl PublicKeyTrait for PublicKey {
+    type PublicKeyBytes = PublicKeyBytes;
+
+    #[inline]
+    fn aggregate_in_place(&mut self, other: Self) {
+        self.0 = *self.as_raw() + other.as_raw();
+    }
+}
+
+impl PublicKey {
+    pub(crate) const fn as_raw(&self) -> &G1Projective {
+        &self.0
+    }
+}

--- a/bls/bls-arkworks/src/public_key_bytes.rs
+++ b/bls/bls-arkworks/src/public_key_bytes.rs
@@ -1,0 +1,28 @@
+use ark_serialize::CanonicalSerialize;
+use bls_core::{impl_public_key_bytes, COMPRESSED_SIZE};
+use derive_more::derive::AsRef;
+use fixed_hash::construct_fixed_hash;
+use impl_serde::impl_fixed_hash_serde;
+
+use super::public_key::PublicKey;
+
+construct_fixed_hash! {
+    #[derive(AsRef)]
+    pub struct PublicKeyBytes(COMPRESSED_SIZE);
+}
+
+impl_fixed_hash_serde!(PublicKeyBytes, COMPRESSED_SIZE);
+
+impl_public_key_bytes!(PublicKeyBytes);
+
+impl From<PublicKey> for PublicKeyBytes {
+    #[inline]
+    fn from(public_key: PublicKey) -> Self {
+        let mut bytes = [0u8; COMPRESSED_SIZE];
+        public_key
+            .as_raw()
+            .serialize_compressed(&mut bytes[..])
+            .unwrap();
+        Self(bytes)
+    }
+}

--- a/bls/bls-arkworks/src/secret_key.rs
+++ b/bls/bls-arkworks/src/secret_key.rs
@@ -1,7 +1,11 @@
-use bls12_381::{
-    hash_to_curve::{ExpandMsgXmd, HashToCurve},
-    G1Projective, G2Projective, Scalar,
+use ark_bls12_381::{g2, Fr, G1Projective};
+use ark_ec::{
+    hashing::{curve_maps::wb::WBMap, map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve},
+    short_weierstrass::Projective,
+    PrimeGroup,
 };
+use ark_ff::{field_hashers::DefaultFieldHasher, BigInteger, PrimeField};
+use ark_serialize::CanonicalSerialize;
 use bls_core::{
     consts::DOMAIN_SEPARATION_TAG, error::Error, impl_secret_key,
     traits::SecretKey as SecretKeyTrait,
@@ -17,11 +21,11 @@ use super::{
 impl_secret_key!(
     SecretKeyTrait<SIZE>,
     SecretKey,
-    Scalar,
+    Fr,
     SecretKeyBytes,
     PublicKey,
     Signature,
-    |scalar: &Scalar| scalar.to_bytes()
+    |scalar: &Fr| scalar.into_bigint().to_bytes_le()
 );
 
 impl TryFrom<SecretKeyBytes> for SecretKey {
@@ -33,10 +37,7 @@ impl TryFrom<SecretKeyBytes> for SecretKey {
             return Err(Error::InvalidSecretKey);
         }
 
-        let mut le_bytes = secret_key_bytes.bytes;
-        le_bytes.reverse();
-
-        let scalar = match Option::from(Scalar::from_bytes(&le_bytes)) {
+        let scalar = match Option::from(Fr::from_be_bytes_mod_order(&secret_key_bytes.bytes)) {
             Some(scalar) => scalar,
             None => {
                 return Err(Error::InvalidSecretKey);
@@ -54,9 +55,8 @@ impl SecretKeyTrait<SIZE> for SecretKey {
     #[inline]
     #[must_use]
     fn to_bytes(&self) -> SecretKeyBytes {
-        let mut bytes = self.as_raw().to_bytes();
-        bytes.reverse();
-
+        let mut bytes = [0u8; SIZE];
+        self.as_raw().serialize_compressed(&mut bytes[..]).unwrap();
         SecretKeyBytes { bytes }
     }
 
@@ -70,11 +70,14 @@ impl SecretKeyTrait<SIZE> for SecretKey {
     #[inline]
     #[must_use]
     fn sign(&self, message: impl AsRef<[u8]>) -> Signature {
-        let h = <G2Projective as HashToCurve<ExpandMsgXmd<Sha256>>>::hash_to_curve(
-            [message.as_ref()],
-            DOMAIN_SEPARATION_TAG,
-        );
-        let signature = h * self.as_raw();
+        let hasher = MapToCurveBasedHasher::<
+            Projective<g2::Config>,
+            DefaultFieldHasher<Sha256, 128>,
+            WBMap<g2::Config>,
+        >::new(DOMAIN_SEPARATION_TAG)
+        .unwrap();
+        let hash = hasher.hash(message.as_ref()).unwrap();
+        let signature = hash * self.as_raw();
 
         Signature::from(signature)
     }

--- a/bls/bls-arkworks/src/secret_key_bytes.rs
+++ b/bls/bls-arkworks/src/secret_key_bytes.rs
@@ -1,0 +1,7 @@
+use bls_core::impl_secret_key_bytes;
+
+use crate::secret_key::SecretKey;
+
+pub const SIZE: usize = size_of::<SecretKey>();
+
+impl_secret_key_bytes!(SecretKeyBytes, SIZE);

--- a/bls/bls-arkworks/src/signature.rs
+++ b/bls/bls-arkworks/src/signature.rs
@@ -1,0 +1,190 @@
+use ark_bls12_381::{g2, Bls12_381, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
+use ark_ec::{
+    hashing::{curve_maps::wb::WBMap, map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve},
+    pairing::Pairing,
+    short_weierstrass::Projective,
+    AffineRepr, CurveGroup,
+};
+use ark_ff::{field_hashers::DefaultFieldHasher, UniformRand};
+use ark_serialize::CanonicalDeserialize;
+use bls_core::{consts::DOMAIN_SEPARATION_TAG, error::Error, traits::Signature as SignatureTrait};
+use derive_more::From;
+use itertools::Itertools as _;
+use rand::thread_rng;
+use sha2::Sha256;
+
+use super::{public_key::PublicKey, signature_bytes::SignatureBytes};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, From)]
+pub struct Signature(G2Projective);
+
+impl Default for Signature {
+    #[inline]
+    fn default() -> Self {
+        Self(G2Projective::default())
+    }
+}
+
+impl TryFrom<SignatureBytes> for Signature {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(bytes: SignatureBytes) -> Result<Self, Self::Error> {
+        let point = G2Affine::deserialize_compressed::<&[u8]>(bytes.as_ref())
+            .map_err(|_| Error::DecompressionFailed)?;
+
+        Ok(Self(point.into()))
+    }
+}
+
+impl SignatureTrait for Signature {
+    type SignatureBytes = SignatureBytes;
+    type PublicKey = PublicKey;
+
+    #[must_use]
+    fn verify(&self, message: impl AsRef<[u8]>, public_key: Self::PublicKey) -> bool {
+        let h = MapToCurveBasedHasher::<
+            Projective<g2::Config>,
+            DefaultFieldHasher<Sha256, 128>,
+            WBMap<g2::Config>,
+        >::new(DOMAIN_SEPARATION_TAG)
+        .unwrap()
+        .hash(message.as_ref())
+        .unwrap();
+
+        let gt1 = Bls12_381::pairing(public_key.as_raw(), &G2Affine::from(h));
+        let gt2 = Bls12_381::pairing(&G1Affine::generator(), self.as_raw().into_affine());
+
+        gt1 == gt2
+    }
+
+    #[inline]
+    fn aggregate_in_place(&mut self, other: Self) {
+        self.0 = *self.as_raw() + *other.as_raw();
+    }
+
+    #[must_use]
+    fn fast_aggregate_verify<'keys>(
+        &self,
+        message: impl AsRef<[u8]>,
+        public_keys: impl IntoIterator<Item = &'keys PublicKey>,
+    ) -> bool {
+        if bool::from(self.as_raw().into_affine().is_zero()) {
+            return false;
+        }
+
+        let agg_pk = public_keys
+            .into_iter()
+            .fold(G1Projective::default(), |acc, pk| acc + pk.as_raw());
+
+        let h = MapToCurveBasedHasher::<
+            Projective<g2::Config>,
+            DefaultFieldHasher<Sha256, 128>,
+            WBMap<g2::Config>,
+        >::new(DOMAIN_SEPARATION_TAG)
+        .unwrap()
+        .hash(message.as_ref())
+        .unwrap();
+
+        Bls12_381::pairing(&agg_pk.into_affine(), &h)
+            == Bls12_381::pairing(&G1Affine::generator(), &self.as_raw().into_affine())
+    }
+
+    #[must_use]
+    fn multi_verify<'all>(
+        messages: impl IntoIterator<Item = &'all [u8]>,
+        signatures: impl IntoIterator<Item = &'all Self>,
+        public_keys: impl IntoIterator<Item = &'all PublicKey>,
+    ) -> bool {
+        let mut rng = thread_rng();
+
+        let msgs: Vec<&[u8]> = messages.into_iter().collect_vec();
+        let sigs: Vec<&G2Projective> = signatures.into_iter().map(Self::as_raw).collect_vec();
+        let pks: Vec<&G1Projective> = public_keys.into_iter().map(PublicKey::as_raw).collect_vec();
+
+        if msgs.len() != sigs.len() || sigs.len() != pks.len() {
+            return false;
+        }
+
+        if sigs
+            .iter()
+            .any(|sig| bool::from(sig.into_affine().is_zero()))
+        {
+            return false;
+        }
+
+        let rand_scalars: Vec<Fr> = (0..sigs.len()).map(|_| Fr::rand(&mut rng)).collect_vec();
+
+        let mut agg_sig = G2Projective::default();
+        let mut lhs = Bls12_381::pairing(&G1Affine::generator(), &G2Affine::identity());
+
+        for i in 0..sigs.len() {
+            let h = MapToCurveBasedHasher::<
+                Projective<g2::Config>,
+                DefaultFieldHasher<Sha256, 128>,
+                WBMap<g2::Config>,
+            >::new(DOMAIN_SEPARATION_TAG)
+            .unwrap()
+            .hash(msgs[i])
+            .unwrap();
+
+            agg_sig += *sigs[i] * rand_scalars[i];
+
+            lhs += Bls12_381::pairing(&(*pks[i] * rand_scalars[i]), &h);
+        }
+
+        lhs == Bls12_381::pairing(&G1Affine::generator(), &agg_sig.into_affine())
+    }
+}
+
+impl Signature {
+    pub(crate) const fn as_raw(&self) -> &G2Projective {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bls_core::SecretKey as _;
+
+    use crate::{secret_key::SecretKey, secret_key_bytes::SecretKeyBytes};
+
+    use super::*;
+
+    const MESSAGE: &str = "foo";
+
+    #[test]
+    fn signature_verify_succeeds_on_correct_triple() {
+        let secret_key = secret_key();
+        let public_key = SecretKey::to_public_key(&secret_key);
+        let signature = SecretKey::sign(&secret_key, MESSAGE);
+
+        assert!(Signature::verify(&signature, MESSAGE, public_key));
+    }
+
+    #[test]
+    fn signature_verify_fails_on_incorrect_public_key() {
+        let secret_key = secret_key();
+        let public_key = PublicKey::default();
+        let signature = SecretKey::sign(&secret_key, MESSAGE);
+
+        assert!(!Signature::verify(&signature, MESSAGE, public_key));
+    }
+
+    #[test]
+    fn signature_verify_fails_on_incorrect_signature() {
+        let secret_key = secret_key();
+        let public_key = SecretKey::to_public_key(&secret_key);
+        let signature = Signature::default();
+
+        assert!(!Signature::verify(&signature, MESSAGE, public_key));
+    }
+
+    fn secret_key() -> SecretKey {
+        let bytes = b"????????????????????????????????";
+        SecretKey::try_from(SecretKeyBytes {
+            bytes: bytes.to_owned(),
+        })
+        .expect("bytes encode a valid secret key")
+    }
+}

--- a/bls/bls-arkworks/src/signature_bytes.rs
+++ b/bls/bls-arkworks/src/signature_bytes.rs
@@ -1,0 +1,28 @@
+use ark_ec::CurveGroup;
+use ark_serialize::CanonicalSerialize;
+use derive_more::AsRef;
+use fixed_hash::construct_fixed_hash;
+use impl_serde::impl_fixed_hash_serde;
+use typenum::Unsigned as _;
+
+use bls_core::{
+    impl_signature_bytes,
+    traits::{CompressedSize, SignatureBytes as SignatureBytesTrait},
+};
+
+use super::signature::Signature;
+
+impl_signature_bytes!(SignatureBytesTrait, SignatureBytes, CompressedSize::USIZE);
+
+impl From<Signature> for SignatureBytes {
+    #[inline]
+    fn from(signature: Signature) -> Self {
+        let mut bytes = [0u8; CompressedSize::USIZE];
+        signature
+            .as_raw()
+            .into_affine()
+            .serialize_compressed(&mut bytes[..])
+            .unwrap();
+        Self(bytes)
+    }
+}

--- a/bls/bls-blst/src/secret_key.rs
+++ b/bls/bls-blst/src/secret_key.rs
@@ -18,7 +18,8 @@ impl_secret_key!(
     RawSecretKey,
     SecretKeyBytes,
     PublicKey,
-    Signature
+    Signature,
+    |scalar: &RawSecretKey| scalar.to_bytes()
 );
 
 impl TryFrom<SecretKeyBytes> for SecretKey {

--- a/bls/bls-core/src/traits/secret_key.rs
+++ b/bls/bls-core/src/traits/secret_key.rs
@@ -17,7 +17,7 @@ pub trait SecretKey<const N: usize>: Debug + PartialEq + Eq + Hash {
 #[expect(clippy::module_name_repetitions)]
 #[macro_export]
 macro_rules! impl_secret_key {
-    ($trait:ty, $name:ident, $raw:ty, $skb:ty, $pk:ty, $sig:ty) => {
+    ($trait:ty, $name:ident, $raw:ty, $skb:ty, $pk:ty, $sig:ty, $to_bytes:expr) => {
         #[derive(derive_more::Debug)]
         // Inspired by `DebugSecret` from the `secrecy` crate.
         #[debug("[REDACTED]")]
@@ -37,7 +37,7 @@ macro_rules! impl_secret_key {
         impl PartialEq for $name {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
-                self.as_raw().to_bytes() == other.as_raw().to_bytes()
+                ($to_bytes)(self.as_raw()) == ($to_bytes)(other.as_raw())
             }
         }
 
@@ -45,7 +45,7 @@ macro_rules! impl_secret_key {
 
         impl core::hash::Hash for $name {
             fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
-                self.as_raw().to_bytes().hash(hasher)
+                ($to_bytes)(self.as_raw()).hash(hasher)
             }
         }
 

--- a/bls/src/lib.rs
+++ b/bls/src/lib.rs
@@ -16,6 +16,9 @@ macro_rules! implement_backend {
     };
 }
 
+#[cfg(feature = "arkworks")]
+implement_backend!(bls_arkworks);
+
 #[cfg(feature = "blst")]
 implement_backend!(bls_blst);
 


### PR DESCRIPTION
This PR builds on #69 adding more backends to the `bls` crate. 

Checklist of backends added:
- [x] `arkworks`
- [ ] `constantine`
- [ ] `mcl`

@sauliusgrigaitis Please let me know if some more backends should be added to this list. 