### PR TITLE
Misc: reorder `chain_config` as first argument

### DIFF
--- a/eip_7594/src/tests.rs
+++ b/eip_7594/src/tests.rs
@@ -42,7 +42,7 @@ fn run_get_custody_groups_case<P: Preset>(case: Case) {
     let mut raw_node_id = [0u8; 32];
     node_id.into_raw().to_big_endian(&mut raw_node_id);
 
-    let custody_groups = get_custody_groups(raw_node_id, custody_group_count, &config)
+    let custody_groups = get_custody_groups(&config, raw_node_id, custody_group_count)
         .expect("custody groups must be valid");
 
     assert_eq!(custody_groups, result);
@@ -72,7 +72,7 @@ fn run_compute_columns_for_custody_group<P: Preset>(case: Case) {
     } = case.yaml("meta");
 
     let config = P::default_config().start_and_stay_in(Phase::Fulu);
-    let columns = compute_columns_for_custody_group::<P>(custody_group, &config)
+    let columns = compute_columns_for_custody_group::<P>(&config, custody_group)
         .expect("custody group must be valid");
 
     assert_eq!(columns.collect::<Vec<_>>(), result);

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -1844,10 +1844,6 @@ where
                     &data_column_sidecar,
                     DataColumnSidecarOrigin::Own,
                 );
-
-                if let Some(metrics) = self.metrics.as_ref() {
-                    metrics.reconstructed_columns.inc();
-                }
             }
 
             if self.store.is_forward_synced() {

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2058,7 +2058,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         // [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar)
         ensure!(
-            verify_data_column_sidecar(&data_column_sidecar, &self.chain_config),
+            verify_data_column_sidecar(&self.chain_config, &data_column_sidecar),
             Error::DataColumnSidecarInvalid {
                 data_column_sidecar
             },

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -2023,9 +2023,9 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         let last_finalized_state = self.controller.last_finalized_state().value;
         let own_validator_indices = self.own_validator_indices(&last_finalized_state);
         let validator_custody_requirement = eip_7594::get_validator_custody_requirement(
+            &self.chain_config,
             &last_finalized_state,
             &own_validator_indices,
-            &self.chain_config,
         );
 
         let current_sampling_size: u64 = self


### PR DESCRIPTION
this PR reorder function arguments in `eip_7594` module to place `chain_config` as the first argument to follow the convention as commented https://github.com/grandinetech/grandine/pull/425#discussion_r2431755366. it also de-duplicate `reconstructed_columns` metric increase calls as it has been called at https://github.com/grandinetech/grandine/blob/39a7b871fc86f13ee5cf2873a216ae9827d7c51d/operation_pools/src/blob_reconstruction_pool/tasks.rs#L69-L73 