### PR TITLE
fix typos in docs and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The documentation is available [here](https://docs.grandine.io/). Feel free to r
 
 ## Performance
 
-Grandine is a optimised and parallelised client. There aren't many published performance comparisions, but a previous [research](https://arxiv.org/abs/2311.05252) by MigaLabs may give some insight. We run 50,000 Holesky validators on one of our developer's machine.
+Grandine is a optimised and parallelised client. There aren't many published performance comparisons, but a previous [research](https://arxiv.org/abs/2311.05252) by MigaLabs may give some insight. We run 50,000 Holesky validators on one of our developer's machine.
 
 ## Memory Usage
 

--- a/book/src/beacon_node_api.md
+++ b/book/src/beacon_node_api.md
@@ -18,4 +18,4 @@ docker run                                                          \
 
 * `--http-port` - sets API listen port (default: `5052`);
 * `--http-address` - sets API listen address (default: `127.0.0.1`);
-* `--timeout` - sets API timeout in miliseconds (default: `10000`).
+* `--timeout` - sets API timeout in milliseconds (default: `10000`).

--- a/p2p/src/back_sync.rs
+++ b/p2p/src/back_sync.rs
@@ -401,7 +401,7 @@ impl<P: Preset> Batch<P> {
             if block.message().slot() == GENESIS_SLOT {
                 // if it's a genesis block, return it as is.
                 // It will be validated against our own genesis_block during
-                // final checkpoint vaildation
+                // final checkpoint validation
                 verified_blocks.push(block.clone_arc());
             } else if let Some(parent) = blocks.peek() {
                 debug!("back-sync batch block: {} {:?}", message.slot(), actual);


### PR DESCRIPTION

 Corrects minor spelling mistakes in documentation and a comment. No functional changes.

  - README: “comparisions” → “comparisons”  
  - book/src/beacon_node_api.md: “miliseconds” → “milliseconds”  
  - p2p/src/back_sync.rs: comment “vaildation” → “validation”

