### PR TITLE
Add `ProcessingTimings` struct to additionally track delay times

### DIFF
--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -49,7 +49,7 @@ use crate::{
         AttestationVerifierMessage, MutatorMessage, P2pMessage, PoolMessage, SubnetMessage,
         SyncMessage, ValidatorMessage,
     },
-    misc::{VerifyAggregateAndProofResult, VerifyAttestationResult},
+    misc::{ProcessingTimings, VerifyAggregateAndProofResult, VerifyAttestationResult},
     mutator::Mutator,
     state_at_slot_cache::StateAtSlotCache,
     storage::Storage,
@@ -555,7 +555,7 @@ where
             wait_group,
             block,
             origin,
-            submission_time: Instant::now(),
+            processing_timings: ProcessingTimings::new(),
             metrics: self.metrics.clone(),
         })
     }

--- a/fork_choice_control/src/messages.rs
+++ b/fork_choice_control/src/messages.rs
@@ -25,7 +25,10 @@ use types::{
 };
 
 use crate::{
-    misc::{MutatorRejectionReason, VerifyAggregateAndProofResult, VerifyAttestationResult},
+    misc::{
+        MutatorRejectionReason, ProcessingTimings, VerifyAggregateAndProofResult,
+        VerifyAttestationResult,
+    },
     unbounded_sink::UnboundedSink,
 };
 
@@ -75,7 +78,7 @@ pub enum MutatorMessage<P: Preset, W> {
         wait_group: W,
         result: Result<BlockAction<P>>,
         origin: BlockOrigin,
-        submission_time: Instant,
+        processing_timings: ProcessingTimings,
         block_root: H256,
     },
     AggregateAndProof {

--- a/fork_choice_control/src/tasks.rs
+++ b/fork_choice_control/src/tasks.rs
@@ -37,8 +37,11 @@ use types::{
 };
 
 use crate::{
-    block_processor::BlockProcessor, messages::MutatorMessage, misc::VerifyAggregateAndProofResult,
-    state_at_slot_cache::StateAtSlotCache, storage::Storage,
+    block_processor::BlockProcessor,
+    messages::MutatorMessage,
+    misc::{ProcessingTimings, VerifyAggregateAndProofResult},
+    state_at_slot_cache::StateAtSlotCache,
+    storage::Storage,
 };
 
 pub trait Run {
@@ -65,7 +68,7 @@ pub struct BlockTask<P: Preset, E, W> {
     pub wait_group: W,
     pub block: Arc<SignedBeaconBlock<P>>,
     pub origin: BlockOrigin,
-    pub submission_time: Instant,
+    pub processing_timings: ProcessingTimings,
     pub metrics: Option<Arc<Metrics>>,
 }
 
@@ -79,7 +82,7 @@ impl<P: Preset, E: ExecutionEngine<P> + Send, W> Run for BlockTask<P, E, W> {
             wait_group,
             block,
             origin,
-            submission_time,
+            processing_timings,
             metrics,
         } = self;
 
@@ -137,7 +140,7 @@ impl<P: Preset, E: ExecutionEngine<P> + Send, W> Run for BlockTask<P, E, W> {
             wait_group,
             result,
             origin,
-            submission_time,
+            processing_timings,
             block_root,
         }
         .send(&mutator_tx);

--- a/prometheus_metrics/dashboards/fork_choice.json
+++ b/prometheus_metrics/dashboards/fork_choice.json
@@ -708,9 +708,96 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 34
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(MUTATOR_BLOCK_INSERTION_TIMES_sum{instance=~\"$Instance\"}[$__rate_interval]) / rate(MUTATOR_BLOCK_INSERTION_TIMES_count{instance=~\"$Instance\"}[$__rate_interval])",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Block inserting times",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "semi-dark-purple",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 42
       },
       "id": 10,
       "options": {
@@ -794,10 +881,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 34
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 52
       },
       "id": 11,
       "options": {

--- a/prometheus_metrics/src/metrics.rs
+++ b/prometheus_metrics/src/metrics.rs
@@ -65,6 +65,7 @@ pub struct Metrics {
     mutator_attestations: IntCounterVec,
     mutator_aggregate_and_proofs: IntCounterVec,
 
+    pub block_insertion_times: Histogram,
     pub block_processing_times: Histogram,
     pub block_post_processing_times: Histogram,
 
@@ -316,6 +317,11 @@ impl Metrics {
                 ),
                 &["type"],
             )?,
+
+            block_insertion_times: Histogram::with_opts(histogram_opts!(
+                "MUTATOR_BLOCK_INSERTION_TIMES",
+                "Mutator Block insertion times",
+            ))?,
 
             block_processing_times: Histogram::with_opts(histogram_opts!(
                 "MUTATOR_BLOCK_PROCESSING_TIMES",
@@ -781,6 +787,7 @@ impl Metrics {
         default_registry.register(Box::new(self.gossip_block_slot_start_delay_time.clone()))?;
         default_registry.register(Box::new(self.mutator_attestations.clone()))?;
         default_registry.register(Box::new(self.mutator_aggregate_and_proofs.clone()))?;
+        default_registry.register(Box::new(self.block_insertion_times.clone()))?;
         default_registry.register(Box::new(self.block_processing_times.clone()))?;
         default_registry.register(Box::new(self.block_post_processing_times.clone()))?;
         default_registry.register(Box::new(


### PR DESCRIPTION
This renames current block processing time metric to insertion time. Processing time is now reported as `insertion_time - delay_time`