### PR TITLE
Enable multiple BLS backends in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            backend: blst
+            backend: arkworks,blst,constantine,mcl
           - os: windows-latest
-            backend: blst
+            backend: arkworks,constantine,zkcrypto
           - os: macos-latest
-            backend: blst
+            backend: arkworks,blst,mcl
 
     runs-on: ${{ matrix.os }}
 
@@ -21,6 +21,20 @@ jobs:
     - name: Disable autocrlf (Windows)
       if: runner.os == 'Windows'
       run: git config --global core.autocrlf false
+    - name: Setup nim for constantine backend
+      if: runner.os != 'Macos'
+      uses: jiro4989/setup-nim-action@v2
+      with:
+        nim-version: '2.0.2'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        parent-nim-install-directory: ${{ runner.temp }}
+    - name: Install dependencies for constantine backend
+      if: runner.os == 'Linux'
+      run: |
+        sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
+          --no-install-recommends -yq \
+          libgmp-dev \
+          llvm
     - uses: actions/checkout@v4
       with:
         submodules: true


### PR DESCRIPTION
In #88, support for multiple BLS backend in kzg was implemented. However, it broke pipeline, so multiple backend testing was disabled in main branch. This PR enables multiple backends back, without breaking CI.