### PR TITLE
rotate exception.log when it exceeds 1GB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,11 +2001,13 @@ dependencies = [
  "fs-err",
  "gag",
  "logging",
+ "logroller",
  "panics",
  "rayon",
  "serial_test",
  "tempfile",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber 0.3.20",
 ]
 
@@ -3094,6 +3096,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -4655,6 +4666,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -7242,6 +7263,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "logroller"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83db12bbf439ebe64c0b0e4402f435b6f866db498fc1ae17e1b5d1a01625e2be"
+dependencies = [
+ "chrono",
+ "flate2",
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "loom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7470,6 +7503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -11009,6 +11043,12 @@ dependencies = [
  "tracing",
  "types",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,6 +376,7 @@ libp2p-mplex = '0.43'
 libp2p-identity = { version = '0.2.10', features = ['peerid'] }
 local-ip-address = '0.6'
 log = '0.4'
+logroller = "0.1.10"
 lru = '0.16'
 mediatype = '0.20'
 memoffset = '0.9'
@@ -457,7 +458,8 @@ tokio-util = { version = '0.7', features = ['codec', 'compat', 'time'] }
 tower = { version = '0.5', features = ['timeout'] }
 tower-http = { version = '0.6', features = ['cors', 'trace'] }
 tracing = '0.1'
-tracing-subscriber = { version = "0.3", features = ['chrono', 'env-filter', 'fmt', 'registry'] }
+tracing-appender = "0.2.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry", "chrono"] }
 tracing-test = "0.2"
 triomphe = '0.1'
 tynm = '0.2'

--- a/binary_utils/Cargo.toml
+++ b/binary_utils/Cargo.toml
@@ -11,9 +11,11 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 fs-err ={ workspace = true }
 logging = { workspace = true }
+logroller = { workspace = true }
 panics = { workspace = true }
 rayon = { workspace = true }
 tracing = { workspace = true }
+tracing-appender = { workspace = true }
 tracing-subscriber = {workspace = true }
 
 [dev-dependencies]

--- a/grandine/src/main.rs
+++ b/grandine/src/main.rs
@@ -361,7 +361,6 @@ fn try_main() -> Result<()> {
         &data_dir,
         cfg!(feature = "logger-always-write-style"),
     )?;
-
     binary_utils::initialize_rayon()?;
 
     let config = parsed_args


### PR DESCRIPTION
Currently, exception.log could grow indefinitely, eventually(worst case) consuming all available disk space.

This PR migrates the exception logging system to use the logroller crate, introducing size-based rotation, compression, and file retention:

- Rotation strategy: size-based, with a 1 GB limit per file
- Compression: old logs are automatically compressed using gzip
- Retention: up to 5 log files are kept (1 current + 4 compressed)

In the worst case, this setup can retain up to ~2 GB of exception logs on disk,
which would correspond to about 5 GB of uncompressed data.
> compressed logs reduce their size by approximately 5–6×

---

solves #455  (continues the conversation from #451)

---

## Verification:

The rotation and compression behavior were verified during runtime by **temporarily lowering** the rotation threshold to **1 KB**.

This allowed observing rotations and compressed files being correctly generated and retained.
An exception message was injected in one of the **frequently** executed parts of the code before node startup (specifically in `execution_service.rs`).

test example:

<img width="1313" height="1121" alt="Screenshot from 2025-11-03 19-50-16" src="https://github.com/user-attachments/assets/37a33f00-8832-4541-88bc-3f1e3068a9fa" />

<img width="1313" height="1121" alt="Screenshot from 2025-11-03 19-50-31" src="https://github.com/user-attachments/assets/146b21fd-1ed7-4115-81d7-6e43ca675d21" />
