### PR TITLE
Fix incorrect data columns by root requests

### DIFF
--- a/eth1_api/src/execution_blob_fetcher.rs
+++ b/eth1_api/src/execution_blob_fetcher.rs
@@ -221,7 +221,6 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
     ) {
         let slot = block_or_sidecar.slot();
         let block_root = block_or_sidecar.block_root();
-        let block_header = block_or_sidecar.signed_block_header().message;
 
         if self.controller.contains_block(block_root)
             || self.sidecars_construction_started.contains_key(&block_root)
@@ -233,12 +232,7 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
         if let Some(kzg_commitments) = block_or_sidecar.kzg_commitments() {
             let missing_columns_indices = data_column_identifiers
                 .iter()
-                .filter(|identifier| {
-                    !self
-                        .controller
-                        .accepted_data_column_sidecar(block_header, identifier.index)
-                        || !self.received_data_column_sidecars.contains_key(identifier)
-                })
+                .filter(|identifier| !self.received_data_column_sidecars.contains_key(identifier))
                 .map(|identifier| identifier.index)
                 .collect::<HashSet<ColumnIndex>>();
 

--- a/execution_engine/src/types.rs
+++ b/execution_engine/src/types.rs
@@ -1046,7 +1046,7 @@ impl<P: Preset> BlockOrDataColumnSidecar<P> {
     pub fn block_root(&self) -> H256 {
         match self {
             Self::Block(block) => block.message().hash_tree_root(),
-            Self::Sidecar(sidecar) => sidecar.signed_block_header.hash_tree_root(),
+            Self::Sidecar(sidecar) => sidecar.signed_block_header.message.hash_tree_root(),
         }
     }
 

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -1479,10 +1479,15 @@ where
                             .mark_requested_blobs_from_el(block_root, data_column_sidecar.slot());
                         self.update_store_snapshot();
 
-                        let data_column_identifiers =
-                            (0..self.store.chain_config().number_of_columns)
-                                .map(|index| DataColumnIdentifier { block_root, index })
-                                .collect::<Vec<_>>();
+                        let data_column_identifiers = self
+                            .store
+                            .sampling_columns()
+                            .iter()
+                            .map(|index| DataColumnIdentifier {
+                                block_root,
+                                index: *index,
+                            })
+                            .collect::<Vec<_>>();
                         self.request_blobs_from_execution_engine(
                             EngineGetBlobsV2Params {
                                 block_or_sidecar: data_column_sidecar.clone_arc().into(),

--- a/p2p/src/block_sync_service.rs
+++ b/p2p/src/block_sync_service.rs
@@ -1073,7 +1073,7 @@ impl<P: Preset> BlockSyncService<P> {
         } = data_columns_by_root;
 
         if self.controller.contains_block(block_root) {
-            debug!("Block {block_root:?} already imported into the fork choice");
+            debug!("block {block_root:?} already imported into the fork choice");
             return Ok(());
         }
 


### PR DESCRIPTION
on the case when received any data column sidecar, I have incorrectly pass all column indices as missing columns to request from peers, so this will change to its sampling columns instead. also this will correctly return block root derived from the sidecar