### PR TITLE
Update consensus-spec-tests to `v1.6.0-beta.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,54 +23,55 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Maximize build space
-      if: runner.os == 'Linux'
-      uses: easimon/maximize-build-space@master
-      with:
-        root-reserve-mb: 2048
-        swap-size-mb: 1024
-    - name: Disable autocrlf (Windows)
-      if: runner.os == 'Windows'
-      run: git config --global core.autocrlf false
-    - name: Setup nim for constantine backend
-      if: runner.os != 'Macos'
-      uses: jiro4989/setup-nim-action@v2
-      with:
-        nim-version: '2.0.2'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        parent-nim-install-directory: ${{ runner.temp }}
-    - name: Install dependencies for constantine backend
-      if: runner.os == 'Linux'
-      run: |
-        sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
-          --no-install-recommends -yq \
-          libgmp-dev \
-          llvm
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-        lfs: true
-    - name: Run cargo build
-      run: cargo build --release --no-default-features --features default-networks,${{ matrix.backend }} --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
-    - name: Check if code is formatted (Linux)
-      if: runner.os == 'Linux'
-      run: cargo fmt --check
-    - name: Run Clippy (Linux)
-      if: runner.os == 'Linux'
-      run: scripts/ci/clippy.bash --deny warnings
-    # It's a known issue that networking tests randomly fails on Macos
-    - name: Run tests
-      if: runner.os == 'Macos'
-      run: cargo test --release --no-fail-fast --no-default-features --features ${{ matrix.backend }} --workspace --exclude zkvm_host --exclude zkvm_guest_risc0 -- --skip behaviour --skip common
-    # For debugging on window-specific error
-    - name: Run tests
-      if: runner.os != 'Macos'
-      run: cargo test --release --no-default-features --features ${{ matrix.backend }} --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
-      env:
-        KZG_BACKEND: ${{ matrix.default_kzg_backend }}
-    - name: Run other kzg backend tests
-      if: matrix.test_kzg_backends != ''
-      run: ${{ matrix.test_kzg_backends }}
-    - name: Check consensus-spec-tests coverage (Linux)
-      if: runner.os == 'Linux'
-      run: scripts/ci/consensus-spec-tests-coverage.rb
+      - name: Maximize build space
+        if: runner.os == 'Linux'
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 2048
+          swap-size-mb: 1024
+      - name: Disable autocrlf (Windows)
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+      - name: Setup nim for constantine backend
+        if: runner.os != 'Macos'
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: "2.0.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          parent-nim-install-directory: ${{ runner.temp }}
+      - name: Install dependencies for constantine backend
+        if: runner.os == 'Linux'
+        run: |
+          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
+            --no-install-recommends -yq \
+            libgmp-dev \
+            llvm
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Run cargo build
+        run: cargo build --release --no-default-features --features default-networks,${{ matrix.backend }} --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
+      - name: Check if code is formatted (Linux)
+        if: runner.os == 'Linux'
+        run: cargo fmt --check
+      - name: Download consensus-spec-tests
+        run: bash scripts/download_spec_tests.sh
+      - name: Run Clippy (Linux)
+        if: runner.os == 'Linux'
+        run: scripts/ci/clippy.bash --deny warnings
+      # It's a known issue that networking tests randomly fails on Macos
+      - name: Run tests
+        if: runner.os == 'Macos'
+        run: cargo test --release --no-fail-fast --no-default-features --features ${{ matrix.backend }} --workspace --exclude zkvm_host --exclude zkvm_guest_risc0 -- --skip behaviour --skip common
+      # For debugging on window-specific error
+      - name: Run tests
+        if: runner.os != 'Macos'
+        run: cargo test --release --no-default-features --features ${{ matrix.backend }} --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
+        env:
+          KZG_BACKEND: ${{ matrix.default_kzg_backend }}
+      - name: Run other kzg backend tests
+        if: matrix.test_kzg_backends != ''
+        run: ${{ matrix.test_kzg_backends }}
+      - name: Check consensus-spec-tests coverage (Linux)
+        if: runner.os == 'Linux'
+        run: scripts/ci/consensus-spec-tests-coverage.rb

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ book/deploy
 
 # Omit the trailing slash from `/eth2-cache`. This way it can be a symlink.
 /eth2-cache
+
+# large files
+consensus-spec-tests/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "slashing-protection-interchange-tests"]
 	path = slashing-protection-interchange-tests
 	url = https://github.com/eth2-clients/slashing-protection-interchange-tests.git
-[submodule "consensus-spec-tests"]
-	path = consensus-spec-tests
-	url = https://github.com/ethereum/consensus-spec-tests.git
 [submodule "hive"]
 	path = hive
 	url = https://github.com/grandinetech/hive.git

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
+EXCLUDES = --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
 all: build
 
+check:
+	cargo check --features default-networks $(EXCLUDES)
+
 build:
-	cargo build --release --bin grandine --features default-networks --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
+	cargo build --release --bin grandine --features default-networks $(EXCLUDES)
+
+download-spec-tests:
+	./scripts/download_spec_tests.sh
 
 release:
-	cargo build --profile compact --bin grandine --features default-networks --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
+	cargo build --profile compact --bin grandine --features default-networks $(EXCLUDES)
 
-test:
-	cargo test --release --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
+test: download-spec-tests
+	cargo test --release $(EXCLUDES)

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -8,14 +8,9 @@ cd "$(dirname "$0")"
 export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
 
 git submodule update --init       \
-    ../../consensus-spec-tests    \
     ../../eth2_libp2p             \
     ../../grandine-snapshot-tests \
     ../../slashing-protection-interchange-tests
-(
-    cd ../../consensus-spec-tests
-    git lfs pull
-)
 
 curl                     \
     --fail               \
@@ -34,6 +29,12 @@ curl                     \
 (
     cd ../..
     cargo fmt -- --check
+)
+
+# download consensus spec tests if not exist.
+(
+  cd ../..
+  ./scripts/download_spec_tests.sh
 )
 
 ./clippy.bash --deny warnings

--- a/scripts/ci/consensus-spec-tests-coverage.rb
+++ b/scripts/ci/consensus-spec-tests-coverage.rb
@@ -4,58 +4,38 @@
 # If a glob in the codebase matches the path of a test case directory,
 # every file in that test case is assumed to be covered.
 
-SUBMODULE = 'consensus-spec-tests'
+DIRECTORY = 'consensus-spec-tests'
 
 IGNORED_GLOBS = %w[
-  **/README.md
-  .git*
-  LICENSE
-  configs/*.yaml
-  presets/*/*.yaml
-  presets/*/trusted_setups/*.json
+  .version
   tests/*/*/light_client/single_merkle_proof/*/*/*.{ssz_snappy,yaml}
   tests/*/*/light_client/sync/pyspec_tests/*/*.{ssz_snappy,yaml}
   tests/*/*/light_client/update_ranking/pyspec_tests/*/*.{ssz_snappy,yaml}
   tests/*/*/light_client/data_collection/pyspec_tests/*/*.{ssz_snappy,yaml}
   tests/*/eip7805/*/*/*/*/*.{ssz_snappy,yaml}
   tests/*/gloas/*/*/*/*/*.{ssz_snappy,yaml}
-  tests/general/phase0/ssz_generic/{progressive_bitlist,progressive_containers,basic_progressive_list}/*/*/*.{ssz_snappy,yaml}
+  tests/general/phase0/ssz_generic/{compatible_unions,progressive_bitlist,progressive_containers,basic_progressive_list}/*/*/*.{ssz_snappy,yaml}
   tests/general/phase0/ssz_generic/containers/{valid,invalid}/{ProgressiveBitsStruct,ProgressiveTestStruct}_*/*.{ssz_snappy,yaml}
   tests/general/deneb/kzg/compute_challenge/*/*/*.{ssz_snappy,yaml}
   tests/general/fulu/kzg/compute_verify_cell_kzg_proof_batch_challenge/*/*/*.{ssz_snappy,yaml}
   tests/general/fulu/ssz_generic/progressive_containers/*/*/*.{ssz_snappy,yaml}
-  tests/diagnostics_obj.json{,.lock}
-].map! { |glob| File.join(SUBMODULE, glob) }
+].map! { |glob| File.join(DIRECTORY, glob) }
 
-GIT_LS_FILES_COMMAND = %W[
-  git
-  -C #{SUBMODULE}
-  ls-files
-  -z
-]
+LS_FILES_COMMAND = ['find', DIRECTORY, '-type', 'f', '-print0']
 
-GIT_GREP_COMMAND = %W[
-  git
+GREP_COMMAND = %W[
   grep
-  --extended-regexp
-  -h
-  --no-color
-  --no-column
-  --no-line-number
-  --only-matching
-  --untracked
-  #{SUBMODULE}/tests/[^"`]+
+  -ErohI
+  #{DIRECTORY}/tests/[^\"`]+
 ]
 
 Dir.chdir(File.join(__dir__, '..', '..'))
 
