### PR TITLE
refactor: Eliminate code duplication in hex/bytes deserialization

### DIFF
--- a/serde_utils/src/prefixed_hex_or_bytes_array.rs
+++ b/serde_utils/src/prefixed_hex_or_bytes_array.rs
@@ -1,46 +1,21 @@
-use core::fmt::{Formatter, Result as FmtResult};
+use serde::{de::Error, Deserializer};
 
-use serde::{
-    de::{Error, Visitor},
-    Deserializer,
-};
+use crate::shared::{deserialize_with_hex_or_bytes, HexOrBytesConvert};
 
-use crate::shared;
+impl<const N: usize> HexOrBytesConvert<'_> for [u8; N] {
+    fn from_bytes<E: Error>(bytes: &[u8]) -> Result<Self, E> {
+        bytes.try_into().map_err(E::custom)
+    }
+
+    fn from_hex_digits<E: Error>(digits: &str) -> Result<Self, E> {
+        let mut bytes = [0; N];
+        const_hex::decode_to_slice(digits, &mut bytes).map_err(E::custom)?;
+        Ok(bytes)
+    }
+}
 
 pub fn deserialize<'de, D: Deserializer<'de>, const N: usize>(
     deserializer: D,
 ) -> Result<[u8; N], D::Error> {
-    struct ArrayVisitor<const N: usize> {
-        human_readable: bool,
-    }
-
-    impl<const N: usize> Visitor<'_> for ArrayVisitor<N> {
-        type Value = [u8; N];
-
-        fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
-            formatter.write_str(shared::expecting_prefixed_hex_or_bytes(self.human_readable))
-        }
-
-        fn visit_bytes<E: Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
-            bytes.try_into().map_err(E::custom)
-        }
-
-        fn visit_str<E: Error>(self, string: &str) -> Result<Self::Value, E> {
-            let digits = shared::strip_hex_prefix(string)?;
-
-            let mut bytes = [0; N];
-            const_hex::decode_to_slice(digits, &mut bytes).map_err(E::custom)?;
-
-            Ok(bytes)
-        }
-    }
-
-    let human_readable = deserializer.is_human_readable();
-    let visitor = ArrayVisitor { human_readable };
-
-    if human_readable {
-        deserializer.deserialize_str(visitor)
-    } else {
-        deserializer.deserialize_bytes(visitor)
-    }
+    deserialize_with_hex_or_bytes(deserializer)
 }

--- a/serde_utils/src/prefixed_hex_or_bytes_cow.rs
+++ b/serde_utils/src/prefixed_hex_or_bytes_cow.rs
@@ -1,50 +1,28 @@
-use core::fmt::{Formatter, Result as FmtResult};
 use std::borrow::Cow;
 
-use serde::{
-    de::{Error, Visitor},
-    Deserializer,
-};
+use serde::{de::Error, Deserializer};
 
-use crate::shared;
+use crate::shared::{deserialize_with_hex_or_bytes, HexOrBytesConvert};
+
+impl<'de> HexOrBytesConvert<'de> for Cow<'de, [u8]> {
+    fn from_borrowed_bytes<E: Error>(bytes: &'de [u8]) -> Result<Self, E> {
+        Ok(Cow::Borrowed(bytes))
+    }
+
+    fn from_byte_buf<E: Error>(bytes: Vec<u8>) -> Result<Self, E> {
+        Ok(Cow::Owned(bytes))
+    }
+
+    fn from_bytes<E: Error>(bytes: &[u8]) -> Result<Self, E> {
+        Ok(Cow::Owned(bytes.to_owned()))
+    }
+
+    fn from_hex_digits<E: Error>(digits: &str) -> Result<Self, E> {
+        let bytes = const_hex::decode(digits).map_err(E::custom)?;
+        Ok(Cow::Owned(bytes))
+    }
+}
 
 pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Cow<'de, [u8]>, D::Error> {
