### PR TITLE
docs: fixes "contact us" link

### DIFF
--- a/book/src/support.md
+++ b/book/src/support.md
@@ -6,4 +6,4 @@ It's best to reach us via [Grandine Discord](https://discord.gg/H9XCdUSyZd). Fee
 
 ### Commercial support
 
-Please [contacts us](mainto:info@grandine.io) if you are interested in commercial support for Grandine and related services.
+Please [contacts us](mailto:info@grandine.io) if you are interested in commercial support for Grandine and related services.


### PR DESCRIPTION
Hello! I found a display bug with `contact us` link and fixed it