-all_files = IO.popen(GIT_LS_FILES_COMMAND, IO::RDONLY | IO::BINARY) do |io|
-  io.each_line("\0").map do |line|
-    File.join(SUBMODULE, line.chomp!("\0"))
-  end
+all_files = IO.popen(LS_FILES_COMMAND, IO::RDONLY | IO::BINARY) do |io|
+  io.each_line("\0").map { |line| line.delete_suffix("\0") }
 end
 
-covered_globs = IO.popen(GIT_GREP_COMMAND) do |io|
+covered_globs = IO.popen(GREP_COMMAND) do |io|
   io.each_line.map do |line|
     File.join(line.chomp!, '*.{ssz_snappy,yaml}')
   end
@@ -65,11 +45,11 @@ covered_files = Dir.glob(covered_globs + IGNORED_GLOBS)
 uncovered_files = all_files - covered_files
 
 if uncovered_files.empty?
-  puts("All #{all_files.size} files in #{SUBMODULE} are covered by tests.")
+  puts("All #{all_files.size} files in #{DIRECTORY} are covered by tests.")
 else
   heading = <<~END
     #{uncovered_files.size} of #{all_files.size} \
-    files in #{SUBMODULE} are not covered by tests:
+    files in #{DIRECTORY} are not covered by tests:
   END
 
   puts(heading, uncovered_files)

