### PR TITLE
SSZ size improvements

### DIFF
--- a/ssz/src/bit_list.rs
+++ b/ssz/src/bit_list.rs
@@ -130,7 +130,7 @@ impl<'de, N: Unsigned> Deserialize<'de> for BitList<N> {
 }
 
 // `BitBox` serializes itself as a struct with multiple fields.
-impl<N> Serialize for BitList<N> {
+impl<N: Unsigned> Serialize for BitList<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut ssz_bytes = vec![];
         self.write_variable(&mut ssz_bytes)
@@ -139,8 +139,11 @@ impl<N> Serialize for BitList<N> {
     }
 }
 
-impl<N> SszSize for BitList<N> {
-    const SIZE: Size = Size::Variable { minimum_size: 1 };
+impl<N: Unsigned> SszSize for BitList<N> {
+    const SIZE: Size = Size::Variable {
+        minimum: 1,
+        maximum: Ok(bytes_with_delimiting_bit(N::USIZE)),
+    };
 }
 
 impl<C, N: Unsigned> SszRead<C> for BitList<N> {
@@ -151,7 +154,7 @@ impl<C, N: Unsigned> SszRead<C> for BitList<N> {
     }
 }
 
-impl<N> SszWrite for BitList<N> {
+impl<N: Unsigned> SszWrite for BitList<N> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         let length_before = bytes.len();
         let length_after = length_before + bytes_with_delimiting_bit(self.len());

--- a/ssz/src/byte_list.rs
+++ b/ssz/src/byte_list.rs
@@ -51,8 +51,8 @@ impl<'de, N: Unsigned> Deserialize<'de> for ByteList<N> {
     }
 }
 
-impl<N> SszSize for ByteList<N> {
-    const SIZE: Size = Size::Variable { minimum_size: 0 };
+impl<N: Unsigned> SszSize for ByteList<N> {
+    const SIZE: Size = Size::for_list(u8::SIZE, N::USIZE);
 }
 
 impl<C, N: Unsigned> SszRead<C> for ByteList<N> {
@@ -61,7 +61,7 @@ impl<C, N: Unsigned> SszRead<C> for ByteList<N> {
     }
 }
 
-impl<N> SszWrite for ByteList<N> {
+impl<N: Unsigned> SszWrite for ByteList<N> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         self.bytes.write_variable(bytes)
     }

--- a/ssz/src/contiguous_list.rs
+++ b/ssz/src/contiguous_list.rs
@@ -98,8 +98,8 @@ impl<'de, T: Deserialize<'de>, N: Unsigned> Deserialize<'de> for ContiguousList<
     }
 }
 
-impl<T: SszSize, N> SszSize for ContiguousList<T, N> {
-    const SIZE: Size = Size::Variable { minimum_size: 0 };
+impl<T: SszSize, N: Unsigned> SszSize for ContiguousList<T, N> {
+    const SIZE: Size = Size::for_list(T::SIZE, N::USIZE);
 }
 
 impl<C, T: SszRead<C>, N: Unsigned> SszRead<C> for ContiguousList<T, N> {
@@ -109,7 +109,7 @@ impl<C, T: SszRead<C>, N: Unsigned> SszRead<C> for ContiguousList<T, N> {
     }
 }
 
-impl<T: SszWrite, N> SszWrite for ContiguousList<T, N> {
+impl<T: SszWrite, N: Unsigned> SszWrite for ContiguousList<T, N> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         shared::write_list(bytes, self)
     }

--- a/ssz/src/contiguous_vector.rs
+++ b/ssz/src/contiguous_vector.rs
@@ -114,7 +114,7 @@ impl<'de, T: Deserialize<'de>, N: ArrayLength<T>> Deserialize<'de> for Contiguou
 }
 
 impl<T: SszSize, N: ContiguousVectorElements<T>> SszSize for ContiguousVector<T, N> {
-    const SIZE: Size = T::SIZE.mul(N::USIZE);
+    const SIZE: Size = Size::for_vector(T::SIZE, N::USIZE);
 }
 
 impl<C, T: SszRead<C>, N: ContiguousVectorElements<T>> SszRead<C> for ContiguousVector<T, N> {

--- a/ssz/src/dynamic_list.rs
+++ b/ssz/src/dynamic_list.rs
@@ -58,7 +58,7 @@ impl<T: Serialize> Serialize for DynamicList<T> {
 }
 
 impl<T: SszSize> SszSize for DynamicList<T> {
-    const SIZE: Size = Size::Variable { minimum_size: 0 };
+    const SIZE: Size = Size::for_list(T::SIZE, usize::MAX);
 }
 
 impl<T: SszReadDefault> SszRead<usize> for DynamicList<T> {

--- a/ssz/src/error.rs
+++ b/ssz/src/error.rs
@@ -6,6 +6,12 @@ use crate::{
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Error)]
+pub enum SizeError {
+    #[error("maximum size does not fit in usize")]
+    MaximumSizeDoesNotFitInUsize,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Error)]
 pub enum ReadError {
     #[error("expected fixed-size value of {expected} bytes, found {actual} bytes")]
     FixedSizeMismatch { expected: usize, actual: usize },

--- a/ssz/src/lib.rs
+++ b/ssz/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::{
     contiguous_list::ContiguousList,
     contiguous_vector::ContiguousVector,
     dynamic_list::DynamicList,
-    error::{IndexError, PushError, ReadError, WriteError},
+    error::{IndexError, PushError, ReadError, SizeError, WriteError},
     hc::Hc,
     merkle_tree::{mix_in_length, MerkleTree, ProofWithLength},
     persistent_list::PersistentList,

--- a/ssz/src/persistent_list.rs
+++ b/ssz/src/persistent_list.rs
@@ -235,8 +235,8 @@ impl<T: Serialize, N, B: BundleSize<T>> Serialize for PersistentList<T, N, B> {
     }
 }
 
-impl<T: SszSize, N, B> SszSize for PersistentList<T, N, B> {
-    const SIZE: Size = Size::Variable { minimum_size: 0 };
+impl<T: SszSize, N: Unsigned, B> SszSize for PersistentList<T, N, B> {
+    const SIZE: Size = Size::for_list(T::SIZE, N::USIZE);
 }
 
 impl<C, T: SszRead<C>, N: Unsigned, B: BundleSize<T>> SszRead<C> for PersistentList<T, N, B> {
@@ -246,7 +246,7 @@ impl<C, T: SszRead<C>, N: Unsigned, B: BundleSize<T>> SszRead<C> for PersistentL
     }
 }
 
-impl<T: SszWrite, N, B: BundleSize<T>> SszWrite for PersistentList<T, N, B> {
+impl<T: SszWrite, N: Unsigned, B: BundleSize<T>> SszWrite for PersistentList<T, N, B> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         shared::write_list(bytes, self)
     }

--- a/ssz/src/persistent_vector.rs
+++ b/ssz/src/persistent_vector.rs
@@ -241,7 +241,7 @@ where
 }
 
 impl<T: SszSize, N: Unsigned + NonZero, B: BundleSize<T>> SszSize for PersistentVector<T, N, B> {
-    const SIZE: Size = T::SIZE.mul(N::USIZE);
+    const SIZE: Size = Size::for_vector(T::SIZE, N::USIZE);
 }
 
 impl<C, T, N, B> SszRead<C> for PersistentVector<T, N, B>

