### PR TITLE
Retry block when all accepted while syncing

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -2411,7 +2411,13 @@ where
 
         let slot = data_column_sidecar.slot();
         let accepted_data_columns = self.store.accepted_data_column_sidecars_at_slot(slot);
-        let should_retry_block = if self.store.is_sidecars_construction_started(&block_root) {
+
+        // There is no data columns by each root request, while syncing we batch by root requests
+        // to respective custodial peers in `p2p/src/block_sync_service.rs::batch_request_missing_data_columns` method
+        let should_retry_block = if self.store.is_sidecars_construction_started(&block_root)
+            || (!self.store.is_forward_synced()
+                && self.store.sampling_columns_count() * 2 < P::NumberOfColumns::USIZE)
+        {
             accepted_data_columns == self.store.sampling_columns_count()
         } else {
             accepted_data_columns * 2 >= self.store.sampling_columns_count()


### PR DESCRIPTION
this change is for non-supernode behavior, without this, it takes out the pending block when half of its sampling columns accepted, so even when all sampling columns are available, it won't retry block because of no pending block in the memory until the block is received again