--- a/scripts/download_spec_tests.sh
+++ b/scripts/download_spec_tests.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPEC_VERSION="${SPEC_VERSION:-v1.6.0-beta.1}"
+TESTS_DIR="consensus-spec-tests"
+VERSION_FILE="${TESTS_DIR}/.version"
+BASE_URL="https://github.com/ethereum/consensus-specs/releases/download/${SPEC_VERSION}"
+
+# Tarballs to download
+TARBALLS=("general" "minimal" "mainnet")
+
+# Normalize paths on Windows Git Bash
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    TESTS_DIR=$(cygpath -m "$TESTS_DIR")
+    VERSION_FILE=$(cygpath -m "$VERSION_FILE")
+fi
+
+# Check if tests already exist with the same version
+if [[ -f "$VERSION_FILE" ]]; then
+    EXISTING_VERSION=$(<"$VERSION_FILE")
+    if [[ "$EXISTING_VERSION" == "$SPEC_VERSION" ]]; then
+        echo "Consensus-spec-tests ${SPEC_VERSION} already exists."
+        exit 0
+    else
+        echo "Found existing tests version ${EXISTING_VERSION}, updating to ${SPEC_VERSION}..."
+        rm -rf "$TESTS_DIR"
+    fi
+fi
+
+echo "Downloading consensus-spec-tests ${SPEC_VERSION}..."
+
+# Create directory if it doesn't exist
+mkdir -p "$TESTS_DIR"
+
+# Function to download and extract a tarball
+download_tarball() {
+    local tarball_name="$1"
+    local download_url="${BASE_URL}/${tarball_name}.tar.gz"
+    
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$download_url" | tar -xz -C "$TESTS_DIR"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- "$download_url" | tar -xz -C "$TESTS_DIR"
+    else
+        echo "Error: No download tool found. Please install curl or wget."
+        exit 1
+    fi
+    
+    echo "  ✓ ${tarball_name}.tar.gz extracted"
+}
+
+# Check if we can parallelize downloads
+if command -v xargs >/dev/null 2>&1; then
+    # Parallel downloads and extract using xargs
+    echo "${TARBALLS[@]}" | tr ' ' '\n' | xargs -P 3 -I {} sh -c '
+        tarball="$1"
+        download_url="'"${BASE_URL}"'/${tarball}.tar.gz"
+        echo "Downloading ${tarball}.tar.gz..."
+        if command -v curl >/dev/null 2>&1; then
+            curl -fsSL "$download_url" | tar -xz -C "'"$TESTS_DIR"'"
+        elif command -v wget >/dev/null 2>&1; then
+            wget -qO- "$download_url" | tar -xz -C "'"$TESTS_DIR"'"
+        else
+            echo "Error: No download tool found. Please install curl or wget."
+            exit 1
+        fi
+        echo "  ✓ ${tarball}.tar.gz extracted"
+    ' _ {}
+else
+    # Fallback to sequential if xargs is not available
+    for tarball in "${TARBALLS[@]}"; do
+        download_tarball "$tarball"
+    done
+fi
+
+# Save version file
+echo "$SPEC_VERSION" > "$VERSION_FILE"
+
+echo "Successfully downloaded and extracted all tests to ${TESTS_DIR}"


### PR DESCRIPTION
start from consensus-spec-tests `v1.6.0-beta.1`, there will be not spec-tests release in [`consensus-spec-tests`](https://github.com/ethereum/consensus-spec-tests) (already archived), though we can't reference as submodule anymore.

in this PR, there is a script to download the spec tests tarball (available as assets in each `consensus-spec` release) and extract to the same directory (same as with submodule). it will only download if no spec tests exist in current working directory. after retrieving is completed, it will also create a `.version` file to keep track the version of current spec tests and to avoid re-download everything. if there is new spec tests release, we just need to change the `SPEC_VERSION` in `scripts/download_spec_tests.sh` script to replace the old with the new one.