### PR TITLE
Fix comments and type definitions for MaxCellProofsPerBlock in Preset trait

### DIFF
--- a/types/src/preset.rs
+++ b/types/src/preset.rs
@@ -214,7 +214,7 @@ pub trait Preset: Copy + Eq + Ord + Hash + Default + Debug + Send + Sync + 'stat
         + Eq;
 
     // Maximum possible number of cell proofs per blocks:
-    // FieldElementsPerExtBlob * MaxBlobCommitmentsPerBlock
+    // CellsPerExtBlob * MaxBlobCommitmentsPerBlock
     type MaxCellProofsPerBlock: MerkleElements<KzgProof> + Unsigned + Eq + Debug + Send + Sync;
 
     // Meta
@@ -336,7 +336,7 @@ impl Preset for Mainnet {
     // Derived type-level variables
     type MaxAttestersPerSlot = Prod<Self::MaxValidatorsPerCommittee, Self::MaxCommitteesPerSlot>;
     type MaxCellProofsPerBlock =
-        Prod<Self::FieldElementsPerExtBlob, Self::MaxBlobCommitmentsPerBlock>;
+        Prod<Self::MaxBlobCommitmentsPerBlock, Self::CellsPerExtBlob>;
     type CellsPerExtBlob = Quot<Self::FieldElementsPerExtBlob, Self::FieldElementsPerCell>;
 
     // Meta
@@ -432,7 +432,7 @@ impl Preset for Minimal {
     // Derived type-level variables
     type MaxAttestersPerSlot = Prod<Self::MaxValidatorsPerCommittee, Self::MaxCommitteesPerSlot>;
     type MaxCellProofsPerBlock =
-        Prod<Self::FieldElementsPerExtBlob, Self::MaxBlobCommitmentsPerBlock>;
+        Prod<Self::MaxBlobCommitmentsPerBlock, Self::CellsPerExtBlob>;
     type CellsPerExtBlob = Quot<Self::FieldElementsPerExtBlob, Self::FieldElementsPerCell>;
 
     // Meta


### PR DESCRIPTION
## Summary
Corrects the comment and type definitions for `MaxCellProofsPerBlock` in the Preset trait to ensure they accurately reflect the intended calculation.
## Issue Addressed
Fix #477 
## Changes

### 1. Updated Comment (Line 217)
**Before:**
```rust
// Maximum possible number of cell proofs per blocks:
// FieldElementsPerExtBlob * MaxBlobCommitmentsPerBlock
```

**After:**
```rust
// Maximum possible number of cell proofs per blocks:
// CellsPerExtBlob * MaxBlobCommitmentsPerBlock
```

### 2. Updated Mainnet Preset Implementation (Lines 339-340)
**Before:**
```rust
type MaxCellProofsPerBlock =
    Prod<Self::FieldElementsPerExtBlob, Self::MaxBlobCommitmentsPerBlock>;
```

**After:**
```rust
type MaxCellProofsPerBlock =
    Prod<Self::MaxBlobCommitmentsPerBlock, Self::CellsPerExtBlob>;
```

### 3. Updated Minimal Preset Implementation (Lines 435-436)
**Before:**
```rust
type MaxCellProofsPerBlock =
    Prod<Self::FieldElementsPerExtBlob, Self::MaxBlobCommitmentsPerBlock>;
```

**After:**
```rust
type MaxCellProofsPerBlock =
    Prod<Self::MaxBlobCommitmentsPerBlock, Self::CellsPerExtBlob>;
```

## Rationale

The correct calculation for the maximum number of cell proofs per block is:
- **CellsPerExtBlob** (derived as `FieldElementsPerExtBlob / FieldElementsPerCell`) × **MaxBlobCommitmentsPerBlock**

This ensures the type definition matches both:
1. The intended semantic meaning
2. The documentation comment

## Files Modified
- `types/src/preset.rs`

## Impact
- Fixes incorrect type definitions that could lead to compilation errors or incorrect behavior
- Aligns documentation with actual implementation
- Applies to both `Mainnet` and `Minimal` presets

## Testing
Changes are type-level definitions that will be validated at compile time. No runtime behavior changes.
