### PR TITLE
Don't take delayed block when retry block

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -2428,8 +2428,8 @@ where
         // During syncing, if we retry everytime when receiving a sidecar, this might spamming the
         // queue, leading to delaying other data column sidecar tasks
         if should_retry_block {
-            if let Some(pending_block) = self.take_delayed_until_blobs(block_root) {
-                self.retry_block(wait_group.clone(), pending_block);
+            if let Some(pending_block) = self.delayed_until_blobs.get(&block_root) {
+                self.retry_block(wait_group.clone(), pending_block.clone());
             }
         }
 

--- a/p2p/src/block_sync_service.rs
+++ b/p2p/src/block_sync_service.rs
@@ -842,7 +842,9 @@ impl<P: Preset> BlockSyncService<P> {
         }
 
         // Batch request data columns by root for missing columns if any
-        self.batch_request_missing_data_columns()?;
+        if !self.is_forward_synced {
+            self.batch_request_missing_data_columns()?;
+        }
 
         let snapshot = self.controller.snapshot();
         let head_slot = snapshot.head_slot();


### PR DESCRIPTION
while checking `grandine-besu-1` and `grandine-nethermind-1` on `fusaka-devnet-3` which are [stucked at the same slot](https://dora.fusaka-devnet-3.ethpandaops.io/clients/consensus), I saw a number of orphaned reconstruction which blocked by this condition
https://github.com/grandinetech/grandine/blob/001a2d92b201860609764fb0d182d6a1f2fc49a5/fork_choice_control/src/mutator.rs#L1800-L1802
while it has been taken out in `accept_data_column_sidecar` function
https://github.com/grandinetech/grandine/blob/001a2d92b201860609764fb0d182d6a1f2fc49a5/fork_choice_control/src/mutator.rs#L2431-L2433

this pull request also batch data columns by root requests only while syncing to avoid redundant request with `request_needed_data_columns`