### PR TITLE
Add `Store::is_reconstruction_enabled`

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -2407,15 +2407,10 @@ where
 
         let accepted_data_columns = self.store.accepted_data_column_sidecars_count(block_header);
 
-        // There is no data columns by each root request, while syncing we batch by root requests
-        // to respective custodial peers in `p2p/src/block_sync_service.rs::batch_request_missing_data_columns` method
-        let should_retry_block = if self.store.is_sidecars_construction_started(&block_root)
-            || (!self.store.is_forward_synced()
-                && self.store.sampling_columns_count() * 2 < P::NumberOfColumns::USIZE)
-        {
-            accepted_data_columns == self.store.sampling_columns_count()
-        } else {
+        let should_retry_block = if self.store.is_reconstruction_enabled_for(block_root) {
             accepted_data_columns * 2 >= self.store.sampling_columns_count()
+        } else {
+            accepted_data_columns == self.store.sampling_columns_count()
         };
 
         // During syncing, if we retry everytime when receiving a sidecar, this might spamming the

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2628,6 +2628,16 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         ))
     }
 
+    pub fn is_reconstruction_enabled_for(&self, block_root: H256) -> bool {
+        // samples enough columns for reconstruction
+        self.sampling_columns_count() * 2 >= P::NumberOfColumns::USIZE
+            // reconstruction not started for given block
+            && !self.is_sidecars_construction_started(&block_root)
+            // reconstruction is enabled during syncing (if syncing)
+            && (self.is_forward_synced()
+                || self.store_config().sync_with_reconstruction)
+    }
+
     fn insert_block(&mut self, chain_link: ChainLink<P>) -> Result<()> {
         let block_root = chain_link.block_root;
         let block = &chain_link.block;


### PR DESCRIPTION
Fixes too many block retries issue when syncing without reconstruction