### PR TITLE
Fix `Mutator` performance issues related to data column reconstruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,7 +4563,6 @@ dependencies = [
  "derivative",
  "derive_more 2.0.1",
  "duplicate",
- "eip_7594",
  "eth2_cache_utils",
  "eth2_libp2p",
  "execution_engine",

--- a/fork_choice_control/Cargo.toml
+++ b/fork_choice_control/Cargo.toml
@@ -16,7 +16,6 @@ dashmap = { workspace = true }
 database = { workspace = true }
 derivative = { workspace = true }
 derive_more = { workspace = true }
-eip_7594 = { workspace = true }
 eth2_libp2p = { workspace = true }
 execution_engine = { workspace = true }
 features = { workspace = true }

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -41,10 +41,7 @@ use types::{
     },
     config::Config as ChainConfig,
     deneb::containers::BlobSidecar,
-    fulu::{
-        containers::{DataColumnSidecar, MatrixEntry},
-        primitives::ColumnIndex,
-    },
+    fulu::{containers::DataColumnSidecar, primitives::ColumnIndex},
     nonstandard::ValidationOutcome,
     phase0::{
         containers::BeaconBlockHeader,
@@ -117,7 +114,7 @@ where
         metrics: Option<Arc<Metrics>>,
         attestation_verifier_tx: A, // impl UnboundedSink<AttestationVerifierMessage<P, W>>,
         p2p_tx: impl UnboundedSink<P2pMessage<P>>,
-        pool_tx: impl UnboundedSink<PoolMessage<W>>,
+        pool_tx: impl UnboundedSink<PoolMessage<P, W>>,
         subnet_tx: impl UnboundedSink<SubnetMessage<W>>,
         sync_tx: impl UnboundedSink<SyncMessage<P>>,
         validator_tx: impl UnboundedSink<ValidatorMessage<P, W>>,
@@ -659,12 +656,14 @@ where
         &self,
         wait_group: W,
         block_root: H256,
-        full_matrix: Vec<MatrixEntry<P>>,
+        block: Arc<SignedBeaconBlock<P>>,
+        data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
     ) {
         MutatorMessage::ReconstructedMissingColumns {
             wait_group,
             block_root,
-            full_matrix,
+            block,
+            data_column_sidecars,
         }
         .send(&self.mutator_tx)
     }

--- a/operation_pools/src/blob_reconstruction_pool/manager.rs
+++ b/operation_pools/src/blob_reconstruction_pool/manager.rs
@@ -6,6 +6,7 @@ use fork_choice_control::Wait;
 use prometheus_metrics::Metrics;
 use std_ext::ArcExt as _;
 use types::{
+    combined::SignedBeaconBlock,
     phase0::primitives::{Slot, H256},
     preset::Preset,
 };
@@ -32,7 +33,13 @@ impl<P: Preset, W: Wait> Manager<P, W> {
         }
     }
 
-    pub fn spawn_reconstruction(&self, wait_group: W, block_root: H256, slot: Slot) {
+    pub fn spawn_reconstruction(
+        &self,
+        wait_group: W,
+        block_root: H256,
+        block: Arc<SignedBeaconBlock<P>>,
+        slot: Slot,
+    ) {
         self.controller
             .mark_sidecar_construction_started(block_root, slot);
 
@@ -40,6 +47,7 @@ impl<P: Preset, W: Wait> Manager<P, W> {
             controller: self.controller.clone_arc(),
             wait_group,
             block_root,
+            block,
             metrics: self.metrics.clone(),
         })
     }

--- a/operation_pools/src/blob_reconstruction_pool/tasks.rs
+++ b/operation_pools/src/blob_reconstruction_pool/tasks.rs
@@ -1,18 +1,24 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use eth1_api::ApiController;
 use fork_choice_control::Wait;
 use helper_functions::misc;
 use logging::{debug_with_peers, info_with_peers, warn_with_peers};
 use prometheus_metrics::Metrics;
-use std::sync::Arc;
+use tap::Tap as _;
 use typenum::Unsigned as _;
-use types::{fulu::containers::DataColumnIdentifier, phase0::primitives::H256, preset::Preset};
+use types::{
+    combined::SignedBeaconBlock, fulu::containers::DataColumnIdentifier, phase0::primitives::H256,
+    preset::Preset,
+};
 
 use crate::misc::PoolTask;
 pub struct ReconstructDataColumnSidecarsTask<P: Preset, W: Wait> {
     pub controller: ApiController<P, W>,
     pub wait_group: W,
     pub block_root: H256,
+    pub block: Arc<SignedBeaconBlock<P>>,
     pub metrics: Option<Arc<Metrics>>,
 }
 
