### PR TITLE
Ignore non-sampling data column sidecars

### DIFF
--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2047,6 +2047,11 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             return Ok(DataColumnSidecarAction::Ignore(false));
         }
 
+        // Ignore non-sampling data column sidecars
+        if !self.sampling_columns.contains(&data_column_sidecar.index) {
+            return Ok(DataColumnSidecarAction::Ignore(false));
+        }
+
         // [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar)
         ensure!(
             verify_data_column_sidecar(&data_column_sidecar),


### PR DESCRIPTION
Add a check condition to import only sampling data column sidecars, and ignore what's not.

This issue might be switching from supernode to fullnode, which the node still subscribe to all column subnets. It will be address in follow up PR once confirmed.