### PR TITLE
Refine `should_retry_block` condition after accepting data column

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -2408,7 +2408,7 @@ where
         let accepted_data_columns = self.store.accepted_data_column_sidecars_count(block_header);
 
         let should_retry_block = if self.store.is_reconstruction_enabled_for(block_root) {
-            accepted_data_columns * 2 >= self.store.sampling_columns_count()
+            accepted_data_columns * 2 >= P::NumberOfColumns::USIZE
         } else {
             accepted_data_columns == self.store.sampling_columns_count()
         };


### PR DESCRIPTION
covers the case when for whatever reason sampling size is >= 64 && < 128

See: https://github.com/grandinetech/grandine/pull/350#discussion_r2324770598