### PR TITLE
Optimize SSZ decoding

### DIFF
--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -1261,8 +1261,8 @@ pub async fn blob_sidecars<P: Preset, W: Wait>(
         controller.blob_sidecars_by_ids(blob_identifiers)?
     };
 
-    let blob_sidecars = DynamicList::try_from_iter_with_maximum(
-        blob_sidecars.into_iter(),
+    let blob_sidecars = DynamicList::from_vec(
+        blob_sidecars,
         usize::try_from(max_blobs_per_block).map_err(AnyhowError::new)?,
     )
     .map_err(AnyhowError::new)?;
@@ -1359,8 +1359,8 @@ pub async fn blobs<P: Preset, W: Wait>(
             .collect()
     };
 
-    let blobs = DynamicList::try_from_iter_with_maximum(
-        blobs.into_iter(),
+    let blobs = DynamicList::from_vec(
+        blobs,
         usize::try_from(max_blobs_per_block).map_err(AnyhowError::new)?,
     )
     .map_err(AnyhowError::new)?;
@@ -2153,11 +2153,9 @@ pub async fn debug_beacon_data_column_sidecars<P: Preset, W: Wait>(
 
     let data_column_sidecars = controller.data_column_sidecars_by_ids(data_column_identifiers)?;
 
-    let data_column_sidecars = DynamicList::try_from_iter_with_maximum(
-        data_column_sidecars.into_iter(),
-        P::NumberOfColumns::USIZE,
-    )
-    .map_err(AnyhowError::new)?;
+    let data_column_sidecars =
+        DynamicList::from_vec(data_column_sidecars, P::NumberOfColumns::USIZE)
+            .map_err(AnyhowError::new)?;
 
     Ok(EthResponse::json_or_ssz(data_column_sidecars, &headers)?
         .execution_optimistic(status.is_optimistic())

--- a/ssz/src/contiguous_list.rs
+++ b/ssz/src/contiguous_list.rs
@@ -104,8 +104,7 @@ impl<T: SszSize, N> SszSize for ContiguousList<T, N> {
 
 impl<C, T: SszRead<C>, N: Unsigned> SszRead<C> for ContiguousList<T, N> {
     fn from_ssz_unchecked(context: &C, bytes: &[u8]) -> Result<Self, ReadError> {
-        let results = shared::read_list(context, bytes)?;
-        itertools::process_results(results, |elements| Self::try_from_iter(elements))?
+        shared::read_list(N::USIZE, context, bytes)
     }
 }
 
@@ -144,7 +143,7 @@ impl<T, N> ContiguousList<T, N> {
         ContiguousList::new_unchecked(self.into_iter().map(function).collect())
     }
 
-    const fn validate_length(actual: usize) -> Result<(), ReadError>
+    pub(crate) const fn validate_length(actual: usize) -> Result<(), ReadError>
     where
         N: Unsigned,
     {
@@ -157,7 +156,7 @@ impl<T, N> ContiguousList<T, N> {
         Ok(())
     }
 
-    const fn new_unchecked(elements: Box<[T]>) -> Self {
+    pub(crate) const fn new_unchecked(elements: Box<[T]>) -> Self {
         Self {
             elements,
             phantom: PhantomData,

--- a/ssz/src/error.rs
+++ b/ssz/src/error.rs
@@ -1,3 +1,5 @@
+use core::convert::Infallible;
+
 use thiserror::Error;
 
 use crate::{
@@ -28,6 +30,8 @@ pub enum ReadError {
     VectorFirstOffsetMismatch { expected: usize, actual: usize },
     #[error("expected vector to have {expected} elements, found {actual} elements")]
     VectorSizeMismatch { expected: usize, actual: usize },
+    #[error("list size in bytes is not a multiple of element size")]
+    ListSizeNotMultiple { list: usize, element: usize },
     #[error("first offset of list is not aligned")]
     ListFirstOffsetUnaligned { first_offset: usize },
     #[error("expected list to have no more than {maximum} elements, found {actual} elements")]
@@ -49,6 +53,12 @@ pub enum ReadError {
     //                      worsen performance.
     #[error("{message}")]
     Custom { message: &'static str },
+}
+
+impl From<Infallible> for ReadError {
+    fn from(infallible: Infallible) -> Self {
+        match infallible {}
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Error)]

--- a/ssz/src/persistent_list.rs
+++ b/ssz/src/persistent_list.rs
@@ -241,8 +241,7 @@ impl<T: SszSize, N, B> SszSize for PersistentList<T, N, B> {
 
 impl<C, T: SszRead<C>, N: Unsigned, B: BundleSize<T>> SszRead<C> for PersistentList<T, N, B> {
     fn from_ssz_unchecked(context: &C, bytes: &[u8]) -> Result<Self, ReadError> {
-        let results = shared::read_list(context, bytes)?;
-        itertools::process_results(results, |elements| Self::try_from_iter(elements))?
+        shared::read_list(N::USIZE, context, bytes)
     }
 }
 

--- a/try_from_iterator/src/lib.rs
+++ b/try_from_iterator/src/lib.rs
@@ -12,6 +12,14 @@ pub trait TryFromIterator<T>: Sized {
     fn try_from_iter(items: impl IntoIterator<Item = T>) -> Result<Self, Self::Error>;
 }
 
+impl<T> TryFromIterator<T> for Box<[T]> {
+    type Error = Infallible;
+
+    fn try_from_iter(items: impl IntoIterator<Item = T>) -> Result<Self, Self::Error> {
+        Ok(Self::from_iter(items))
+    }
+}
+
 impl<T> TryFromIterator<T> for Vec<T> {
     type Error = Infallible;
 


### PR DESCRIPTION
This was motivated by results of benchmarks in [ghiliweld/ssz-arena].
@ghiliweld may be interested.

The slowness was largely due to byte collections [again].
Their `SszRead` implementations were overly generic.
`SignedBeaconBlock` decoding is now roughly 5 times faster.
`BlobSidecar` decoding is now roughly 20 times faster.

The work is a couple months old.
A compilation error appeared in `http_api::standard` after rebasing on `develop`.

[ghiliweld/ssz-arena]: https://github.com/ghiliweld/ssz-arena
[again]: https://github.com/grandinetech/grandine/pull/84