@@ -24,6 +30,7 @@ impl<P: Preset, W: Wait> PoolTask for ReconstructDataColumnSidecarsTask<P, W> {
             controller,
             wait_group,
             block_root,
+            block,
             metrics,
         } = self;
 
@@ -51,7 +58,7 @@ impl<P: Preset, W: Wait> PoolTask for ReconstructDataColumnSidecarsTask<P, W> {
 
         debug_with_peers!("starting reconstruction for block: {block_root:?}");
 
-        let _columns_reconstruction_timer = metrics
+        let columns_reconstruction_timer = metrics
             .as_ref()
             .map(|metrics| metrics.columns_reconstruction_time.start_timer());
 
@@ -61,10 +68,30 @@ impl<P: Preset, W: Wait> PoolTask for ReconstructDataColumnSidecarsTask<P, W> {
             .flat_map(|sidecar| misc::compute_matrix_for_data_column_sidecar(&sidecar))
             .collect::<Vec<_>>();
 
-        match eip_7594::recover_matrix(&partial_matrix, controller.store_config().kzg_backend) {
-            Ok(full_matrix) => {
+        let reconstruction_result =
+            eip_7594::recover_matrix(&partial_matrix, controller.store_config().kzg_backend)
+                .tap(|_| prometheus_metrics::stop_and_record(columns_reconstruction_timer))
+                .and_then(|full_matrix| {
+                    let timer = metrics
+                        .as_ref()
+                        .map(|metrics| metrics.data_column_sidecar_computation.start_timer());
+
+                    let cells_and_kzg_proofs =
+                        eip_7594::construct_cells_and_kzg_proofs(full_matrix)?;
+
+                    let data_column_sidecars =
+                        eip_7594::construct_data_column_sidecars(&block, &cells_and_kzg_proofs)?;
+
+                    prometheus_metrics::stop_and_record(timer);
+
+                    Ok(data_column_sidecars)
+                });
+
+        match reconstruction_result {
+            Ok(data_column_sidecars) => {
                 info_with_peers!("reconstructed missing data columns for block: {block_root:?}");
-                controller.on_reconstruction(wait_group, block_root, full_matrix);
+
+                controller.on_reconstruction(wait_group, block_root, block, data_column_sidecars);
 
                 if let Some(metrics) = metrics.as_ref() {
                     metrics

--- a/operation_pools/src/manager.rs
+++ b/operation_pools/src/manager.rs
@@ -14,7 +14,7 @@ pub struct Manager<P: Preset, W: Wait> {
     pub blob_reconstruction_pool: BlobReconstructionPool<P, W>,
     pub bls_to_execution_change_pool: Arc<BlsToExecutionChangePool>,
     pub sync_committee_agg_pool: Arc<SyncCommitteeAggPool<P, W>>,
-    pub fork_choice_to_pool_rx: UnboundedReceiver<PoolMessage<W>>,
+    pub fork_choice_to_pool_rx: UnboundedReceiver<PoolMessage<P, W>>,
 }
 
 impl<P: Preset, W: Wait> Manager<P, W> {
@@ -24,7 +24,7 @@ impl<P: Preset, W: Wait> Manager<P, W> {
         blob_reconstruction_pool: BlobReconstructionPool<P, W>,
         bls_to_execution_change_pool: Arc<BlsToExecutionChangePool>,
         sync_committee_agg_pool: Arc<SyncCommitteeAggPool<P, W>>,
-        fork_choice_to_pool_rx: UnboundedReceiver<PoolMessage<W>>,
+        fork_choice_to_pool_rx: UnboundedReceiver<PoolMessage<P, W>>,
     ) -> Self {
         Self {
             attestation_agg_pool,
@@ -55,10 +55,11 @@ impl<P: Preset, W: Wait> Manager<P, W> {
                 PoolMessage::ReconstructDataColumns {
                     wait_group,
                     block_root,
+                    block,
                     slot,
                 } => {
                     self.blob_reconstruction_pool
-                        .spawn_reconstruction(wait_group, block_root, slot);
+                        .spawn_reconstruction(wait_group, block_root, block, slot);
                 }
             }
         }


### PR DESCRIPTION
* Not removing pending block from delayed queue caused multiple block validation tasks to be spawned for the same block in a short period of time (each time when a new data column is accepted);

* Data column and proof construction does not belong in `Mutator` - it blocks `Mutator` from performing other tasks in the mean time.