### PR TITLE
Avoid using `initial_forward_sync` flag in `Store::is_forward_synced`

### DIFF
--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -3164,7 +3164,6 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
     #[must_use]
     pub fn is_forward_synced(&self) -> bool {
         self.head().slot() + self.store_config.max_empty_slots >= self.slot()
-            && self.finished_initial_forward_sync
     }
 
     #[must_use]


### PR DESCRIPTION
Previously, relying on this flag caused discrepancies between `validator::SlotHead` and `Store` until the store was initially forward-synced.