### PR TITLE
Update consensus-spec-tests to v1.6.0-alpha.4

### DIFF
--- a/eip_7594/src/lib.rs
+++ b/eip_7594/src/lib.rs
@@ -145,10 +145,7 @@ pub fn compute_subnets_for_node(
 }
 
 /// Verify if the data column sidecar is valid.
-pub fn verify_data_column_sidecar<P: Preset>(
-    data_column_sidecar: &DataColumnSidecar<P>,
-    config: &Config,
-) -> bool {
+pub fn verify_data_column_sidecar<P: Preset>(data_column_sidecar: &DataColumnSidecar<P>) -> bool {
     let DataColumnSidecar {
         index,
         column,
@@ -158,7 +155,7 @@ pub fn verify_data_column_sidecar<P: Preset>(
     } = data_column_sidecar;
 
     // The sidecar index must be within the valid range
-    if *index >= config.number_of_columns {
+    if *index >= P::NumberOfColumns::U64 {
         return false;
     }
 
@@ -261,7 +258,6 @@ fn get_data_column_sidecars<P: Preset>(
     kzg_commitments: &ContiguousList<KzgCommitment, P::MaxBlobCommitmentsPerBlock>,
     kzg_commitments_inclusion_proof: BlobCommitmentsInclusionProof<P>,
     cells_and_kzg_proofs: &[CellsAndKzgProofs<P>],
-    config: &Config,
 ) -> Result<Vec<DataColumnSidecar<P>>> {
     let blob_count = kzg_commitments.len();
     ensure!(
@@ -273,7 +269,7 @@ fn get_data_column_sidecars<P: Preset>(
     );
 
     let mut sidecars: Vec<DataColumnSidecar<P>> = Vec::new();
-    for column_index in 0..config.number_of_columns() {
+    for column_index in 0..P::NumberOfColumns::USIZE {
         let column = ContiguousList::try_from_iter(
             (0..blob_count)
                 .map(|row_index| cells_and_kzg_proofs[row_index].0[column_index].clone()),
@@ -298,7 +294,6 @@ fn get_data_column_sidecars<P: Preset>(
 pub fn construct_data_column_sidecars<P: Preset>(
     signed_block: &SignedBeaconBlock<P>,
     cells_and_kzg_proofs: &[CellsAndKzgProofs<P>],
-    config: &Config,
     metrics: Option<&Arc<Metrics>>,
 ) -> Result<Vec<DataColumnSidecar<P>>> {
     let _timer = metrics
@@ -323,14 +318,12 @@ pub fn construct_data_column_sidecars<P: Preset>(
         kzg_commitments,
         kzg_commitments_inclusion_proof,
         cells_and_kzg_proofs,
-        config,
     )
 }
 
 pub fn construct_data_column_sidecars_from_sidecar<P: Preset>(
     data_column_sidecar: &DataColumnSidecar<P>,
     cells_and_kzg_proofs: &[CellsAndKzgProofs<P>],
-    config: &Config,
     metrics: Option<&Arc<Metrics>>,
 ) -> Result<Vec<DataColumnSidecar<P>>> {
     let _timer = metrics
@@ -349,7 +342,6 @@ pub fn construct_data_column_sidecars_from_sidecar<P: Preset>(
         kzg_commitments,
         *kzg_commitments_inclusion_proof,
         cells_and_kzg_proofs,
-        config,
     )
 }
 

--- a/eth1_api/src/execution_blob_fetcher.rs
+++ b/eth1_api/src/execution_blob_fetcher.rs
@@ -41,7 +41,7 @@ pub struct ExecutionBlobFetcher<P: Preset, W: Wait> {
     received_data_column_sidecars: Arc<DashMap<DataColumnIdentifier, Slot>>,
     sidecars_construction_started: Arc<DashMap<H256, Slot>>,
     metrics: Option<Arc<Metrics>>,
-    p2p_tx: UnboundedSender<BlobFetcherToP2p>,
+    p2p_tx: UnboundedSender<BlobFetcherToP2p<P>>,
     rx: UnboundedReceiver<Eth1ApiToBlobFetcher<P>>,
 }
 
@@ -54,7 +54,7 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
         received_data_column_sidecars: Arc<DashMap<DataColumnIdentifier, Slot>>,
         sidecars_construction_started: Arc<DashMap<H256, Slot>>,
         metrics: Option<Arc<Metrics>>,
-        p2p_tx: UnboundedSender<BlobFetcherToP2p>,
+        p2p_tx: UnboundedSender<BlobFetcherToP2p<P>>,
         rx: UnboundedReceiver<Eth1ApiToBlobFetcher<P>>,
     ) -> Self {
         Self {
@@ -295,13 +295,11 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
                                             BlockOrDataColumnSidecar::Block(block) => eip_7594::construct_data_column_sidecars(
                                                 &block,
                                                 &cells_and_kzg_proofs,
-                                                self.controller.chain_config(),
                                                 self.metrics.as_ref(),
                                             ),
                                             BlockOrDataColumnSidecar::Sidecar(sidecar) => eip_7594::construct_data_column_sidecars_from_sidecar(
                                                 &sidecar,
                                                 &cells_and_kzg_proofs,
-                                                self.controller.chain_config(),
                                                 self.metrics.as_ref(),
                                             ),
                                         };

--- a/eth1_api/src/messages.rs
+++ b/eth1_api/src/messages.rs
@@ -45,12 +45,12 @@ impl<P: Preset> Eth1ApiToBlobFetcher<P> {
 }
 
 #[derive(Serialize)]
-pub enum BlobFetcherToP2p {
+pub enum BlobFetcherToP2p<P: Preset> {
     BlobsNeeded(Vec<BlobIdentifier>, Slot, Option<PeerId>),
-    DataColumnsNeeded(DataColumnsByRootIdentifier, Slot),
+    DataColumnsNeeded(DataColumnsByRootIdentifier<P>, Slot),
 }
 
-impl BlobFetcherToP2p {
+impl<P: Preset> BlobFetcherToP2p<P> {
     pub fn send(self, tx: &UnboundedSender<Self>) {
         if tx.unbounded_send(self).is_err() {
             debug!("send to p2p failed because the receiver was dropped");

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -34,6 +34,7 @@ use log::debug;
 use prometheus_metrics::Metrics;
 use std_ext::ArcExt as _;
 use thiserror::Error;
+use typenum::Unsigned as _;
 use types::{
     combined::{
         Attestation, AttesterSlashing, BeaconState, SignedAggregateAndProof, SignedBeaconBlock,
@@ -575,7 +576,7 @@ where
                 let accepted = store_snapshot.accepted_data_column_sidecars_at_slot(slot);
 
                 if accepted < store_snapshot.sampling_columns_count()
-                    && accepted * 2 >= store_snapshot.chain_config().number_of_columns()
+                    && accepted * 2 >= P::NumberOfColumns::USIZE
                 {
                     MutatorMessage::ReconstructMissingColumns {
                         wait_group: self.owned_wait_group(),

--- a/fork_choice_control/src/helpers.rs
+++ b/fork_choice_control/src/helpers.rs
@@ -14,6 +14,7 @@ use futures::channel::mpsc::UnboundedReceiver;
 use helper_functions::misc;
 use ssz::SszHash as _;
 use std_ext::ArcExt as _;
+use typenum::Unsigned as _;
 use types::{
     combined::{Attestation, AttesterSlashing, BeaconState, SignedBeaconBlock},
     config::Config,
@@ -86,7 +87,6 @@ impl<P: Preset> Context<P> {
         let (p2p_tx, p2p_rx) = futures::channel::mpsc::unbounded();
 
         let phase = anchor_block.phase();
-        let number_of_columns = config.number_of_columns;
 
         let (controller, mutator_handle) = TestController::with_p2p_tx(
             config,
@@ -97,7 +97,7 @@ impl<P: Preset> Context<P> {
         );
 
         if phase.is_peerdas_activated() {
-            controller.on_store_sampling_columns((0..number_of_columns).collect());
+            controller.on_store_sampling_columns((0..P::NumberOfColumns::U64).collect());
         }
 
         Self {

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -49,6 +49,7 @@ use num_traits::identities::Zero as _;
 use prometheus_metrics::Metrics;
 use ssz::SszHash as _;
 use std_ext::ArcExt as _;
+use typenum::Unsigned as _;
 use types::{
     combined::{BeaconState, ExecutionPayloadParams, SignedBeaconBlock},
     deneb::containers::{BlobIdentifier, BlobSidecar},
@@ -1711,7 +1712,7 @@ where
         if self.store.has_unpersisted_data_column_sidecars()
             && (self.store.is_forward_synced()
                 || self.store.unpersisted_data_column_sidecars().count()
-                    >= self.store.chain_config().number_of_columns())
+                    >= P::NumberOfColumns::USIZE)
         {
             self.spawn(PersistDataColumnSidecarsTask {
                 store_snapshot: self.owned_store(),
@@ -1763,7 +1764,6 @@ where
         let mut data_column_sidecars = eip_7594::construct_data_column_sidecars(
             &pending.block,
             &cells_and_kzg_proofs,
-            self.store.chain_config(),
             self.metrics.as_ref(),
         )?;
 
@@ -3601,7 +3601,7 @@ where
             .saturating_sub(missing_indices.len());
 
         if self.store.is_forward_synced()
-            && available_columns_count * 2 >= self.store.chain_config().number_of_columns()
+            && available_columns_count * 2 >= P::NumberOfColumns::USIZE
         {
             return BlockDataColumnAvailability::CompleteWithReconstruction;
         }

--- a/fork_choice_control/src/spec_tests.rs
+++ b/fork_choice_control/src/spec_tests.rs
@@ -10,6 +10,7 @@ use ssz::ContiguousList;
 use std_ext::ArcExt as _;
 use tap::Pipe as _;
 use test_generator::test_resources;
+use typenum::Unsigned as _;
 use types::{
     combined::{Attestation, AttesterSlashing, BeaconBlock, BeaconState, SignedBeaconBlock},
     config::Config,
@@ -252,7 +253,7 @@ fn run_case<P: Preset>(config: &Arc<Config>, case: Case) {
                     // If half of data column sidecars are available, we can reconstruct the rest
                     // and consider the block valid
                     if block.phase().is_peerdas_activated()
-                        && data_column_sidecar_count * 2 >= config.number_of_columns()
+                        && data_column_sidecar_count * 2 >= P::NumberOfColumns::USIZE
                     {
                         context.on_block_with_reconstructing_data_columns(&block);
                     } else {

--- a/fork_choice_control/src/tasks.rs
+++ b/fork_choice_control/src/tasks.rs
@@ -21,6 +21,7 @@ use helper_functions::{
 use log::{debug, warn};
 use prometheus_metrics::Metrics;
 use ssz::SszHash as _;
+use typenum::Unsigned as _;
 use types::{
     combined::{
         AttesterSlashing, BeaconState as CombinedBeaconState, SignedAggregateAndProof,
@@ -561,7 +562,7 @@ impl<P: Preset, W> Run for ReconstructDataColumnSidecarsTask<P, W> {
             .as_ref()
             .map(|metrics| metrics.columns_reconstruction_time.start_timer());
 
-        let Ok(available_columns) = (0..store_snapshot.chain_config().number_of_columns)
+        let Ok(available_columns) = (0..P::NumberOfColumns::U64)
             .map(|index| {
                 let identifier = DataColumnIdentifier { block_root, index };
                 match store_snapshot.cached_data_column_sidecar_by_id(identifier) {
@@ -576,7 +577,7 @@ impl<P: Preset, W> Run for ReconstructDataColumnSidecarsTask<P, W> {
             return;
         };
 
-        if available_columns.len() * 2 >= store_snapshot.chain_config().number_of_columns() {
+        if available_columns.len() * 2 >= P::NumberOfColumns::USIZE {
             let blob_count = available_columns
                 .first()
                 .expect("first data column sidecar must be available")

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2033,7 +2033,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         // [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar)
         ensure!(
-            verify_data_column_sidecar(&data_column_sidecar, &self.chain_config),
+            verify_data_column_sidecar(&data_column_sidecar),
             Error::DataColumnSidecarInvalid {
                 data_column_sidecar
             },

--- a/scripts/ci/consensus-spec-tests-coverage.rb
+++ b/scripts/ci/consensus-spec-tests-coverage.rb
@@ -20,6 +20,8 @@ IGNORED_GLOBS = %w[
   tests/*/eip7732/*/*/*/*/*.{ssz_snappy,yaml}
   tests/*/eip7441/*/*/*/*/*.{ssz_snappy,yaml}
   tests/*/eip7805/*/*/*/*/*.{ssz_snappy,yaml}
+  tests/general/phase0/ssz_generic/{progressive_bitlist,basic_progressive_list}/*/*/*.{ssz_snappy,yaml}
+  tests/general/phase0/ssz_generic/containers/{valid,invalid}/{ProgressiveBitsStruct,ProgressiveTestStruct}_*/*.{ssz_snappy,yaml}
   tests/diagnostics_obj.json{,.lock}
 ].map! { |glob| File.join(SUBMODULE, glob) }
 

--- a/ssz/src/spec_tests.rs
+++ b/ssz/src/spec_tests.rs
@@ -6,7 +6,10 @@ use spec_test_utils::Case;
 use ssz_derive::Ssz;
 use static_assertions::assert_not_impl_any;
 use test_generator::test_resources;
-use typenum::{U0, U1, U1024, U128, U16, U2, U256, U3, U31, U32, U4, U5, U512, U513, U6, U8, U9};
+use typenum::{
+    U0, U1, U1024, U128, U15, U16, U17, U2, U256, U3, U31, U32, U33, U4, U5, U511, U512, U513, U6,
+    U7, U8, U9,
+};
 
 use crate::{
     bit_list::BitList,
@@ -172,9 +175,17 @@ mod valid {
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_3_*"]                      [bitlist_3]                [BitList<U3>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_4_*"]                      [bitlist_4]                [BitList<U4>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_5_*"]                      [bitlist_5]                [BitList<U5>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_6_*"]                      [bitlist_6]                [BitList<U6>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_7_*"]                      [bitlist_7]                [BitList<U7>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_8_*"]                      [bitlist_8]                [BitList<U8>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_9_*"]                      [bitlist_9]                [BitList<U9>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_15_*"]                     [bitlist_15]               [BitList<U15>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_16_*"]                     [bitlist_16]               [BitList<U16>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_17_*"]                     [bitlist_17]               [BitList<U17>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_31_*"]                     [bitlist_31]               [BitList<U31>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_32_*"]                     [bitlist_32]               [BitList<U32>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_33_*"]                     [bitlist_33]               [BitList<U33>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_511_*"]                    [bitlist_511]              [BitList<U511>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_512_*"]                    [bitlist_512]              [BitList<U512>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/valid/*_513_*"]                    [bitlist_513]              [BitList<U513>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_1_*"]                    [bitvector_1]              [BitVector<U1>];
@@ -182,9 +193,17 @@ mod valid {
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_3_*"]                    [bitvector_3]              [BitVector<U3>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_4_*"]                    [bitvector_4]              [BitVector<U4>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_5_*"]                    [bitvector_5]              [BitVector<U5>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_6_*"]                    [bitvector_6]              [BitVector<U6>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_7_*"]                    [bitvector_7]              [BitVector<U7>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_8_*"]                    [bitvector_8]              [BitVector<U8>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_9_*"]                    [bitvector_9]              [BitVector<U9>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_15_*"]                   [bitvector_15]             [BitVector<U15>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_16_*"]                   [bitvector_16]             [BitVector<U16>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_17_*"]                   [bitvector_17]             [BitVector<U17>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_31_*"]                   [bitvector_31]             [BitVector<U31>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_32_*"]                   [bitvector_32]             [BitVector<U32>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_33_*"]                   [bitvector_33]             [BitVector<U33>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_511_*"]                  [bitvector_511]            [BitVector<U511>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_512_*"]                  [bitvector_512]            [BitVector<U512>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitvector/valid/*_513_*"]                  [bitvector_513]            [BitVector<U513>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/boolean/valid/*"]                          [boolean]                  [bool];
@@ -287,6 +306,8 @@ mod invalid {
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_3_*"]                      [bitlist_3]                [BitList<U3>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_4_*"]                      [bitlist_4]                [BitList<U4>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_5_*"]                      [bitlist_5]                [BitList<U5>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_6_*"]                      [bitlist_6]                [BitList<U6>];
+        ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_7_*"]                      [bitlist_7]                [BitList<U7>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_8_*"]                      [bitlist_8]                [BitList<U8>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_32_*"]                     [bitlist_32]               [BitList<U32>];
         ["consensus-spec-tests/tests/general/*/ssz_generic/bitlist/invalid/*_512_*"]                    [bitlist_512]              [BitList<U512>];

--- a/types/src/config.rs
+++ b/types/src/config.rs
@@ -12,6 +12,7 @@ use typenum::Unsigned as _;
 
 use crate::{
     bellatrix::primitives::Difficulty,
+    fulu::consts::NumberOfColumns,
     nonstandard::{Phase, Toption},
     phase0::{
         consts::{FAR_FUTURE_EPOCH, GENESIS_EPOCH},
@@ -171,8 +172,6 @@ pub struct Config {
     #[serde(with = "serde_utils::string_or_native")]
     pub custody_requirement: u64,
     #[serde(with = "serde_utils::string_or_native")]
-    pub number_of_columns: u64,
-    #[serde(with = "serde_utils::string_or_native")]
     pub number_of_custody_groups: u64,
     #[serde(with = "serde_utils::string_or_native")]
     pub samples_per_slot: u64,
@@ -285,7 +284,6 @@ impl Default for Config {
 
             // Custody
             custody_requirement: 4,
-            number_of_columns: 128,
             number_of_custody_groups: 128,
             samples_per_slot: 8,
             validator_custody_requirement: 8,
@@ -921,13 +919,7 @@ impl Config {
 
     #[must_use]
     pub const fn columns_per_group(&self) -> u64 {
-        self.number_of_columns
-            .saturating_div(self.number_of_custody_groups)
-    }
-
-    #[must_use]
-    pub fn number_of_columns(&self) -> usize {
-        usize::try_from(self.number_of_columns).expect("should be able to parse number_of_columns")
+        NumberOfColumns::U64.saturating_div(self.number_of_custody_groups)
     }
 
     #[must_use]

--- a/types/src/fulu/container_impls.rs
+++ b/types/src/fulu/container_impls.rs
@@ -176,8 +176,8 @@ impl<P: Preset> From<&DataColumnSidecar<P>> for DataColumnIdentifier {
     }
 }
 
-impl From<DataColumnsByRootIdentifier> for Vec<DataColumnIdentifier> {
-    fn from(data_columns_by_root: DataColumnsByRootIdentifier) -> Self {
+impl<P: Preset> From<DataColumnsByRootIdentifier<P>> for Vec<DataColumnIdentifier> {
+    fn from(data_columns_by_root: DataColumnsByRootIdentifier<P>) -> Self {
         let DataColumnsByRootIdentifier {
             block_root,
             columns,

--- a/types/src/fulu/containers.rs
+++ b/types/src/fulu/containers.rs
@@ -14,10 +14,7 @@ use crate::{
         consts::{CurrentSyncCommitteeIndex, FinalizedRootIndex, NextSyncCommitteeIndex},
         containers::{Attestation, AttesterSlashing, ExecutionRequests},
     },
-    fulu::{
-        consts::NumberOfColumns,
-        primitives::{BlobCommitmentsInclusionProof, Cell, ColumnIndex, RowIndex},
-    },
+    fulu::primitives::{BlobCommitmentsInclusionProof, Cell, ColumnIndex, RowIndex},
     phase0::{
         containers::{
             BeaconBlockHeader, Deposit, Eth1Data, ProposerSlashing, SignedBeaconBlockHeader,
@@ -163,10 +160,10 @@ pub struct DataColumnIdentifier {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize, Serialize, Ssz)]
 #[serde(bound = "", deny_unknown_fields)]
-pub struct DataColumnsByRootIdentifier {
+pub struct DataColumnsByRootIdentifier<P: Preset> {
     pub block_root: H256,
     #[serde(with = "serde_utils::string_or_native_sequence")]
-    pub columns: ContiguousList<ColumnIndex, NumberOfColumns>,
+    pub columns: ContiguousList<ColumnIndex, P::NumberOfColumns>,
 }
 
 #[derive(Clone, Default, PartialEq, Eq, Deserialize, Serialize, Ssz)]

--- a/types/src/fulu/spec_tests.rs
+++ b/types/src/fulu/spec_tests.rs
@@ -147,7 +147,7 @@ tests_for_type! {
 }
 
 tests_for_type! {
-    DataColumnsByRootIdentifier,
+    DataColumnsByRootIdentifier<_>,
     "consensus-spec-tests/tests/mainnet/fulu/ssz_static/DataColumnsByRootIdentifier/*/*",
     "consensus-spec-tests/tests/minimal/fulu/ssz_static/DataColumnsByRootIdentifier/*/*",
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -986,7 +986,6 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                     for data_column_sidecar in eip_7594::construct_data_column_sidecars(
                         &block,
                         &cells_and_kzg_proofs,
-                        &self.chain_config,
                         self.metrics.as_ref(),
                     )? {
                         let data_column_sidecar = Arc::new(data_column_sidecar);


### PR DESCRIPTION
Update spec tests to https://github.com/ethereum/consensus-specs/releases/tag/v1.6.0-alpha.4, there are 2 new SSZ types has been introduced in EIP7916, since those types are not relevant to Fulu, and PeerDAS specifically, I have just excluded from the script test. In this PR, I also (`mostly`) move `NumberOfColumns` into preset to compliant with the [spec change](https://github.com/ethereum/consensus-specs/pull/4485) while keep it as constant in some place where involve too deep changes. 

