### PR TITLE
Implement basic validator custody without backfill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6003,6 +6003,7 @@ dependencies = [
  "database",
  "dedicated_executor",
  "derive_more 1.0.0",
+ "eip_7594",
  "enum-iterator",
  "eth1_api",
  "eth2_libp2p",

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -199,10 +199,7 @@ where
     }
 
     pub fn on_store_sampling_columns(&self, sampling_columns: HashSet<ColumnIndex>) {
-        if !self.store_snapshot().has_sampling_columns_stored() {
-            MutatorMessage::StoreSamplingColumns { sampling_columns }
-                .send(&self.owned_mutator_tx());
-        }
+        MutatorMessage::StoreSamplingColumns { sampling_columns }.send(&self.owned_mutator_tx());
     }
 
     // This should be called at the start of every tick.
@@ -751,7 +748,7 @@ where
     }
 
     pub fn sampling_columns_count(&self) -> usize {
-        self.store_snapshot().sampling_columns().len()
+        self.store_snapshot().sampling_columns_count()
     }
 
     pub fn accepted_data_column_sidecar(

--- a/http_api/src/context.rs
+++ b/http_api/src/context.rs
@@ -303,6 +303,10 @@ impl<P: Preset> Context<P> {
             validator_to_slasher_tx: None,
         };
 
+        let mut network_config = NetworkConfig::default();
+        network_config.identify_agent_version = Some(IDENTIFY_AGENT_VERSION.to_owned());
+        let network_config = Arc::new(network_config);
+
         let validator = Validator::new(
             validator_config.clone_arc(),
             block_producer.clone_arc(),
@@ -318,11 +322,9 @@ impl<P: Preset> Context<P> {
             None,
             None,
             validator_channels,
+            network_config.network_dir.as_deref(),
+            network_config.subscribe_all_data_column_subnets,
         );
-
-        let mut network_config = NetworkConfig::default();
-        network_config.identify_agent_version = Some(IDENTIFY_AGENT_VERSION.to_owned());
-        let network_config = Arc::new(network_config);
 
         let subnet_service = SubnetService::new(
             attestation_agg_pool.clone_arc(),

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -17,6 +17,7 @@ database = { workspace = true }
 dedicated_executor = { workspace = true }
 derive_more = { workspace = true }
 enum-iterator = { workspace = true }
+eip_7594 = { workspace = true }
 eth1_api = { workspace = true }
 eth2_libp2p = { workspace = true }
 features = { workspace = true }

--- a/p2p/src/block_sync_service.rs
+++ b/p2p/src/block_sync_service.rs
@@ -551,6 +551,9 @@ impl<P: Preset> BlockSyncService<P> {
                         P2pToSync::DataColumnSidecarRejected(data_column_identifier) => {
                             self.received_data_column_sidecars.remove(&data_column_identifier);
                         }
+                        P2pToSync::PeerCgcUpdated(peer_id) => {
+                            self.sync_manager.update_peer_cgc(peer_id);
+                        }
                         P2pToSync::Stop => {
                             SyncToApi::Stop.send(&self.sync_to_api_tx);
 

--- a/p2p/src/messages.rs
+++ b/p2p/src/messages.rs
@@ -264,6 +264,7 @@ pub enum SubnetServiceToP2p {
     AttemptToUpdateCustodyGroupCount(u64),
     UpdateAttestationSubnets(AttestationSubnetActions),
     UpdateCustodyRequirements(Epoch, u64),
+    UpdateEarliestAvailableSlot(Slot),
     UpdateSyncCommitteeSubnets(BTreeMap<SubnetId, SyncCommitteeSubnetAction>),
 }
 
@@ -280,6 +281,7 @@ pub enum ToSubnetService {
     SetRegisteredValidators(Vec<PublicKeyBytes>, Vec<ValidatorIndex>),
     UpdateBeaconCommitteeSubscriptions(Slot, Vec<BeaconCommitteeSubscription>, Sender<Result<()>>),
     UpdateCustodyRequirements(Epoch, u64),
+    UpdateEarliestAvailableSlot(Slot),
     UpdateSyncCommitteeSubscriptions(Epoch, Vec<SyncCommitteeSubscription>),
 }
 

--- a/p2p/src/messages.rs
+++ b/p2p/src/messages.rs
@@ -59,6 +59,7 @@ pub enum P2pToSync<P: Preset> {
     GossipDataColumnSidecar(Arc<DataColumnSidecar<P>>, SubnetId, GossipId),
     BlobSidecarRejected(BlobIdentifier),
     DataColumnSidecarRejected(DataColumnIdentifier),
+    PeerCgcUpdated(PeerId),
     Stop,
 }
 
@@ -215,6 +216,7 @@ impl<P: Preset> P2pToSlasher<P> {
 }
 
 pub enum ServiceInboundMessage<P: Preset> {
+    AttemptToUpdateCustodyGroupCount(u64),
     DiscoverSubnetPeers(Vec<SubnetDiscovery>),
     GoodbyePeer(PeerId, GoodbyeReason, ReportSource),
     Publish(PubsubMessage<P>),
@@ -227,6 +229,7 @@ pub enum ServiceInboundMessage<P: Preset> {
     SubscribeNewForkTopics(Phase, ForkDigest),
     Unsubscribe(GossipTopic),
     UnsubscribeFromForkTopicsExcept(ForkDigest),
+    UpdateCustodyRequirements(Epoch, u64),
     UpdateEnrSubnet(Subnet, bool),
     UpdateFork(EnrForkId),
     UpdateGossipsubParameters(u64, Slot),
@@ -258,7 +261,9 @@ impl<P: Preset> ServiceOutboundMessage<P> {
 pub enum SubnetServiceToP2p {
     // Use `BTreeMap` to make serialization deterministic for snapshot testing.
     // `Vec` would work too and would be slightly faster.
+    AttemptToUpdateCustodyGroupCount(u64),
     UpdateAttestationSubnets(AttestationSubnetActions),
+    UpdateCustodyRequirements(Epoch, u64),
     UpdateSyncCommitteeSubnets(BTreeMap<SubnetId, SyncCommitteeSubnetAction>),
 }
 
@@ -271,8 +276,10 @@ impl SubnetServiceToP2p {
 }
 
 pub enum ToSubnetService {
+    AttemptToUpdateCustodyGroupCount(u64),
     SetRegisteredValidators(Vec<PublicKeyBytes>, Vec<ValidatorIndex>),
     UpdateBeaconCommitteeSubscriptions(Slot, Vec<BeaconCommitteeSubscription>, Sender<Result<()>>),
+    UpdateCustodyRequirements(Epoch, u64),
     UpdateSyncCommitteeSubscriptions(Epoch, Vec<SyncCommitteeSubscription>),
 }
 

--- a/p2p/src/subnet_service.rs
+++ b/p2p/src/subnet_service.rs
@@ -81,6 +81,9 @@ impl<P: Preset, W: Wait> SubnetService<P, W> {
 
     fn handle_other_message(&mut self, message: ToSubnetService) {
         match message {
+            ToSubnetService::AttemptToUpdateCustodyGroupCount(custody_group_count) => {
+                self.attempt_to_update_custody_group_count(custody_group_count);
+            }
             ToSubnetService::SetRegisteredValidators(pubkeys, prepared_proposer_indices) => {
                 self.set_registered_validators(pubkeys, prepared_proposer_indices);
             }
@@ -95,6 +98,9 @@ impl<P: Preset, W: Wait> SubnetService<P, W> {
                 if receiver.send(result).is_err() {
                     debug!("failed to send response because the receiver was dropped");
                 }
+            }
+            ToSubnetService::UpdateCustodyRequirements(advertise_epoch, custody_group_count) => {
+                self.update_custody_requirements(advertise_epoch, custody_group_count);
             }
             ToSubnetService::UpdateSyncCommitteeSubscriptions(current_epoch, subscriptions) => {
                 self.update_sync_committee_subscriptions(current_epoch, subscriptions);
@@ -174,5 +180,15 @@ impl<P: Preset, W: Wait> SubnetService<P, W> {
         if !actions.is_empty() {
             SubnetServiceToP2p::UpdateSyncCommitteeSubnets(actions).send(&self.p2p_tx);
         }
+    }
+
+    fn attempt_to_update_custody_group_count(&self, custody_group_count: u64) {
+        SubnetServiceToP2p::AttemptToUpdateCustodyGroupCount(custody_group_count)
+            .send(&self.p2p_tx);
+    }
+
+    fn update_custody_requirements(&self, advertise_epoch: Epoch, custody_group_count: u64) {
+        SubnetServiceToP2p::UpdateCustodyRequirements(advertise_epoch, custody_group_count)
+            .send(&self.p2p_tx);
     }
 }

--- a/p2p/src/subnet_service.rs
+++ b/p2p/src/subnet_service.rs
@@ -102,6 +102,9 @@ impl<P: Preset, W: Wait> SubnetService<P, W> {
             ToSubnetService::UpdateCustodyRequirements(advertise_epoch, custody_group_count) => {
                 self.update_custody_requirements(advertise_epoch, custody_group_count);
             }
+            ToSubnetService::UpdateEarliestAvailableSlot(slot) => {
+                self.update_earliest_available_slot(slot);
+            }
             ToSubnetService::UpdateSyncCommitteeSubscriptions(current_epoch, subscriptions) => {
                 self.update_sync_committee_subscriptions(current_epoch, subscriptions);
             }
@@ -190,5 +193,9 @@ impl<P: Preset, W: Wait> SubnetService<P, W> {
     fn update_custody_requirements(&self, advertise_epoch: Epoch, custody_group_count: u64) {
         SubnetServiceToP2p::UpdateCustodyRequirements(advertise_epoch, custody_group_count)
             .send(&self.p2p_tx);
+    }
+
+    fn update_earliest_available_slot(&self, slot: Slot) {
+        SubnetServiceToP2p::UpdateEarliestAvailableSlot(slot).send(&self.p2p_tx);
     }
 }

--- a/p2p/src/sync_manager.rs
+++ b/p2p/src/sync_manager.rs
@@ -231,6 +231,15 @@ impl SyncManager {
             .collect_vec()
     }
 
+    pub fn update_peer_cgc(&mut self, peer_id: PeerId) {
+        self.log(
+            Level::Debug,
+            format_args!("update peer custody group count (peer_id: {peer_id})"),
+        );
+
+        self.update_peer_columns_custody(peer_id);
+    }
+
     pub fn retry_batch(
         &mut self,
         request_id: RequestId,
@@ -333,13 +342,13 @@ impl SyncManager {
                                 self.get_data_column_range_received(start_slot)
                             {
                                 self.network_globals
-                                    .sampling_columns
+                                    .sampling_columns()
                                     .iter()
                                     .filter(|index| !received_response.contains(index))
                                     .copied()
                                     .collect()
                             } else {
-                                self.network_globals.sampling_columns.clone()
+                                self.network_globals.sampling_columns()
                             };
 
                             if !columns_to_request.is_empty() {
@@ -518,7 +527,7 @@ impl SyncManager {
                 && self
                     .get_data_column_range_received(self.last_sync_range.start)
                     .is_some_and(|received| {
-                        received.len() < self.network_globals.sampling_columns.len()
+                        received.len() < self.network_globals.sampling_columns_count()
                     })
             {
                 // Keep requesting the last sync range for remaining data columns
@@ -592,7 +601,7 @@ impl SyncManager {
 
             if config.phase_at_slot::<P>(start_slot).is_peerdas_activated() {
                 if data_column_serve_range_slot < max_slot {
-                    let mut columns_to_request = self.network_globals.sampling_columns.clone();
+                    let mut columns_to_request = self.network_globals.sampling_columns().clone();
                     if let Some(received_response) = self.get_data_column_range_received(start_slot)
                     {
                         if !redownloads_increased {
@@ -941,10 +950,24 @@ impl SyncManager {
         }
     }
 
+    fn update_peer_columns_custody(&mut self, peer_id: PeerId) {
+        for column_index in &self.network_globals.sampling_columns() {
+            let custodial_peers = self.custodial_peers.entry(*column_index).or_default();
+            if self
+                .network_globals
+                .is_custody_peer_of(*column_index, &peer_id)
+            {
+                custodial_peers.insert(peer_id);
+            } else if custodial_peers.contains(&peer_id) {
+                custodial_peers.remove(&peer_id);
+            }
+        }
+    }
+
     pub fn refresh_custodial_peers(&mut self) {
         let custodial_peers = self
             .network_globals
-            .sampling_columns
+            .sampling_columns()
             .iter()
             .map(|column_index| {
                 (

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -574,6 +574,8 @@ pub async fn run_after_genesis<P: Preset>(
         metrics.clone(),
         validator_statistics.clone(),
         validator_channels,
+        network_config.network_dir.as_deref(),
+        network_config.subscribe_all_data_column_subnets,
     );
 
     let p2p_channels = Channels {
@@ -611,7 +613,7 @@ pub async fn run_after_genesis<P: Preset>(
     .await?;
 
     if chain_config.is_peerdas_scheduled() {
-        let sampling_columns = network.network_globals().sampling_columns.clone();
+        let sampling_columns = network.network_globals().sampling_columns();
         controller.on_store_sampling_columns(sampling_columns);
     }
 

--- a/types/src/config.rs
+++ b/types/src/config.rs
@@ -176,6 +176,10 @@ pub struct Config {
     pub number_of_custody_groups: u64,
     #[serde(with = "serde_utils::string_or_native")]
     pub samples_per_slot: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    pub validator_custody_requirement: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    pub balance_per_additional_custody_group: Gwei,
 
     #[serde(skip_serializing)]
     pub blacklisted_blocks: Vec<H256>,
@@ -284,6 +288,8 @@ impl Default for Config {
             number_of_columns: 128,
             number_of_custody_groups: 128,
             samples_per_slot: 8,
+            validator_custody_requirement: 8,
+            balance_per_additional_custody_group: 32_000_000_000,
 
             blacklisted_blocks: vec![],
 

--- a/validator/src/custody.rs
+++ b/validator/src/custody.rs
@@ -1,0 +1,94 @@
+use std::io::{prelude::*, BufReader};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use fs_err::{File, OpenOptions};
+use log::{debug, warn};
+use types::config::Config;
+use types::phase0::primitives::Epoch;
+
+const CUSTODY_UPDATES_SCHEDULE_FILENAME: &str = "custody_updates_schedule";
+
+pub struct ValidatorCustody {
+    updates_schedule: Vec<(Epoch, u64)>,
+    chain_config: Arc<Config>,
+    network_dir: Option<PathBuf>,
+}
+
+impl ValidatorCustody {
+    pub fn load_updates_schedule(network_dir: Option<&Path>, chain_config: Arc<Config>) -> Self {
+        let mut updates_schedule = Vec::new();
+
+        if let Some(dir) = network_dir {
+            let updates_schedule_path = dir.join(CUSTODY_UPDATES_SCHEDULE_FILENAME);
+            if let Ok(file) = File::open(updates_schedule_path) {
+                let reader = BufReader::new(file);
+
+                for entry in reader.lines().map_while(Result::ok) {
+                    let parts: Vec<&str> = entry.trim().split(',').collect();
+
+                    if parts.len() == 2 {
+                        if let Ok(epoch) = parts[0].parse::<Epoch>() {
+                            if let Ok(cgc) = parts[1].parse::<u64>() {
+                                updates_schedule.push((epoch, cgc));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!("custody updates schedule: {updates_schedule:?}");
+
+        Self {
+            updates_schedule,
+            chain_config,
+            network_dir: network_dir.map(Path::to_path_buf),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.updates_schedule.is_empty()
+    }
+
+    pub fn at_epoch(&self, current_epoch: Epoch) -> u64 {
+        self.updates_schedule
+            .iter()
+            .find_map(|(epoch, cgc)| (current_epoch >= *epoch).then_some(*cgc))
+            .unwrap_or(self.chain_config.custody_requirement)
+    }
+
+    pub fn schedule_custody_update(&mut self, epoch: Epoch, custody_group_count: u64) {
+        self.updates_schedule.push((epoch, custody_group_count));
+        save_entry_to_disk(epoch, custody_group_count, self.network_dir.as_deref());
+    }
+}
+
+fn save_entry_to_disk(epoch: Epoch, custody_group_count: u64, network_dir: Option<&Path>) {
+    let Some(dir) = network_dir else {
+        debug!("Skipping Metadata writing to disk");
+        return;
+    };
+
+    let write_to_disk = || -> Result<()> {
+        let filename = dir.join(CUSTODY_UPDATES_SCHEDULE_FILENAME);
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(filename)?;
+
+        writeln!(file, "{epoch},{custody_group_count}")?;
+        Ok(())
+    };
+
+    match write_to_disk() {
+        Ok(()) => {
+            debug!("Custody update entry written to disk");
+        }
+        Err(_) => {
+            warn!("Could not write custody update entry to disk");
+        }
+    }
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -6,6 +6,7 @@ pub use crate::{
 };
 
 mod api;
+mod custody;
 mod messages;
 mod misc;
 mod own_beacon_committee_members;

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::{
 };
 
 mod api;
-mod custody;
+// mod custody;
 mod messages;
 mod misc;
 mod own_beacon_committee_members;

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -3,6 +3,7 @@
 use core::error::Error as StdError;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    path::Path,
     sync::Arc,
     time::SystemTime,
 };
@@ -72,7 +73,7 @@ use types::{
             AggregateAndProof as Phase0AggregateAndProof, Attestation as Phase0Attestation,
             AttestationData, Checkpoint, SignedAggregateAndProof as Phase0SignedAggregateAndProof,
         },
-        primitives::{Epoch, Slot, H256},
+        primitives::{Epoch, Slot, ValidatorIndex, H256},
     },
     preset::Preset,
     traits::{BeaconState as _, PostAltairBeaconState, SignedBeaconBlock as _},
@@ -80,6 +81,7 @@ use types::{
 use validator_statistics::ValidatorStatistics;
 
 use crate::{
+    custody::ValidatorCustody,
     messages::{ApiToValidator, InternalMessage},
     misc::{Aggregator, SyncCommitteeMember},
     own_beacon_committee_members::{BeaconCommitteeMember, OwnBeaconCommitteeMembers},
@@ -158,6 +160,8 @@ pub struct Validator<P: Preset, W: Wait> {
     internal_rx: UnboundedReceiver<InternalMessage>,
     validator_to_liveness_tx: Option<UnboundedSender<ValidatorToLiveness<P>>>,
     validator_to_slasher_tx: Option<UnboundedSender<ValidatorToSlasher>>,
+    validator_custody: ValidatorCustody,
+    subscribe_to_all_data_column_subnets: bool,
 }
 
 impl<P: Preset, W: Wait + Sync> Validator<P, W> {
@@ -178,6 +182,8 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         metrics: Option<Arc<Metrics>>,
         validator_statistics: Option<Arc<ValidatorStatistics>>,
         channels: Channels<P, W>,
+        network_dir: Option<&Path>,
+        subscribe_to_all_data_column_subnets: bool,
     ) -> Self {
         let Channels {
             api_to_validator_rx,
@@ -196,6 +202,11 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
             controller.chain_config().clone_arc(),
             signer.clone_arc(),
         ));
+
+        let validator_custody = ValidatorCustody::load_updates_schedule(
+            network_dir,
+            controller.chain_config().clone_arc(),
+        );
 
         Self {
             chain_config: controller.chain_config().clone_arc(),
@@ -232,6 +243,8 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
             internal_tx,
             validator_to_liveness_tx,
             validator_to_slasher_tx,
+            validator_custody,
+            subscribe_to_all_data_column_subnets,
         }
     }
 
@@ -568,6 +581,14 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
         if self.last_registration_epoch.is_none() {
             self.register_validators(current_epoch).await;
+        }
+
+        if tick.is_start_of_epoch::<P>()
+            && !self.subscribe_to_all_data_column_subnets
+            && self.chain_config.is_peerdas_scheduled()
+            && !self.signer.load().no_keys()
+        {
+            self.handle_custody_requirements_update(current_epoch);
         }
 
         self.track_collection_metrics().await;
@@ -1470,6 +1491,13 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         self.signer.load().keys().copied().collect::<HashSet<_>>()
     }
 
+    fn own_validator_indices(&self, state: &BeaconState<P>) -> HashSet<ValidatorIndex> {
+        self.own_public_keys()
+            .into_iter()
+            .filter_map(|public_key| accessors::index_of_public_key(state, public_key))
+            .collect()
+    }
+
     #[expect(clippy::too_many_lines)]
     async fn own_singular_attestations(
         &self,
@@ -1925,6 +1953,53 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
         self.update_beacon_committee_subscriptions(wait_group.clone(), beacon_state.clone_arc());
         self.update_sync_committee_subscriptions(&beacon_state);
+    }
+
+    fn handle_custody_requirements_update(&mut self, current_epoch: Epoch) {
+        let last_finalized_state = self.controller.last_finalized_state().value;
+        let own_validator_indices = self.own_validator_indices(&last_finalized_state);
+        let validator_custody_requirement = eip_7594::get_validator_custody_requirement(
+            &last_finalized_state,
+            &own_validator_indices,
+            &self.chain_config,
+        );
+
+        // If there is no scheduled custody updates, update `cgc` in ENR and metadata for the first
+        // time. otherwise, it will attempt to update if there is an update scheduled at the
+        // current epoch.
+        let advertise_cgc = if self.validator_custody.is_empty() {
+            self.validator_custody
+                .schedule_custody_update(0, validator_custody_requirement);
+            validator_custody_requirement
+        } else {
+            self.validator_custody.at_epoch(current_epoch)
+        };
+        ToSubnetService::AttemptToUpdateCustodyGroupCount(advertise_cgc)
+            .send(&self.subnet_service_tx);
+
+        let current_sampling_size: u64 = self
+            .controller
+            .sampling_columns_count()
+            .try_into()
+            .expect("sampling size should be able to fit into u64");
+        let current_custody_requirements =
+            current_sampling_size.saturating_div(self.chain_config.columns_per_group());
+        if validator_custody_requirement != current_custody_requirements {
+            // Schedule custody requirements update on ENR and metadata after `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs
+            let advertise_epoch = current_epoch.saturating_add(
+                self.chain_config
+                    .min_epochs_for_data_column_sidecars_requests,
+            );
+            self.validator_custody
+                .schedule_custody_update(advertise_epoch, validator_custody_requirement);
+
+            // Refresh data column subnets subscriptions in network globals and sampling columns fork choice store
+            ToSubnetService::UpdateCustodyRequirements(
+                current_epoch,
+                validator_custody_requirement,
+            )
+            .send(&self.subnet_service_tx);
+        }
     }
 
     async fn handle_external_contributions_and_proofs(


### PR DESCRIPTION
In this PR: 

* Update peer columns custody after CGC in peer metadata changed

* Update custody requirements at the start of epoch

* Trigger update custody group count in ENR and metadata based on updates schedule

Limitation: delayed advertising current custody group count till next epoch after restart