### PR TITLE
Implement release pipeline for grandine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,233 @@
+name: Create release
+
+on:
+  push:
+    branches:
+      - develop
+    tags:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The reference (branch/tag/commit) to build'
+        required: false
+
+jobs:
+  version:
+    name: Get version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: false
+
+      - name: Get short commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    outputs:
+      commit: ${{ steps.vars.outputs.sha_short }}
+      version: ${{ (github.event_name == 'push' && github.event.ref != 'refs/heads/develop' && github.ref_name) || steps.vars.outputs.sha_short }}
+      
+  build:
+    name: Build binary for target ${{ matrix.target }}
+    needs: [version]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            rid: linux-x64
+            
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            rid: linux-arm64
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            rid: win-x64
+            
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            rid: osx-x64
+
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            rid: osx-arm64
+    env:
+      GRANDINE_VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - name: Disable autocrlf (Windows)
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+        
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: runner.os == 'Linux'
+
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
+            --no-install-recommends -yq \
+            ca-certificates \
+            libssl-dev \
+            clang \
+            cmake \
+            unzip \
+            protobuf-compiler \
+            libz-dev
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: true
+
+      - name: Install cross
+        if: runner.os == 'Linux'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build binary
+        run: make TARGET=${{ matrix.target }} release
+
+      - name: Rename binary (MacOS / Linux)
+        if: runner.os != 'Windows'
+        run: mv target/${{ matrix.target }}/compact/grandine ./grandine-${{ env.GRANDINE_VERSION }}-${{ matrix.rid }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: mv target/${{ matrix.target }}/compact/grandine.exe ./grandine-${{ env.GRANDINE_VERSION }}-${{ matrix.rid }}.exe
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: grandine-${{ env.GRANDINE_VERSION }}-${{ matrix.rid }}
+          path: |
+            ./grandine-${{ env.GRANDINE_VERSION }}-${{ matrix.rid }}
+            ./grandine-${{ env.GRANDINE_VERSION }}-${{ matrix.rid }}.exe
+          if-no-files-found: error
+
+  build_docker:
+    name: Build docker images
+    runs-on: ubuntu-latest
+    needs: [version, build]
+    env:
+      GRANDINE_VERSION: ${{ needs.version.outputs.version }}
+      GRANDINE_COMMIT: ${{ needs.version.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: false
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: grandine-*
+          path: artifacts
+
+      - name: Move artifacts
+        run: |
+          mv ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-x64/grandine-${{ env.GRANDINE_VERSION }}-linux-x64 ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-x64/grandine
+          mv ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64 ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64/grandine
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta for amd64
+        id: amd64-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            sifrai/grandine
+          tags: |
+            type=semver,pattern=stable-amd64-{{version}}
+            type=raw,enable=${{ github.event_name == 'push' && github.event.ref == 'refs/heads/develop' }},value=unstable-amd64
+            type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},value=unstable-amd64-${{ env.GRANDINE_COMMIT }}
+
+      - name: Build and push amd64
+        id: build-amd64
+        uses: docker/build-push-action@v6
+        with:
+          context: ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-x64/
+          file: ./Dockerfile.cross
+          push: true
+          tags: ${{ steps.amd64-meta.outputs.tags }}
+          labels: ${{ steps.amd64-meta.outputs.labels }}
+          platforms: linux/amd64
+
+      - name: Docker meta for arm64
+        id: arm64-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            sifrai/grandine
+          tags: |
+            type=semver,pattern=stable-arm64-{{version}}
+            type=raw,enable=${{ github.event_name == 'push' && github.event.ref == 'refs/heads/develop' }},value=unstable-arm64
+            type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},value=unstable-arm64-${{ env.GRANDINE_COMMIT }}
+
+      - name: Build and push arm64
+        uses: docker/build-push-action@v6
+        with:
+          context: ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64/
+          file: ./Dockerfile.cross
+          push: true
+          tags: ${{ steps.arm64-meta.outputs.tags }}
+          labels: ${{ steps.arm64-meta.outputs.labels }}
+          platforms: linux/arm64
+
+      - name: Push unstable tag
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/develop'
+        run: |
+          docker buildx imagetools create -t sifrai/grandine:unstable \
+            sifrai/grandine:unstable-amd64 \
+            sifrai/grandine:unstable-arm64
+
+      - name: Push stable tags
+        if: github.event_name == 'push' && github.event.ref != 'refs/heads/develop'
+        run: |
+          docker buildx imagetools create -t sifrai/grandine:${{ env.GRANDINE_VERSION }} \
+            sifrai/grandine:stable-amd64-${{ env.GRANDINE_VERSION }} \
+            sifrai/grandine:stable-arm64-${{ env.GRANDINE_VERSION }}
+          docker buildx imagetools create -t sifrai/grandine:stable \
+            sifrai/grandine:${{ env.GRANDINE_VERSION }}
+          docker buildx imagetools create -t sifrai/grandine:latest \
+            sifrai/grandine:${{ env.GRANDINE_VERSION }}
+
+      - name: Push commit tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          docker buildx imagetools create -t sifrai/grandine:unstable-${{ env.GRANDINE_COMMIT }} \
+            sifrai/grandine:unstable-amd64-${{ env.GRANDINE_COMMIT }} \
+            sifrai/grandine:unstable-arm64-${{ env.GRANDINE_COMMIT }}
+  publish:
+    name: Draft release
+    if: github.event_name == 'push' && github.event.ref != 'refs/heads/develop'
+    needs: [build]
+    env:
+      GRANDINE_VERSION: ${{ needs.version.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: grandine-*
+          path: artifacts
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+          draft: true
+          tag_name: ${{ env.GRANDINE_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,31 @@
 EXCLUDES = --workspace --exclude zkvm_host --exclude zkvm_guest_risc0
+TARGET ?= 
+
+.PHONY: all
 all: build
 
+.PHONY: check
 check:
 	cargo check --features default-networks $(EXCLUDES)
 
+.PHONY: build
 build:
 	cargo build --release --bin grandine --features default-networks $(EXCLUDES)
 
+.PHONY: download-spec-tests
 download-spec-tests:
 	./scripts/download_spec_tests.sh
 
+.PHONY: release
 release:
+ifeq ($(TARGET),)
 	cargo build --profile compact --bin grandine --features default-networks $(EXCLUDES)
+else ifneq (,$(findstring linux,$(TARGET)))
+	cross build --bin grandine --target $(TARGET) --features default-networks --profile compact $(EXCLUDES)
+else
+	cargo build --profile compact --bin grandine --target $(TARGET) --features default-networks $(EXCLUDES)
+endif
 
+.PHONY: test
 test: download-spec-tests
 	cargo test --release $(EXCLUDES)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = '1.90.0'
 profile = 'minimal'
 components = ['clippy', 'rustfmt']
-targets = ['i686-unknown-linux-gnu', 'x86_64-unknown-linux-gnu']
+targets = ['i686-unknown-linux-gnu', 'x86_64-unknown-linux-gnu', 'x86_64-apple-darwin']


### PR DESCRIPTION
This pull request introduces release pipeline. When triggered, it builds grandine binaries for 5 different targets:
* x86_64-unknown-linux-gnu
* aarch64-unknown-linux-gnu
* x86_64-pc-windows-msvc
* x86_64-apple-darwin
* aarch64-apple-darwin

And uploads compiled binaries as workflow artifacts. 

To build for different targets, release script in makefile was updated:
* When TARGET variable is not specified, building for default target, same as old behavior.
* When TARGET variable contains "linux" substring, enabling cross-compilation with `cross`.
* Otherwise, building with `cargo`, but with target passed via `--target` flag.

The last step is needed to compile windows/macos, as these binaries can be compiled only natively, when running on target OS.

With binary compilation this pipeline also compiles docker images for linux amd64 and arm64. Image tags vary based on event, that triggered workflow.

The release pipeline can be triggered in three different ways. In all those cases, pipeline behaves a bit differently:
* When new commit is pushed to `develop` branch, compiled binaries are packaged into docker images with tags: [`unstable-amd64`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/unstable-amd64), [`unstable-arm64`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/unstable-arm64) and multi-arch image [`unstable`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/unstable). Example of such workflow run: https://github.com/ArtiomTr/grandine/actions/runs/19224687082
* When tag is pushed, compiled binaries are packaged into docker images with tags: [`stable-amd64-<tag>`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/stable-amd64-0.1.5), [`stable-arm64-<tag>`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/stable-amd64-0.1.5) and multi-arch images [`<tag>`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/0.1.5), [`stable`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/stable) and [`latest`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/stable). Also, release will be drafted, with all compiled binaries attached: https://github.com/ArtiomTr/grandine/releases/tag/0.1.5. Example of this workflow run: https://github.com/ArtiomTr/grandine/actions/runs/19224382337
* When workflow is ran by hand from GitHub UI (workflow_dispatch event), compiled binaries are packaged into docker images with tags: [`unstable-arm64-<commit-sha>`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/unstable-arm64-c854c2f), [`unstable-amd64-<commit-sha>`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/unstable-amd64-c854c2f) and multi-arch image [`unstable-<commit-sha>`](https://hub.docker.com/repository/docker/sirsedev/test-repo/tags/unstable-c854c2f). Example of such workflow run: https://github.com/ArtiomTr/grandine/actions/runs/19225095075