--- a/ssz/src/porcelain.rs
+++ b/ssz/src/porcelain.rs
@@ -72,8 +72,11 @@ pub trait SszWrite: SszSize {
                 self.write_fixed(bytes.as_mut_slice());
                 Ok(bytes)
             }
-            Size::Variable { minimum_size } => {
-                let mut bytes = Vec::with_capacity(minimum_size);
+            Size::Variable {
+                minimum,
+                maximum: _,
+            } => {
+                let mut bytes = Vec::with_capacity(minimum);
                 self.write_variable(&mut bytes)?;
                 Ok(bytes)
             }

--- a/types/src/altair/containers.rs
+++ b/types/src/altair/containers.rs
@@ -161,3 +161,142 @@ pub struct SyncCommitteeMessage {
     pub validator_index: ValidatorIndex,
     pub signature: SignatureBytes,
 }
+
+#[cfg(test)]
+mod tests {
+    use ssz::{Size, SszSize as _, BYTES_PER_LENGTH_OFFSET as OFFSET};
+    use test_case::test_case;
+    use typenum::Unsigned as _;
+
+    use crate::{phase0::consts::DepositContractTreeDepth, preset::Mainnet};
+
+    use super::*;
+
+    // TODO(feature/ssz-size-improvements): Clean up tests for standard container sizes.
+
+    const UINT: usize = 8;
+    const HASH: usize = 32;
+
+    const PUBLIC_KEY: usize = 48;
+    const SIGNATURE: usize = 96;
+
+    const AGGREGATION_BITS_MAX: usize =
+        <Mainnet as Preset>::MaxValidatorsPerCommittee::USIZE / 8 + 1;
+
+    const DEPOSIT_PROOF: usize = (DepositContractTreeDepth::USIZE + 1) * HASH;
+
+    const ANY_LIST_MIN: usize = 0;
+    const ATTESTATION_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxAttestations::USIZE * (OFFSET + ATTESTATION_MAX);
+    const ATTESTER_SLASHING_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxAttesterSlashings::USIZE * (OFFSET + ATTESTER_SLASHING_MAX);
+    const DEPOSIT_LIST_MAX: usize = <Mainnet as Preset>::MaxDeposits::USIZE * DEPOSIT;
+    const PROPOSER_SLASHING_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxProposerSlashings::USIZE * PROPOSER_SLASHING;
+    const SIGNED_VOLUNTARY_EXIT_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxVoluntaryExits::USIZE * SIGNED_VOLUNTARY_EXIT;
+    const VALIDATOR_INDEX_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxValidatorsPerCommittee::USIZE * UINT;
+
+    const ATTESTATION_MAX: usize = OFFSET + ATTESTATION_DATA + SIGNATURE + AGGREGATION_BITS_MAX;
+    const ATTESTATION_DATA: usize = UINT + UINT + HASH + CHECKPOINT + CHECKPOINT;
+    const ATTESTER_SLASHING_MAX: usize =
+        OFFSET + OFFSET + INDEXED_ATTESTATION_MAX + INDEXED_ATTESTATION_MAX;
+    const BEACON_BLOCK_HEADER: usize = UINT + UINT + HASH + HASH + HASH;
+    const CHECKPOINT: usize = UINT + HASH;
+    const DEPOSIT: usize = DEPOSIT_PROOF + DEPOSIT_DATA;
+    const DEPOSIT_DATA: usize = PUBLIC_KEY + HASH + UINT + SIGNATURE;
+    const ETH1_DATA: usize = HASH + UINT + HASH;
+    const INDEXED_ATTESTATION_MAX: usize =
+        OFFSET + ATTESTATION_DATA + SIGNATURE + VALIDATOR_INDEX_LIST_MAX;
+    const PROPOSER_SLASHING: usize = SIGNED_BEACON_BLOCK_HEADER + SIGNED_BEACON_BLOCK_HEADER;
+    const SIGNED_BEACON_BLOCK_HEADER: usize = BEACON_BLOCK_HEADER + SIGNATURE;
+    const SIGNED_VOLUNTARY_EXIT: usize = VOLUNTARY_EXIT + SIGNATURE;
+    const VOLUNTARY_EXIT: usize = UINT + UINT;
+
+    const AGGREGATION_BITS: usize = SyncSubcommitteeSize::<Mainnet>::USIZE / 8;
+    const SYNC_COMMITTEE_BITS: usize = <Mainnet as Preset>::SyncCommitteeSize::USIZE / 8;
+
+    const CURRENT_SYNC_COMMITTEE_BRANCH: usize = Log2::<CurrentSyncCommitteeIndex>::USIZE * HASH;
+    const FINALITY_BRANCH: usize = Log2::<FinalizedRootIndex>::USIZE * HASH;
+    const NEXT_SYNC_COMMITTEE_BRANCH: usize = Log2::<NextSyncCommitteeIndex>::USIZE * HASH;
+    const PUBKEYS: usize = <Mainnet as Preset>::SyncCommitteeSize::USIZE * PUBLIC_KEY;
+
+    const BEACON_BLOCK_MIN: usize = UINT + UINT + HASH + HASH + OFFSET + BEACON_BLOCK_BODY_MIN;
+    const BEACON_BLOCK_MAX: usize = UINT + UINT + HASH + HASH + OFFSET + BEACON_BLOCK_BODY_MAX;
+    const BEACON_BLOCK_BODY_MIN: usize = SIGNATURE
+        + ETH1_DATA
+        + HASH
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + SYNC_AGGREGATE
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN;
+    const BEACON_BLOCK_BODY_MAX: usize = SIGNATURE
+        + ETH1_DATA
+        + HASH
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + SYNC_AGGREGATE
+        + PROPOSER_SLASHING_LIST_MAX
+        + ATTESTER_SLASHING_LIST_MAX
+        + ATTESTATION_LIST_MAX
+        + DEPOSIT_LIST_MAX
+        + SIGNED_VOLUNTARY_EXIT_LIST_MAX;
+    const CONTRIBUTION_AND_PROOF: usize = UINT + SYNC_COMMITTEE_CONTRIBUTION + SIGNATURE;
+    const LIGHT_CLIENT_BOOTSTRAP: usize =
+        LIGHT_CLIENT_HEADER + SYNC_COMMITTEE + CURRENT_SYNC_COMMITTEE_BRANCH;
+    const LIGHT_CLIENT_FINALITY_UPDATE: usize =
+        LIGHT_CLIENT_HEADER + LIGHT_CLIENT_HEADER + FINALITY_BRANCH + SYNC_AGGREGATE + UINT;
+    const LIGHT_CLIENT_HEADER: usize = BEACON_BLOCK_HEADER;
+    const LIGHT_CLIENT_OPTIMISTIC_UPDATE: usize = LIGHT_CLIENT_HEADER + SYNC_AGGREGATE + UINT;
+    const LIGHT_CLIENT_UPDATE: usize = LIGHT_CLIENT_HEADER
+        + SYNC_COMMITTEE
+        + NEXT_SYNC_COMMITTEE_BRANCH
+        + LIGHT_CLIENT_HEADER
+        + FINALITY_BRANCH
+        + SYNC_AGGREGATE
+        + UINT;
+    const SIGNED_BEACON_BLOCK_MIN: usize = OFFSET + SIGNATURE + BEACON_BLOCK_MIN;
+    const SIGNED_BEACON_BLOCK_MAX: usize = OFFSET + SIGNATURE + BEACON_BLOCK_MAX;
+    const SIGNED_CONTRIBUTION_AND_PROOF: usize = CONTRIBUTION_AND_PROOF + SIGNATURE;
+    const SYNC_AGGREGATE: usize = SYNC_COMMITTEE_BITS + SIGNATURE;
+    const SYNC_AGGREGATOR_SELECTION_DATA: usize = UINT + UINT;
+    const SYNC_COMMITTEE: usize = PUBKEYS + PUBLIC_KEY;
+    const SYNC_COMMITTEE_CONTRIBUTION: usize = UINT + HASH + UINT + AGGREGATION_BITS + SIGNATURE;
+    const SYNC_COMMITTEE_MESSAGE: usize = UINT + HASH + UINT + SIGNATURE;
+
+    #[test_case(BitVector::<SyncSubcommitteeSize<Mainnet>>::SIZE,          Size::Fixed { size: AGGREGATION_BITS    })]
+    #[test_case(BitVector::<<Mainnet as Preset>::SyncCommitteeSize>::SIZE, Size::Fixed { size: SYNC_COMMITTEE_BITS })]
+    #[test_case(ContiguousVector::<H256, Log2<CurrentSyncCommitteeIndex>>::SIZE,                        Size::Fixed { size: CURRENT_SYNC_COMMITTEE_BRANCH })]
+    #[test_case(ContiguousVector::<H256, Log2<FinalizedRootIndex>>::SIZE,                               Size::Fixed { size: FINALITY_BRANCH               })]
+    #[test_case(ContiguousVector::<H256, Log2<NextSyncCommitteeIndex>>::SIZE,                           Size::Fixed { size: NEXT_SYNC_COMMITTEE_BRANCH    })]
+    #[test_case(Box::<ContiguousVector<CachedPublicKey, <Mainnet as Preset>::SyncCommitteeSize>>::SIZE, Size::Fixed { size: PUBKEYS                       })]
+    #[test_case(BeaconBlock::<Mainnet>::SIZE,                 Size::Variable { minimum: BEACON_BLOCK_MIN,        maximum: Ok(BEACON_BLOCK_MAX)        })]
+    #[test_case(BeaconBlockBody::<Mainnet>::SIZE,             Size::Variable { minimum: BEACON_BLOCK_BODY_MIN,   maximum: Ok(BEACON_BLOCK_BODY_MAX)   })]
+    #[test_case(ContributionAndProof::<Mainnet>::SIZE,        Size::Fixed    { size: CONTRIBUTION_AND_PROOF                                           })]
+    #[test_case(LightClientBootstrap::<Mainnet>::SIZE,        Size::Fixed    { size: LIGHT_CLIENT_BOOTSTRAP                                           })]
+    #[test_case(LightClientFinalityUpdate::<Mainnet>::SIZE,   Size::Fixed    { size: LIGHT_CLIENT_FINALITY_UPDATE                                     })]
+    #[test_case(LightClientHeader::SIZE,                      Size::Fixed    { size: LIGHT_CLIENT_HEADER                                              })]
+    #[test_case(LightClientOptimisticUpdate::<Mainnet>::SIZE, Size::Fixed    { size: LIGHT_CLIENT_OPTIMISTIC_UPDATE                                   })]
+    #[test_case(LightClientUpdate::<Mainnet>::SIZE,           Size::Fixed    { size: LIGHT_CLIENT_UPDATE                                              })]
+    #[test_case(SignedBeaconBlock::<Mainnet>::SIZE,           Size::Variable { minimum: SIGNED_BEACON_BLOCK_MIN, maximum: Ok(SIGNED_BEACON_BLOCK_MAX) })]
+    #[test_case(SignedContributionAndProof::<Mainnet>::SIZE,  Size::Fixed    { size: SIGNED_CONTRIBUTION_AND_PROOF                                    })]
+    #[test_case(SyncAggregate::<Mainnet>::SIZE,               Size::Fixed    { size: SYNC_AGGREGATE                                                   })]
+    #[test_case(SyncAggregatorSelectionData::SIZE,            Size::Fixed    { size: SYNC_AGGREGATOR_SELECTION_DATA                                   })]
+    #[test_case(SyncCommittee::<Mainnet>::SIZE,               Size::Fixed    { size: SYNC_COMMITTEE                                                   })]
+    #[test_case(SyncCommitteeContribution::<Mainnet>::SIZE,   Size::Fixed    { size: SYNC_COMMITTEE_CONTRIBUTION                                      })]
+    #[test_case(SyncCommitteeMessage::SIZE,                   Size::Fixed    { size: SYNC_COMMITTEE_MESSAGE                                           })]
+    fn ssz_size(actual: Size, expected: Size) {
+        assert_eq!(actual, expected);
+    }
+}

--- a/types/src/combined.rs
+++ b/types/src/combined.rs
@@ -148,8 +148,8 @@ impl<P: Preset> SszRead<Config> for BeaconState<P> {
         // There are 2 fixed parts before `state.slot`:
         // - The contents of `state.genesis_time`.
         // - The contents of `state.genesis_validators_root`.
-        let slot_start = UnixSeconds::SIZE.get() + H256::SIZE.get();
-        let slot_end = slot_start + Slot::SIZE.get();
+        let slot_start = UnixSeconds::SIZE.fixed_part() + H256::SIZE.fixed_part();
+        let slot_end = slot_start + Slot::SIZE.fixed_part();
         let slot_bytes = ssz::subslice(bytes, slot_start..slot_end)?;
         let slot = Slot::from_ssz_default(slot_bytes)?;
         let phase = config.phase_at_slot::<P>(slot);
@@ -383,8 +383,8 @@ impl<P: Preset> SszRead<Config> for SignedBeaconBlock<P> {
         // There are 2 fixed parts before `block.message.slot`:
         // - The offset of `block.message`.
         // - The contents of `block.signature`.
-        let slot_start = Offset::SIZE.get() + SignatureBytes::SIZE.get();
-        let slot_end = slot_start + Slot::SIZE.get();
+        let slot_start = Offset::SIZE.fixed_part() + SignatureBytes::SIZE.fixed_part();
+        let slot_end = slot_start + Slot::SIZE.fixed_part();
         let slot_bytes = ssz::subslice(bytes, slot_start..slot_end)?;
         let slot = Slot::from_ssz_default(slot_bytes)?;
         let phase = config.phase_at_slot::<P>(slot);
@@ -534,7 +534,7 @@ impl<P: Preset> SszRead<Config> for BeaconBlock<P> {
     fn from_ssz_unchecked(config: &Config, bytes: &[u8]) -> Result<Self, ReadError> {
         // The offset of `block.slot` is the first fixed part in `block`.
         let slot_start = 0;
-        let slot_end = slot_start + Slot::SIZE.get();
+        let slot_end = slot_start + Slot::SIZE.fixed_part();
         let slot_bytes = ssz::subslice(bytes, slot_start..slot_end)?;
         let slot = Slot::from_ssz_default(slot_bytes)?;
         let phase = config.phase_at_slot::<P>(slot);
@@ -1155,8 +1155,11 @@ impl<P: Preset> SszWrite for LightClientBootstrap<P> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         match self {
             Self::Altair(update) => {
+                const { assert!(AltairLightClientBootstrap::<P>::SIZE.is_fixed()) }
+
+                let size = AltairLightClientBootstrap::<P>::SIZE.fixed_part();
                 let length_before = bytes.len();
-                let length_after = length_before + AltairLightClientBootstrap::<P>::SIZE.get();
+                let length_after = length_before + size;
 
                 bytes.resize(length_after, 0);
                 update.write_fixed(&mut bytes[length_before..]);
@@ -1212,8 +1215,11 @@ impl<P: Preset> SszWrite for LightClientFinalityUpdate<P> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         match self {
             Self::Altair(update) => {
+                const { assert!(AltairLightClientFinalityUpdate::<P>::SIZE.is_fixed()) }
+
+                let size = AltairLightClientFinalityUpdate::<P>::SIZE.fixed_part();
                 let length_before = bytes.len();
-                let length_after = length_before + AltairLightClientFinalityUpdate::<P>::SIZE.get();
+                let length_after = length_before + size;
 
                 bytes.resize(length_after, 0);
                 update.write_fixed(&mut bytes[length_before..]);
@@ -1269,7 +1275,9 @@ impl<P: Preset> SszWrite for LightClientOptimisticUpdate<P> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         match self {
             Self::Altair(update) => {
-                let size = AltairLightClientOptimisticUpdate::<P>::SIZE.get();
+                const { assert!(AltairLightClientOptimisticUpdate::<P>::SIZE.is_fixed()) }
+
+                let size = AltairLightClientOptimisticUpdate::<P>::SIZE.fixed_part();
                 let length_before = bytes.len();
                 let length_after = length_before + size;
 
@@ -1315,8 +1323,11 @@ impl<P: Preset> SszWrite for LightClientUpdate<P> {
     fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), WriteError> {
         match self {
             Self::Altair(update) => {
+                const { assert!(AltairLightClientUpdate::<P>::SIZE.is_fixed()) }
+
+                let size = AltairLightClientUpdate::<P>::SIZE.fixed_part();
                 let length_before = bytes.len();
-                let length_after = length_before + AltairLightClientUpdate::<P>::SIZE.get();
+                let length_after = length_before + size;
 
                 bytes.resize(length_after, 0);
                 update.write_fixed(&mut bytes[length_before..]);
@@ -1506,8 +1517,8 @@ impl<P: Preset> SszRead<Config> for Attestation<P> {
     fn from_ssz_unchecked(config: &Config, bytes: &[u8]) -> Result<Self, ReadError> {
         // There is 1 fixed part before `attestation.data.slot`:
         // - The offset of `attestation.aggregation_bits`.
-        let slot_start = Offset::SIZE.get();
-        let slot_end = slot_start + Slot::SIZE.get();
+        let slot_start = Offset::SIZE.fixed_part();
+        let slot_end = slot_start + Slot::SIZE.fixed_part();
         let slot_bytes = ssz::subslice(bytes, slot_start..slot_end)?;
         let slot = Slot::from_ssz_default(slot_bytes)?;
         let phase = config.phase_at_slot::<P>(slot);

--- a/types/src/eip7594.rs
+++ b/types/src/eip7594.rs
@@ -57,16 +57,6 @@ impl<P: Preset> DataColumnSidecar<P> {
     pub const fn slot(&self) -> u64 {
         self.signed_block_header.message.slot
     }
-
-    #[must_use]
-    pub fn full() -> Self {
-        Self {
-            column: DataColumn::<P>::full(Box::default()),
-            kzg_commitments: ContiguousList::full(KzgCommitment::repeat_byte(u8::MAX)),
-            kzg_proofs: ContiguousList::full(KzgProof::repeat_byte(u8::MAX)),
-            ..Default::default()
-        }
-    }
 }
 
 #[expect(clippy::missing_fields_in_debug)]

--- a/types/src/phase0/containers.rs
+++ b/types/src/phase0/containers.rs
@@ -249,3 +249,160 @@ pub struct VoluntaryExit {
     #[serde(with = "serde_utils::string_or_native")]
     pub validator_index: ValidatorIndex,
 }
+
+#[cfg(test)]
+mod tests {
+    use ssz::{Size, SszSize as _, BYTES_PER_LENGTH_OFFSET as OFFSET};
+    use test_case::test_case;
+    use typenum::Unsigned as _;
+
+    use crate::preset::{Mainnet, SlotsPerHistoricalRoot};
+
+    use super::*;
+
+    // TODO(feature/ssz-size-improvements): Clean up tests for standard container sizes.
+
+    const BOOL: usize = 1;
+    const UINT: usize = 8;
+    const HASH: usize = 32;
+
+    const PUBLIC_KEY: usize = 48;
+    const SIGNATURE: usize = 96;
+
+    const VERSION: usize = 4;
+
+    const AGGREGATION_BITS_MIN: usize = 1;
+    const AGGREGATION_BITS_MAX: usize =
+        <Mainnet as Preset>::MaxValidatorsPerCommittee::USIZE / 8 + 1;
+
+    const DEPOSIT_PROOF: usize = (DepositContractTreeDepth::USIZE + 1) * HASH;
+    const RECENT_ROOTS: usize = SlotsPerHistoricalRoot::<Mainnet>::USIZE * HASH;
+
+    const ANY_LIST_MIN: usize = 0;
+    const ATTESTATION_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxAttestations::USIZE * (OFFSET + ATTESTATION_MAX);
+    const ATTESTER_SLASHING_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxAttesterSlashings::USIZE * (OFFSET + ATTESTER_SLASHING_MAX);
+    const DEPOSIT_LIST_MAX: usize = <Mainnet as Preset>::MaxDeposits::USIZE * DEPOSIT;
+    const PROPOSER_SLASHING_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxProposerSlashings::USIZE * PROPOSER_SLASHING;
+    const SIGNED_VOLUNTARY_EXIT_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxVoluntaryExits::USIZE * SIGNED_VOLUNTARY_EXIT;
+    const VALIDATOR_INDEX_LIST_MAX: usize =
+        <Mainnet as Preset>::MaxValidatorsPerCommittee::USIZE * UINT;
+
+    const AGGREGATE_AND_PROOF_MIN: usize = UINT + OFFSET + SIGNATURE + ATTESTATION_MIN;
+    const AGGREGATE_AND_PROOF_MAX: usize = UINT + OFFSET + SIGNATURE + ATTESTATION_MAX;
+    const ATTESTATION_MIN: usize = OFFSET + ATTESTATION_DATA + SIGNATURE + AGGREGATION_BITS_MIN;
+    const ATTESTATION_MAX: usize = OFFSET + ATTESTATION_DATA + SIGNATURE + AGGREGATION_BITS_MAX;
+    const ATTESTATION_DATA: usize = UINT + UINT + HASH + CHECKPOINT + CHECKPOINT;
+    const ATTESTER_SLASHING_MIN: usize =
+        OFFSET + OFFSET + INDEXED_ATTESTATION_MIN + INDEXED_ATTESTATION_MIN;
+    const ATTESTER_SLASHING_MAX: usize =
+        OFFSET + OFFSET + INDEXED_ATTESTATION_MAX + INDEXED_ATTESTATION_MAX;
+    const BEACON_BLOCK_MIN: usize = UINT + UINT + HASH + HASH + OFFSET + BEACON_BLOCK_BODY_MIN;
+    const BEACON_BLOCK_MAX: usize = UINT + UINT + HASH + HASH + OFFSET + BEACON_BLOCK_BODY_MAX;
+    const BEACON_BLOCK_BODY_MIN: usize = SIGNATURE
+        + ETH1_DATA
+        + HASH
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN
+        + ANY_LIST_MIN;
+    const BEACON_BLOCK_BODY_MAX: usize = SIGNATURE
+        + ETH1_DATA
+        + HASH
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + OFFSET
+        + PROPOSER_SLASHING_LIST_MAX
+        + ATTESTER_SLASHING_LIST_MAX
+        + ATTESTATION_LIST_MAX
+        + DEPOSIT_LIST_MAX
+        + SIGNED_VOLUNTARY_EXIT_LIST_MAX;
+    const BEACON_BLOCK_HEADER: usize = UINT + UINT + HASH + HASH + HASH;
+    const CHECKPOINT: usize = UINT + HASH;
+    const DEPOSIT: usize = DEPOSIT_PROOF + DEPOSIT_DATA;
+    const DEPOSIT_DATA: usize = PUBLIC_KEY + HASH + UINT + SIGNATURE;
+    const DEPOSIT_MESSAGE: usize = PUBLIC_KEY + HASH + UINT;
+    const ETH1_DATA: usize = HASH + UINT + HASH;
+    const FORK: usize = VERSION + VERSION + UINT;
+    const FORK_DATA: usize = VERSION + HASH;
+    const HISTORICAL_BATCH: usize = RECENT_ROOTS + RECENT_ROOTS;
+    const INDEXED_ATTESTATION_MIN: usize = OFFSET + ATTESTATION_DATA + SIGNATURE + ANY_LIST_MIN;
+    const INDEXED_ATTESTATION_MAX: usize =
+        OFFSET + ATTESTATION_DATA + SIGNATURE + VALIDATOR_INDEX_LIST_MAX;
+    const PENDING_ATTESTATION_MIN: usize =
+        OFFSET + ATTESTATION_DATA + UINT + UINT + AGGREGATION_BITS_MIN;
+    const PENDING_ATTESTATION_MAX: usize =
+        OFFSET + ATTESTATION_DATA + UINT + UINT + AGGREGATION_BITS_MAX;
+    const PROPOSER_SLASHING: usize = SIGNED_BEACON_BLOCK_HEADER + SIGNED_BEACON_BLOCK_HEADER;
+    const SIGNED_AGGREGATE_AND_PROOF_MIN: usize = OFFSET + SIGNATURE + AGGREGATE_AND_PROOF_MIN;
+    const SIGNED_AGGREGATE_AND_PROOF_MAX: usize = OFFSET + SIGNATURE + AGGREGATE_AND_PROOF_MAX;
+    const SIGNED_BEACON_BLOCK_MIN: usize = OFFSET + SIGNATURE + BEACON_BLOCK_MIN;
+    const SIGNED_BEACON_BLOCK_MAX: usize = OFFSET + SIGNATURE + BEACON_BLOCK_MAX;
+    const SIGNED_BEACON_BLOCK_HEADER: usize = BEACON_BLOCK_HEADER + SIGNATURE;
+    const SIGNED_VOLUNTARY_EXIT: usize = VOLUNTARY_EXIT + SIGNATURE;
+    const SIGNING_DATA: usize = HASH + HASH;
+    const VALIDATOR: usize = PUBLIC_KEY + HASH + UINT + BOOL + UINT + UINT + UINT + UINT;
+    const VOLUNTARY_EXIT: usize = UINT + UINT;
+
+    #[test_case(bool::SIZE, Size::Fixed { size: BOOL })]
+    #[test_case(u64::SIZE,  Size::Fixed { size: UINT })]
+    #[test_case(H256::SIZE, Size::Fixed { size: HASH })]
+    #[test_case(AggregateSignatureBytes::SIZE, Size::Fixed { size: SIGNATURE  })]
+    #[test_case(CachedPublicKey::SIZE,         Size::Fixed { size: PUBLIC_KEY })]
+    #[test_case(SignatureBytes::SIZE,          Size::Fixed { size: SIGNATURE  })]
+    #[test_case(CommitteeIndex::SIZE,     Size::Fixed { size: UINT })]
+    #[test_case(DepositIndex::SIZE,       Size::Fixed { size: UINT })]
+    #[test_case(Epoch::SIZE,              Size::Fixed { size: UINT })]
+    #[test_case(ExecutionBlockHash::SIZE, Size::Fixed { size: HASH })]
+    #[test_case(Gwei::SIZE,               Size::Fixed { size: UINT })]
+    #[test_case(Slot::SIZE,               Size::Fixed { size: UINT })]
+    #[test_case(ValidatorIndex::SIZE,     Size::Fixed { size: UINT })]
+    #[test_case(BitList::<<Mainnet as Preset>::MaxValidatorsPerCommittee>::SIZE, Size::Variable { minimum: AGGREGATION_BITS_MIN, maximum: Ok(AGGREGATION_BITS_MAX) })]
+    #[test_case(ProofWithLength::<DepositContractTreeDepth>::SIZE, Size::Fixed { size: DEPOSIT_PROOF })]
+    #[test_case(RecentRoots::<Mainnet>::SIZE,                      Size::Fixed { size: RECENT_ROOTS  })]
+    #[test_case(ContiguousList::<Attestation<Mainnet>,      <Mainnet as Preset>::MaxAttestations>::SIZE,           Size::Variable { minimum: ANY_LIST_MIN, maximum: Ok(ATTESTATION_LIST_MAX) })]
+    #[test_case(ContiguousList::<AttesterSlashing<Mainnet>, <Mainnet as Preset>::MaxAttesterSlashings>::SIZE,      Size::Variable { minimum: ANY_LIST_MIN, maximum: Ok(ATTESTER_SLASHING_LIST_MAX) })]
+    #[test_case(ContiguousList::<Deposit,                   <Mainnet as Preset>::MaxDeposits>::SIZE,               Size::Variable { minimum: ANY_LIST_MIN, maximum: Ok(DEPOSIT_LIST_MAX) })]
+    #[test_case(ContiguousList::<ProposerSlashing,          <Mainnet as Preset>::MaxProposerSlashings>::SIZE,      Size::Variable { minimum: ANY_LIST_MIN, maximum: Ok(PROPOSER_SLASHING_LIST_MAX) })]
+    #[test_case(ContiguousList::<SignedVoluntaryExit,       <Mainnet as Preset>::MaxVoluntaryExits>::SIZE,         Size::Variable { minimum: ANY_LIST_MIN, maximum: Ok(SIGNED_VOLUNTARY_EXIT_LIST_MAX) })]
+    #[test_case(ContiguousList::<ValidatorIndex,            <Mainnet as Preset>::MaxValidatorsPerCommittee>::SIZE, Size::Variable { minimum: ANY_LIST_MIN, maximum: Ok(VALIDATOR_INDEX_LIST_MAX) })]
+    #[test_case(AggregateAndProof::<Mainnet>::SIZE,       Size::Variable { minimum: AGGREGATE_AND_PROOF_MIN,        maximum: Ok(AGGREGATE_AND_PROOF_MAX)        })]
+    #[test_case(Attestation::<Mainnet>::SIZE,             Size::Variable { minimum: ATTESTATION_MIN,                maximum: Ok(ATTESTATION_MAX)                })]
+    #[test_case(AttestationData::SIZE,                    Size::Fixed    { size: ATTESTATION_DATA                                                               })]
+    #[test_case(AttesterSlashing::<Mainnet>::SIZE,        Size::Variable { minimum: ATTESTER_SLASHING_MIN,          maximum: Ok(ATTESTER_SLASHING_MAX)          })]
+    #[test_case(BeaconBlock::<Mainnet>::SIZE,             Size::Variable { minimum: BEACON_BLOCK_MIN,               maximum: Ok(BEACON_BLOCK_MAX)               })]
+    #[test_case(BeaconBlockBody::<Mainnet>::SIZE,         Size::Variable { minimum: BEACON_BLOCK_BODY_MIN,          maximum: Ok(BEACON_BLOCK_BODY_MAX)          })]
+    #[test_case(BeaconBlockHeader::SIZE,                  Size::Fixed    { size: BEACON_BLOCK_HEADER                                                            })]
+    #[test_case(Checkpoint::SIZE,                         Size::Fixed    { size: CHECKPOINT                                                                     })]
+    #[test_case(Deposit::SIZE,                            Size::Fixed    { size: DEPOSIT                                                                        })]
+    #[test_case(DepositData::SIZE,                        Size::Fixed    { size: DEPOSIT_DATA                                                                   })]
+    #[test_case(DepositMessage::SIZE,                     Size::Fixed    { size: DEPOSIT_MESSAGE                                                                })]
+    #[test_case(Eth1Data::SIZE,                           Size::Fixed    { size: ETH1_DATA                                                                      })]
+    #[test_case(Fork::SIZE,                               Size::Fixed    { size: FORK                                                                           })]
+    #[test_case(ForkData::SIZE,                           Size::Fixed    { size: FORK_DATA                                                                      })]
+    #[test_case(HistoricalBatch::<Mainnet>::SIZE,         Size::Fixed    { size: HISTORICAL_BATCH                                                               })]
+    #[test_case(IndexedAttestation::<Mainnet>::SIZE,      Size::Variable { minimum: INDEXED_ATTESTATION_MIN,        maximum: Ok(INDEXED_ATTESTATION_MAX)        })]
+    #[test_case(PendingAttestation::<Mainnet>::SIZE,      Size::Variable { minimum: PENDING_ATTESTATION_MIN,        maximum: Ok(PENDING_ATTESTATION_MAX)        })]
+    #[test_case(ProposerSlashing::SIZE,                   Size::Fixed    { size: PROPOSER_SLASHING                                                              })]
+    #[test_case(SignedAggregateAndProof::<Mainnet>::SIZE, Size::Variable { minimum: SIGNED_AGGREGATE_AND_PROOF_MIN, maximum: Ok(SIGNED_AGGREGATE_AND_PROOF_MAX) })]
+    #[test_case(SignedBeaconBlock::<Mainnet>::SIZE,       Size::Variable { minimum: SIGNED_BEACON_BLOCK_MIN,        maximum: Ok(SIGNED_BEACON_BLOCK_MAX)        })]
+    #[test_case(SignedBeaconBlockHeader::SIZE,            Size::Fixed    { size: SIGNED_BEACON_BLOCK_HEADER                                                     })]
+    #[test_case(SignedVoluntaryExit::SIZE,                Size::Fixed    { size: SIGNED_VOLUNTARY_EXIT                                                          })]
+    #[test_case(SigningData::SIZE,                        Size::Fixed    { size: SIGNING_DATA                                                                   })]
+    #[test_case(Validator::SIZE,                          Size::Fixed    { size: VALIDATOR                                                                      })]
+    #[test_case(VoluntaryExit::SIZE,                      Size::Fixed    { size: VOLUNTARY_EXIT                                                                 })]
+    fn ssz_size(actual: Size, expected: Size) {
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
Some bug fixes for minimum size calculation and a currently broken implementation of maximum size calculation.
The `maximum` field should have a type like `Result<usize, SizeError>` or `Result<usize, TryFromIntError>`.

There seem to be size calculation bugs in `eth2_libp2p` that I pointed out elsewhere.