### PR TITLE
Skip participating in aggregation duty if chain head is not fully verified by execution engine

### DIFF
--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1119,6 +1119,14 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
     #[expect(clippy::too_many_lines)]
     async fn publish_aggregates_and_proofs(&self, wait_group: &W, slot_head: &SlotHead<P>) {
+        if slot_head.optimistic {
+            warn!(
+                "validators cannot participate in aggregation because \
+                 chain head has not been fully verified by an execution engine",
+            );
+            return;
+        }
+
         let config = &self.chain_config;
         let phase = slot_head.phase();
 


### PR DESCRIPTION
It currently does skip attesting and sync committee duties if chain head is not fully verified, so it makes sense to skip aggregating too.