### PR TITLE
docs: add checkpoint loading error handling description

### DIFF
--- a/book/src/storage.md
+++ b/book/src/storage.md
@@ -8,7 +8,7 @@ By default, Grandine keeps the non-finalized part of the chain in the memory usi
 
 Grandine stores finalized part of the chain in the disk using an embedded key-value database `libmdbx`. Disk storage is passive and mainly used for storing/loading checkpoints, and serving historical data via API. Historical blocks and corresponding intermediate states are stored on the disk. It's possible to set the length of the intermediate states period. A higher value for this interval means lower disk usage and slower API responses for historical data.
 
-Grandine allows starting the Beacon Node from an earlier stored checkpoint by using `--state-slot` option. In this case, Grandine will try to find and load from the disk the closest stored checkpoint before the specified `--state-slot`.
+Grandine allows starting the Beacon Node from an earlier stored checkpoint by using `--state-slot` option. In this case, Grandine will try to find and load from the disk the closest stored checkpoint before the specified `--state-slot`. If no local checkpoint is found, Grandine will attempt checkpoint sync from a remote server (if configured) or fall back to the anchor checkpoint. If all fallback options fail, the node will exit with an error.
 
 ### Prune Mode
 


### PR DESCRIPTION
Added comprehensive description of checkpoint loading fallback behavior in storage documentation. Now explains what happens when local checkpoint is not found, including checkpoint sync attempts and anchor checkpoint fallback, with clear error handling information for users.