-    struct CowVisitor {
-        human_readable: bool,
-    }
-
-    impl<'de> Visitor<'de> for CowVisitor {
-        type Value = Cow<'de, [u8]>;
-
-        fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
-            formatter.write_str(shared::expecting_prefixed_hex_or_bytes(self.human_readable))
-        }
-
-        fn visit_borrowed_bytes<E>(self, bytes: &'de [u8]) -> Result<Self::Value, E> {
-            Ok(Cow::Borrowed(bytes))
-        }
-
-        fn visit_byte_buf<E>(self, bytes: Vec<u8>) -> Result<Self::Value, E> {
-            Ok(Cow::Owned(bytes))
-        }
-
-        fn visit_bytes<E>(self, bytes: &[u8]) -> Result<Self::Value, E> {
-            Ok(Cow::Owned(bytes.to_owned()))
-        }
-
-        fn visit_str<E: Error>(self, string: &str) -> Result<Self::Value, E> {
-            let digits = shared::strip_hex_prefix(string)?;
-            let bytes = const_hex::decode(digits).map_err(E::custom)?;
-            Ok(Cow::Owned(bytes))
-        }
-    }
-
-    let human_readable = deserializer.is_human_readable();
-    let visitor = CowVisitor { human_readable };
-
-    if human_readable {
-        deserializer.deserialize_str(visitor)
-    } else {
-        deserializer.deserialize_bytes(visitor)
-    }
+    deserialize_with_hex_or_bytes(deserializer)
 }

--- a/serde_utils/src/shared.rs
+++ b/serde_utils/src/shared.rs
@@ -1,4 +1,9 @@
-use serde::de::Error;
+use core::fmt::{Formatter, Result as FmtResult};
+
+use serde::{
+    de::{Error, Visitor},
+    Deserializer,
+};
 
 pub trait Sortable {
     fn key(&self) -> impl Ord;
@@ -16,4 +21,65 @@ pub(crate) fn strip_hex_prefix<E: Error>(string: &str) -> Result<&str, E> {
     string
         .strip_prefix("0x")
         .ok_or_else(|| E::custom("string does not have hexadecimal prefix"))
+}
+
+ub(crate) trait HexOrBytesConvert<'de>: Sized {
+    fn from_bytes<E: Error>(bytes: &[u8]) -> Result<Self, E>;
+    fn from_hex_digits<E: Error>(digits: &str) -> Result<Self, E>;
+    
+    fn from_borrowed_bytes<E: Error>(bytes: &'de [u8]) -> Result<Self, E> {
+        Self::from_bytes(bytes)
+    }
+    
+    fn from_byte_buf<E: Error>(bytes: Vec<u8>) -> Result<Self, E> {
+        Self::from_bytes(&bytes)
+    }
+}
+
+pub(crate) struct HexOrBytesVisitor<'de, T: HexOrBytesConvert<'de>> {
+    human_readable: bool,
+    _phantom: core::marker::PhantomData<fn() -> &'de T>,
+}
+
+impl<'de, T: HexOrBytesConvert<'de>> Visitor<'de> for HexOrBytesVisitor<'de, T> {
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+        formatter.write_str(expecting_prefixed_hex_or_bytes(self.human_readable))
+    }
+
+    fn visit_borrowed_bytes<E: Error>(self, bytes: &'de [u8]) -> Result<Self::Value, E> {
+        T::from_borrowed_bytes(bytes)
+    }
+
+    fn visit_byte_buf<E: Error>(self, bytes: Vec<u8>) -> Result<Self::Value, E> {
+        T::from_byte_buf(bytes)
+    }
+
+    fn visit_bytes<E: Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
+        T::from_bytes(bytes)
+    }
+
+    fn visit_str<E: Error>(self, string: &str) -> Result<Self::Value, E> {
+        let digits = strip_hex_prefix(string)?;
+        T::from_hex_digits(digits)
+    }
+}
+
+pub(crate) fn deserialize_with_hex_or_bytes<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: HexOrBytesConvert<'de>,
+{
+    let human_readable = deserializer.is_human_readable();
+    let visitor = HexOrBytesVisitor {
+        human_readable,
+        _phantom: core::marker::PhantomData,
+    };
+
+    if human_readable {
+        deserializer.deserialize_str(visitor)
+    } else {
+        deserializer.deserialize_bytes(visitor)
+    }
 }


### PR DESCRIPTION
## Summary

Refactored hex/bytes deserialization by introducing a common `HexOrBytesConvert` trait, eliminating ~80 lines of duplicated Visitor boilerplate across 3 modules.

## Changes

- Added `HexOrBytesConvert` trait and unified `HexOrBytesVisitor` to `shared.rs`
- Simplified `prefixed_hex_or_bytes_{array,cow,generic_array}.rs` 

Each type now only implements conversion logic while sharing common deserialization infrastructure.