### PR TITLE
Fix columns back sync validation

### DIFF
--- a/p2p/src/back_sync.rs
+++ b/p2p/src/back_sync.rs
@@ -343,10 +343,11 @@ impl<P: Preset> Batch<P> {
     ) -> Result<Vec<Arc<DataColumnSidecar<P>>>> {
         let block = block.message();
 
-        if !config
-            .phase_at_slot::<P>(block.slot())
-            .is_peerdas_activated()
-        {
+        let Some(body) = block.body().post_fulu() else {
+            return Ok(vec![]);
+        };
+
+        if body.blob_kzg_commitments().is_empty() {
             return Ok(vec![]);
         }
 


### PR DESCRIPTION
While test checkpoint sync on `fusaka-devnet-3`, I found a potential bug when back sync slots which there is no blob sidecars within it, and it stuck validating the slot, and blocked further back sync progress. below is the encountered error:

```
error occurred while verifying back-sync data: missing data column 50 for block 0xd80a04898ba4b71af751854f2ef453f9635ddd8a8703fa2b31768e8e32afdfd3 in slot 450079
```
while the slot [450079](https://dora.fusaka-devnet-3.ethpandaops.io/slot/450079) has no any blob sidecars in it.