### PR TITLE
Corrected typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The documentation is available [here](https://docs.grandine.io/). Feel free to r
 
 ## Performance
 
-Grandine is a optimised and parallelised client. There aren't many published performance comparisions, but a previous [research](https://arxiv.org/abs/2311.05252) by MigaLabs may give some insight. We run 50,000 Holesky validators on one of our developer's machine.
+Grandine is a optimised and parallelised client. There aren't many published performance comparisons, but a previous [research](https://arxiv.org/abs/2311.05252) by MigaLabs may give some insight. We run 50,000 Holesky validators on one of our developer's machine.
 
 ## Memory Usage
 

--- a/book/src/beacon_node_api.md
+++ b/book/src/beacon_node_api.md
@@ -18,4 +18,4 @@ docker run                                                          \
 
 * `--http-port` - sets API listen port (default: `5052`);
 * `--http-address` - sets API listen address (default: `127.0.0.1`);
-* `--timeout` - sets API timeout in miliseconds (default: `10000`).
+* `--timeout` - sets API timeout in milliseconds (default: `10000`).


### PR DESCRIPTION
Changes made in:

- /README.md ("comparisions" → "comparisons")

- /book/src/beacon_node_api.md ("miliseconds" → "milliseconds")
