### PR TITLE
Batch data column by root requests

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -677,18 +677,20 @@ where
                                 Ok(ValidationOutcome::Ignore(false)),
                             );
 
-                            let data_column_ids = missing_column_indices
-                                .into_iter()
-                                .map(|index| DataColumnIdentifier { block_root, index })
-                                .collect_vec();
+                            if self.store.is_forward_synced() {
+                                let data_column_ids = missing_column_indices
+                                    .into_iter()
+                                    .map(|index| DataColumnIdentifier { block_root, index })
+                                    .collect_vec();
 
-                            let peer_id = pending_block.origin.peer_id();
+                                let peer_id = pending_block.origin.peer_id();
 
-                            self.request_blobs_from_execution_engine(
-                                pending_block.block.clone_arc(),
-                                data_column_ids.into(),
-                                peer_id,
-                            );
+                                self.request_blobs_from_execution_engine(
+                                    pending_block.block.clone_arc(),
+                                    data_column_ids.into(),
+                                    peer_id,
+                                );
+                            }
 
                             self.delay_block_until_blobs(block_root, pending_block);
                         }

--- a/p2p/src/block_sync_service.rs
+++ b/p2p/src/block_sync_service.rs
@@ -33,7 +33,11 @@ use tokio_stream::wrappers::IntervalStream;
 use types::{
     config::Config,
     deneb::containers::BlobIdentifier,
-    fulu::containers::{DataColumnIdentifier, DataColumnsByRootIdentifier},
+    fulu::{
+        containers::{DataColumnIdentifier, DataColumnsByRootIdentifier},
+        primitives::ColumnIndex,
+    },
+    nonstandard::ColumnIndicesByRoot,
     phase0::primitives::{Slot, H256},
     preset::Preset,
     traits::SignedBeaconBlock as _,
@@ -444,6 +448,13 @@ impl<P: Preset> BlockSyncService<P> {
                         }
                         P2pToSync::GossipDataColumnSidecar(data_column_sidecar, subnet_id, gossip_id) => {
                             let data_column_identifier: DataColumnIdentifier = data_column_sidecar.as_ref().into();
+                            let data_column_sidecar_slot = data_column_sidecar.slot();
+
+                            self.register_new_received_data_column_sidecar(
+                                data_column_identifier,
+                                data_column_sidecar_slot,
+                            );
+
                             let block_seen = self
                                 .received_block_roots
                                 .contains_key(&data_column_identifier.block_root);
@@ -457,8 +468,14 @@ impl<P: Preset> BlockSyncService<P> {
                         }
                         P2pToSync::RequestedDataColumnSidecar(data_column_sidecar, peer_id, request_id, request_type) => {
                             let data_column_identifier = data_column_sidecar.as_ref().into();
+                            let data_column_sidecar_slot = data_column_sidecar.slot();
 
-                            self.sync_manager.record_received_data_column_sidecar_response(data_column_identifier, peer_id, request_id);
+                            self.sync_manager.record_received_data_column_sidecar_response(
+                                data_column_sidecar_slot,
+                                data_column_identifier,
+                                peer_id,
+                                request_id
+                            );
 
                             // Back sync does not issue DataColumnSidecarsByRoot requests
                             let request_direction = match request_type {
@@ -471,8 +488,6 @@ impl<P: Preset> BlockSyncService<P> {
 
                             match request_direction {
                                 SyncDirection::Forward => {
-                                    let data_column_sidecar_slot = data_column_sidecar.signed_block_header.message.slot;
-
                                     if !self.controller.contains_block(data_column_identifier.block_root)
                                         && self.register_new_received_data_column_sidecar(
                                             data_column_identifier,
@@ -698,18 +713,14 @@ impl<P: Preset> BlockSyncService<P> {
                 SyncTarget::DataColumnSidecar => {
                     if let Some(ref data_columns) = batch.data_columns {
                         let mut request_id = self.request_id()?;
-                        let columns_to_request = if let Some(received_response) = self
+                        let received_response = self
                             .sync_manager
-                            .get_data_column_range_received(batch.start_slot)
-                        {
-                            data_columns
-                                .iter()
-                                .filter(|index| !received_response.contains(index))
-                                .copied()
-                                .collect::<HashSet<_>>()
-                        } else {
-                            data_columns.iter().copied().collect()
-                        };
+                            .get_data_column_range_received(batch.start_slot);
+                        let columns_to_request = data_columns
+                            .iter()
+                            .filter(|index| !received_response.contains(index))
+                            .copied()
+                            .collect_vec();
 
                         if !columns_to_request.is_empty() {
                             debug!(
@@ -717,14 +728,13 @@ impl<P: Preset> BlockSyncService<P> {
                                 columns_to_request.len(),
                                 columns_to_request.iter().join(", "),
                             );
-                            let preferred_peer = self
-                                .sync_manager
-                                .find_most_coverage_peer(&columns_to_request);
 
+                            let peers_to_request = self
+                                .sync_manager
+                                .find_most_coverage_peers(&columns_to_request);
                             match self.sync_manager.map_peer_custody_columns(
-                                columns_to_request,
-                                None,
-                                preferred_peer,
+                                &columns_to_request,
+                                &peers_to_request,
                                 Some(peer_id),
                             ) {
                                 Ok(peer_custody_columns_mapping) => {
@@ -821,6 +831,16 @@ impl<P: Preset> BlockSyncService<P> {
         if !self.sync_manager.ready_to_request_by_range() {
             return Ok(());
         }
+
+        // Batch request data columns by root for missing columns if any
+        if self
+            .sync_manager
+            .ready_to_batch_request_data_column_by_roots()
+        {
+            self.batch_request_missing_data_columns()?;
+        }
+
+        // check if the bach request has been finished, then proceed with the new sync batch round
 
         let snapshot = self.controller.snapshot();
         let head_slot = snapshot.head_slot();
@@ -1061,7 +1081,7 @@ impl<P: Preset> BlockSyncService<P> {
                         .sync_manager
                         .ready_to_request_data_column_by_root(&identifier, None)
             })
-            .collect::<HashSet<_>>();
+            .collect_vec();
 
         if missing_indices.is_empty() {
             debug!(
@@ -1071,13 +1091,11 @@ impl<P: Preset> BlockSyncService<P> {
             return Ok(());
         }
 
-        let preferred_peer = self.sync_manager.find_most_coverage_peer(&missing_indices);
-        match self.sync_manager.map_peer_custody_columns(
-            missing_indices,
-            None,
-            preferred_peer,
-            None,
-        ) {
+        let peers_to_request = self.sync_manager.find_most_coverage_peers(&missing_indices);
+        match self
+            .sync_manager
+            .map_peer_custody_columns(&missing_indices, &peers_to_request, None)
+        {
             Ok(peer_custody_columns_mapping) => {
                 for (peer_id, column_indices) in peer_custody_columns_mapping {
                     let request_id = self.request_id()?;
@@ -1092,12 +1110,111 @@ impl<P: Preset> BlockSyncService<P> {
                         .sync_manager
                         .add_data_columns_request_by_root(data_columns_by_root, peer_id)
                     {
+                        debug!("add data column request by root (data_columns_by_root: {data_columns_by_root:?}, peer_id: {peer_id})");
+
                         SyncToP2p::RequestDataColumnsByRoot(
                             request_id,
                             peer_id,
                             vec![data_columns_by_root],
                         )
                         .send(&self.sync_to_p2p_tx);
+                    }
+                }
+            }
+            Err(_) => {
+                warn!("could not find available peers to request column sidecars");
+
+                self.sync_manager.refresh_custodial_peers();
+            }
+        }
+
+        Ok(())
+    }
+
+    fn batch_request_missing_data_columns(&mut self) -> Result<()> {
+        let mut missing_column_by_indices: HashMap<ColumnIndex, HashSet<H256>> = HashMap::new();
+        for column_indices_by_root in self.sync_manager.get_missing_columns_by_root() {
+            let ColumnIndicesByRoot {
+                block_root,
+                columns,
+            } = column_indices_by_root;
+            if self.controller.contains_block(block_root) {
+                continue;
+            }
+
+            for index in columns.into_iter().filter(|index| {
+                let identifier = DataColumnIdentifier {
+                    block_root,
+                    index: *index,
+                };
+
+                !self.received_data_column_sidecars.contains_key(&identifier)
+                    && self
+                        .sync_manager
+                        .ready_to_request_data_column_by_root(&identifier, None)
+            }) {
+                missing_column_by_indices
+                    .entry(index)
+                    .or_default()
+                    .insert(block_root);
+            }
+        }
+
+        // Early return if no missing columns found
+        if missing_column_by_indices.is_empty() {
+            return Ok(());
+        }
+
+        // Find the best peer coverage for these missing columns
+        let missing_column_indices = missing_column_by_indices.keys().copied().collect_vec();
+        let peers_to_request = self
+            .sync_manager
+            .find_most_coverage_peers(&missing_column_indices);
+        match self.sync_manager.map_peer_custody_columns(
+            &missing_column_indices,
+            &peers_to_request,
+            None,
+        ) {
+            Ok(peer_custody_columns_mapping) => {
+                for (peer_id, column_indices) in peer_custody_columns_mapping {
+                    let request_id = self.request_id()?;
+                    let mut column_indices_by_root: HashMap<H256, Vec<ColumnIndex>> =
+                        HashMap::new();
+                    for index in column_indices {
+                        if let Some(block_roots) = missing_column_by_indices.get(&index) {
+                            block_roots.iter().for_each(|block_root| {
+                                column_indices_by_root
+                                    .entry(*block_root)
+                                    .or_default()
+                                    .push(index);
+                            })
+                        }
+                    }
+
+                    let by_roots_request = column_indices_by_root
+                        .into_iter()
+                        .filter_map(|(block_root, column_indices)| {
+                            let data_columns_by_root = DataColumnsByRootIdentifier {
+                                block_root,
+                                columns: ContiguousList::try_from(column_indices).expect(
+                                    "column indices must not be more than NUMBER_OF_COLUMNS",
+                                ),
+                            };
+
+                            self.sync_manager
+                                .add_data_columns_request_by_root(data_columns_by_root, peer_id)
+                        })
+                        .collect::<Vec<_>>();
+
+                    if !by_roots_request.is_empty() {
+                        debug!(
+                            "sending batched DataColumnsByRoot request to {peer_id}: {} blocks, {} total columns",
+                            by_roots_request.len(),
+                            by_roots_request.iter().map(|r| r.columns.len()).sum::<usize>()
+                        );
+
+                        SyncToP2p::RequestDataColumnsByRoot(request_id, peer_id, by_roots_request)
+                            .send(&self.sync_to_p2p_tx);
                     }
                 }
             }

--- a/p2p/src/range_and_root_requests.rs
+++ b/p2p/src/range_and_root_requests.rs
@@ -1,7 +1,7 @@
 use core::{hash::Hash, time::Duration};
 use std::{collections::HashSet, sync::Arc, time::Instant};
 
-use cached::{Cached as _, SizedCache, TimedSizedCache};
+use cached::{Cached, SizedCache, TimedSizedCache};
 use eth2_libp2p::PeerId;
 use itertools::Itertools as _;
 use prometheus_metrics::Metrics;
@@ -146,6 +146,12 @@ impl<K: Hash + Eq + Clone> RangeAndRootRequests<K> {
                     .is_some_and(|(_, time)| time.elapsed() < REQUEST_BY_RANGE_TIMEOUT)
             })
             .count()
+    }
+
+    pub fn request_by_root_count(&mut self) -> usize {
+        self.requests_by_root.flush();
+
+        self.requests_by_root.cache_size()
     }
 
     pub fn request_by_range_finished(

--- a/p2p/src/sync_manager.rs
+++ b/p2p/src/sync_manager.rs
@@ -16,7 +16,7 @@ use cached::{Cached as _, TimedSizedCache};
 use eth1_api::RealController;
 use eth2_libp2p::{rpc::StatusMessage, NetworkGlobals, PeerId};
 use helper_functions::misc;
-use itertools::Itertools as _;
+use itertools::Itertools;
 use log::{debug, log, Level};
 use lru::LruCache;
 use prometheus_metrics::Metrics;
@@ -32,6 +32,7 @@ use types::{
         containers::{DataColumnIdentifier, DataColumnsByRootIdentifier},
         primitives::ColumnIndex,
     },
+    nonstandard::ColumnIndicesByRoot,
     phase0::primitives::{Epoch, Slot, H256},
     preset::Preset,
 };
@@ -104,6 +105,7 @@ pub struct SyncManager {
     network_globals: Arc<NetworkGlobals>,
     custodial_peers: HashMap<ColumnIndex, HashSet<PeerId>>,
     data_column_range_received: HashMap<Slot, HashSet<ColumnIndex>>,
+    data_columns_received: HashMap<Slot, HashMap<H256, HashSet<ColumnIndex>>>,
 }
 
 impl SyncManager {
@@ -128,6 +130,7 @@ impl SyncManager {
             network_globals,
             custodial_peers: HashMap::new(),
             data_column_range_received: HashMap::new(),
+            data_columns_received: HashMap::new(),
         }
     }
 
@@ -153,6 +156,7 @@ impl SyncManager {
 
     pub fn record_received_data_column_sidecar_response(
         &mut self,
+        slot: Slot,
         data_column_identifier: DataColumnIdentifier,
         peer_id: PeerId,
         request_id: RequestId,
@@ -162,6 +166,14 @@ impl SyncManager {
             &peer_id,
             request_id,
         );
+
+        if self.record_data_column_received_at_slot(slot, data_column_identifier) {
+            debug!("received data column {data_column_identifier:?} at slot {slot}");
+        } else {
+            debug!(
+                "data column {data_column_identifier:?} at slot {slot} has already been received"
+            );
+        }
 
         if let Some(start_slot) = self.data_column_requests.request_start_slot(request_id) {
             let received_response = self
@@ -178,11 +190,17 @@ impl SyncManager {
         }
     }
 
-    pub fn get_data_column_range_received(
-        &self,
-        start_slot: Slot,
-    ) -> Option<&HashSet<ColumnIndex>> {
-        self.data_column_range_received.get(&start_slot)
+    pub fn record_data_column_received_at_slot(
+        &mut self,
+        slot: Slot,
+        data_column_identifier: DataColumnIdentifier,
+    ) -> bool {
+        self.data_columns_received
+            .entry(slot)
+            .or_default()
+            .entry(data_column_identifier.block_root)
+            .or_default()
+            .insert(data_column_identifier.index)
     }
 
     pub fn request_direction(&mut self, request_id: RequestId) -> Option<SyncDirection> {
@@ -338,18 +356,14 @@ impl SyncManager {
                         }
 
                         if config.phase_at_slot::<P>(start_slot).is_peerdas_activated() {
-                            let columns_to_request = if let Some(received_response) =
-                                self.get_data_column_range_received(start_slot)
-                            {
-                                self.network_globals
-                                    .sampling_columns()
-                                    .iter()
-                                    .filter(|index| !received_response.contains(index))
-                                    .copied()
-                                    .collect()
-                            } else {
-                                self.network_globals.sampling_columns()
-                            };
+                            let received_response = self.get_data_column_range_received(start_slot);
+                            let columns_to_request = self
+                                .network_globals
+                                .sampling_columns()
+                                .iter()
+                                .filter(|index| !received_response.contains(index))
+                                .copied()
+                                .collect_vec();
 
                             if !columns_to_request.is_empty() {
                                 self.log(
@@ -363,9 +377,8 @@ impl SyncManager {
                                 );
 
                                 match self.map_peer_custody_columns(
-                                    columns_to_request,
-                                    Some(&peers_to_sync),
-                                    None,
+                                    &columns_to_request,
+                                    &peers_to_sync,
                                     None,
                                 ) {
                                     Ok(peer_custody_columns_mapping) => {
@@ -526,9 +539,8 @@ impl SyncManager {
                     < self.last_sync_range.start.saturating_add(slots_per_request) - 1
                 && self
                     .get_data_column_range_received(self.last_sync_range.start)
-                    .is_some_and(|received| {
-                        received.len() < self.network_globals.sampling_columns_count()
-                    })
+                    .len()
+                    < self.network_globals.sampling_columns_count()
             {
                 // Keep requesting the last sync range for remaining data columns
                 self.log(
@@ -601,13 +613,13 @@ impl SyncManager {
 
             if config.phase_at_slot::<P>(start_slot).is_peerdas_activated() {
                 if data_column_serve_range_slot < max_slot {
-                    let mut columns_to_request = self.network_globals.sampling_columns().clone();
-                    if let Some(received_response) = self.get_data_column_range_received(start_slot)
-                    {
-                        if !redownloads_increased {
-                            columns_to_request.retain(|index| !received_response.contains(index))
-                        }
-                    }
+                    let received_response = self.get_data_column_range_received(start_slot);
+                    let columns_to_request = self
+                        .network_globals
+                        .sampling_columns()
+                        .into_iter()
+                        .filter(|index| !received_response.contains(index))
+                        .collect_vec();
 
                     if !columns_to_request.is_empty() {
                         // TODO(peerdas-fulu): Distributes requested columns among the minimal set of peers,
@@ -622,9 +634,8 @@ impl SyncManager {
                             ),
                         );
                         match self.map_peer_custody_columns(
-                            columns_to_request,
-                            Some(&peers_to_sync),
-                            None,
+                            &columns_to_request,
+                            &peers_to_sync,
                             None,
                         ) {
                             Ok(peer_custody_columns_mapping) => {
@@ -743,6 +754,10 @@ impl SyncManager {
             .ready_to_request_by_root(data_column_identifier, peer_id)
     }
 
+    pub fn ready_to_batch_request_data_column_by_roots(&mut self) -> bool {
+        self.data_column_requests.request_by_root_count() == 0
+    }
+
     pub fn add_blob_request_by_range(&mut self, request_id: RequestId, batch: SyncBatch) {
         self.log(
             Level::Debug,
@@ -821,10 +836,6 @@ impl SyncManager {
         data_columns_by_root: DataColumnsByRootIdentifier,
         peer_id: PeerId,
     ) -> Option<DataColumnsByRootIdentifier> {
-        self.log(Level::Debug, format_args!(
-            "add data column request by root (data_columns_by_root: {data_columns_by_root:?}, peer_id: {peer_id})",
-        ));
-
         let DataColumnsByRootIdentifier {
             block_root,
             columns,
@@ -1001,6 +1012,38 @@ impl SyncManager {
         local_head_slot <= self.last_sync_head
     }
 
+    pub fn get_missing_columns_by_root(&self) -> Vec<ColumnIndicesByRoot> {
+        self.data_columns_received
+            .values()
+            .into_iter()
+            .flat_map(|columns_by_root| {
+                columns_by_root
+                    .into_iter()
+                    .map(|(block_root, column_indices)| {
+                        let missing_indices = self
+                            .network_globals
+                            .sampling_columns()
+                            .iter()
+                            .filter(|index| !column_indices.contains(index))
+                            .copied()
+                            .collect();
+
+                        ColumnIndicesByRoot {
+                            block_root: *block_root,
+                            columns: missing_indices,
+                        }
+                    })
+            })
+            .collect_vec()
+    }
+
+    pub fn get_data_column_range_received(&self, start_slot: Slot) -> Vec<ColumnIndex> {
+        self.data_column_range_received
+            .get(&start_slot)
+            .map(|indices| indices.into_iter().copied().collect())
+            .unwrap_or_default()
+    }
+
     /// Log a message with peer count information.
     fn log(&self, level: Level, message: impl Display) {
         log!(
@@ -1132,8 +1175,7 @@ impl SyncManager {
     fn get_random_custodial_peer(
         &self,
         column_index: ColumnIndex,
-        request_from_peers: Option<&[PeerId]>,
-        preferred_peer: Option<PeerId>,
+        request_from_peers: &[PeerId],
         skip_peer: Option<PeerId>,
     ) -> Option<PeerId> {
         let mut custodial_peers = if let Some(peers) = self.custodial_peers.get(&column_index) {
@@ -1148,42 +1190,31 @@ impl SyncManager {
         }
 
         // Choose only within specified peers, e.g. non-busy peers to sync
-        if let Some(peers) = request_from_peers {
-            custodial_peers.retain(|peer| peers.contains(peer));
-        }
-
-        // Prioritize the most coverage peer if it custody the column
-        if let Some(peer) = preferred_peer {
-            if custodial_peers.contains(&peer) {
-                return preferred_peer;
-            }
-        }
-
-        custodial_peers.choose(&mut thread_rng()).copied()
+        custodial_peers
+            .into_iter()
+            .filter(|peer| request_from_peers.contains(peer))
+            .choose(&mut thread_rng())
     }
 
     pub fn map_peer_custody_columns(
         &self,
-        column_indices: HashSet<ColumnIndex>,
-        request_from_peers: Option<&[PeerId]>,
-        preferred_peer: Option<PeerId>,
+        column_indices: &[ColumnIndex],
+        request_from_peers: &[PeerId],
         skip_peer: Option<PeerId>,
     ) -> Result<HashMap<PeerId, Vec<ColumnIndex>>> {
         let mut peer_columns_mapping: HashMap<PeerId, Vec<ColumnIndex>> = HashMap::new();
 
         for column_index in column_indices {
-            let Some(custodial_peer) = self.get_random_custodial_peer(
-                column_index,
-                request_from_peers,
-                preferred_peer,
-                skip_peer,
-            ) else {
+            let Some(custodial_peer) =
+                self.get_random_custodial_peer(*column_index, request_from_peers, skip_peer)
+            else {
                 continue;
             };
 
-            let peer_custody_columns = peer_columns_mapping.entry(custodial_peer).or_default();
-
-            peer_custody_columns.push(column_index);
+            peer_columns_mapping
+                .entry(custodial_peer)
+                .or_default()
+                .push(*column_index);
         }
 
         (!peer_columns_mapping.is_empty())
@@ -1191,13 +1222,13 @@ impl SyncManager {
             .ok_or_else(|| MapPeerCustodyError::NoAvailablePeers.into())
     }
 
-    /// Get the most preferred peer which are available at the time of the request, and has the most custodial coverage among all
-    pub fn find_most_coverage_peer(&self, column_indices: &HashSet<ColumnIndex>) -> Option<PeerId> {
+    /// Get the most coverage peers which are available at the time of the request, and has the most custodial coverage among all
+    pub fn find_most_coverage_peers(&self, column_indices: &[ColumnIndex]) -> Vec<PeerId> {
         let mut coverage_count: HashMap<&PeerId, usize> = HashMap::new();
 
         let busy_peers = self.busy_peers();
         for index in column_indices {
-            if let Some(peers) = self.custodial_peers.get(index) {
+            if let Some(peers) = self.custodial_peers.get(&index) {
                 for peer in peers.iter().filter(|peer| !busy_peers.contains(peer)) {
                     *coverage_count.entry(peer).or_default() += 1;
                 }
@@ -1206,8 +1237,10 @@ impl SyncManager {
 
         coverage_count
             .into_iter()
-            .max_by_key(|&(_, count)| count)
+            .sorted_by_key(|a| std::cmp::Reverse(a.1))
+            .take(column_indices.len().saturating_div(10))
             .map(|(peer, _)| *peer)
+            .collect_vec()
     }
 
     pub fn expired_blob_range_batches(
@@ -1235,6 +1268,8 @@ impl SyncManager {
     }
 
     pub fn prune_old_data_column_range_received_response(&mut self) {
+        self.data_columns_received
+            .retain(|slot, _| *slot > self.last_sync_head);
         self.data_column_range_received
             .retain(|slot, _| *slot >= self.last_sync_head);
     }

--- a/types/src/nonstandard.rs
+++ b/types/src/nonstandard.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use bit_field::BitField as _;
 use bls::Signature;
@@ -25,7 +25,10 @@ use crate::{
         primitives::{Blob, KzgCommitment, KzgProofs},
     },
     electra::containers::ExecutionRequests,
-    fulu::containers::{DataColumnIdentifier, DataColumnSidecar},
+    fulu::{
+        containers::{DataColumnIdentifier, DataColumnSidecar},
+        primitives::ColumnIndex,
+    },
     phase0::primitives::{Gwei, Uint256, UnixSeconds, ValidatorIndex, H256},
     preset::Preset,
 };
@@ -531,6 +534,12 @@ impl<T: Clone> WithOrigin<T> {
             Origin::Genesis => Some(self.value.clone()),
         }
     }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ColumnIndicesByRoot {
+    pub block_root: H256,
+    pub columns: HashSet<ColumnIndex>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of requesting data columns by root for each block, this pull request will change to batch those by root requests and request to respective custodial peers at once after by range requests finished. doing so will require to track the received data column sidecars for every slot/block root