### PR TITLE
feat: enable internal block building route for gloas

### DIFF
--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -105,7 +105,7 @@ const PAYLOAD_ID_CACHE_SIZE: usize = 10;
 
 pub type ExecutionPayloadHeaderJoinHandle<P> = JoinHandle<Result<Option<SignedBuilderBid<P>>>>;
 pub type LocalExecutionPayloadJoinHandle<P> =
-    JoinHandle<Option<(WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>, H256)>>;
+    JoinHandle<Option<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>>>;
 
 type PayloadCache<P> =
     Mutex<SizedCache<H256, WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>>>;
@@ -1152,27 +1152,20 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         let can_self_build = !self.beacon_state.is_post_gloas()
             || predicates::has_builder_withdrawal_credential(self.proposer()?);
 
-        let (payload_with_data, payload_root) = if can_self_build {
+        let payload_with_data = if can_self_build {
             if let Some(handle) = local_execution_payload_handle {
-                match handle.await? {
-                    Some((payload, root)) => (
-                        Some(payload.map(|value| value.map(Some))),
-                        Some(root),
-                    ),
-                    None => (None, None),
-                }
+                handle
+                    .await?
+                    .map(|value| value.map(|value| value.map(Some)))
             } else {
-                (None, None)
+                None
             }
         } else {
             // To prevent return error in payload_with_data check
-            (
-                Some(WithClientVersions {
-                    client_versions: Some(vec![ClientVersionV1::own()].into()),
-                    result: WithBlobsAndMev::with_default(None),
-                }),
-                None,
-            )
+            Some(WithClientVersions {
+                client_versions: Some(vec![ClientVersionV1::own()].into()),
+                result: WithBlobsAndMev::with_default(None),
+            })
         };
 
         let WithClientVersions {
@@ -1200,9 +1193,11 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         };
 
         // Cache payload root for Gloas envelope retrieval later (only when self-building)
-        // payload_root already computed in local_execution_payload_result, no need to recompute
+        // External builders publish their own envelope
         if can_self_build && self.beacon_state.phase() >= Phase::Gloas {
-            *self.cached_payload_root.lock().await = payload_root;
+            if let Some(ref payload) = execution_payload {
+                *self.cached_payload_root.lock().await = Some(payload.hash_tree_root());
+            }
         }
 
         let mut without_state_root = if let Some(state) = self.beacon_state.post_gloas() {
@@ -1978,7 +1973,7 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
 
     async fn local_execution_payload_result(
         &self,
-    ) -> Result<Option<(WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>, H256)>> {
+    ) -> Result<Option<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>>> {
         let snapshot = self.producer_context.controller.snapshot();
 
         let mut payload_id = self
@@ -2073,16 +2068,15 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             .await
             .cache_set(payload_root, payload.clone());
 
-        Ok(Some((payload, payload_root)))
+        Ok(Some(payload))
     }
 
     // If the local execution engine fails, a block can still be constructed with a payload received
     // from an external block builder or even the default payload, though blocks with default
     // payloads are only valid before the Merge.
-    // Returns (payload, payload_root) to avoid recomputing hash_tree_root
     async fn local_execution_payload_option(
         &self,
-    ) -> Option<(WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>, H256)> {
+    ) -> Option<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>> {
         if self.producer_context.fake_execution_payloads {
             let slot = self.beacon_state.slot();
 
@@ -2101,11 +2095,9 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
 
                 match execution_payload {
                     Ok(payload) => {
-                        let payload_root = payload.hash_tree_root();
-                        return Some((
-                            WithClientVersions::none(WithBlobsAndMev::with_default(payload)),
-                            payload_root,
-                        ))
+                        return Some(WithClientVersions::none(WithBlobsAndMev::with_default(
+                            payload,
+                        )))
                     }
                     Err(error) => panic!("failed to produce fake payload: {error:?}"),
                 };

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -1953,11 +1953,20 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             signature: SignatureBytes::default(),
         };
 
-        let BeaconState::Gloas(ref gloas_state) = *self.beacon_state else {
-            return Err(AnyhowError::msg("compute_post_execution_state_root requires Gloas state"));
+        let mut post_execution_state = match &*self.beacon_state {
+            BeaconState::Phase0(_)
+            | BeaconState::Altair(_)
+            | BeaconState::Bellatrix(_)
+            | BeaconState::Capella(_)
+            | BeaconState::Deneb(_)
+            | BeaconState::Electra(_)
+            | BeaconState::Fulu(_) => {
+                return Err(AnyhowError::msg(
+                    "compute_post_execution_state_root requires Gloas state",
+                ));
+            }
+            BeaconState::Gloas(gloas_state) => gloas_state.clone(),
         };
-
-        let mut post_execution_state = gloas_state.clone();
 
         gloas::process_execution_payload(
             &self.producer_context.chain_config,

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -36,6 +36,8 @@ use tap::Pipe as _;
 use tokio::task::JoinHandle;
 use tracing::instrument;
 use transition_functions::{capella, electra, gloas, unphased};
+use helper_functions::verifier::NullVerifier;
+use types::gloas::containers::{ExecutionPayloadEnvelope, SignedExecutionPayloadEnvelope};
 use try_from_iterator::TryFromIterator as _;
 use typenum::Unsigned as _;
 use types::{
@@ -174,6 +176,7 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
             head_block_root,
             proposer_index,
             options,
+            cached_payload_root: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -648,6 +651,8 @@ pub struct BlockBuildContext<P: Preset, W: Wait> {
     head_block_root: H256,
     proposer_index: ValidatorIndex,
     options: BlockBuildOptions,
+    /// Payload root for retrieving cached envelope data from payload_cache
+    cached_payload_root: Arc<Mutex<Option<H256>>>,
 }
 
 impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
@@ -1186,6 +1191,14 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                 WithClientVersions::none(WithBlobsAndMev::with_default(None))
             }
         };
+
+        // Cache payload root for Gloas envelope retrieval later (only when self-building)
+        // External builders publish their own envelope
+        if can_self_build && self.beacon_state.phase() >= Phase::Gloas {
+            if let Some(ref payload) = execution_payload {
+                *self.cached_payload_root.lock().await = Some(payload.hash_tree_root());
+            }
+        }
 
         let mut without_state_root = if let Some(state) = self.beacon_state.post_gloas() {
             let signed_payload_bid = if can_self_build {
@@ -1869,6 +1882,95 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             tokio::spawn(async move { builder_context.local_execution_payload_option().await });
 
         Some(handle)
+    }
+
+    /// Get cached Gloas envelope data from payload_cache (called by validator after signing block)
+    /// Returns None if not self-building (external builder publishes envelope)
+    /// Returns only the fields needed to build ExecutionPayloadEnvelope
+    pub async fn get_gloas_envelope_data(
+        &self,
+    ) -> Option<(
+        DenebExecutionPayload<P>,
+        ExecutionRequests<P>,
+        ContiguousList<KzgCommitment, P::MaxBlobCommitmentsPerBlock>,
+    )> {
+        let payload_root = (*self.cached_payload_root.lock().await)?;
+
+        let cached = self
+            .producer_context
+            .payload_cache
+            .lock()
+            .await
+            .cache_get(&payload_root)
+            .cloned()?;
+
+        let WithBlobsAndMev {
+            value: execution_payload,
+            commitments,
+            execution_requests,
+            ..
+        } = cached.result;
+
+        let deneb_payload = match execution_payload {
+            ExecutionPayload::Deneb(p) => p,
+            _ => {
+                warn_with_peers!(
+                    "unexpected non-Deneb payload format in Gloas envelope data"
+                );
+                return None;
+            }
+        };
+
+        Some((
+            deneb_payload,
+            execution_requests.unwrap_or_default(),
+            commitments.unwrap_or_default(),
+        ))
+    }
+
+    /// Compute the post-execution state root for the envelope
+    pub async fn compute_post_execution_state_root(
+        &self,
+        beacon_block_root: H256,
+        builder_index: ValidatorIndex,
+    ) -> Result<H256> {
+        let (deneb_payload, execution_requests_data, blob_kzg_commitments) = self
+            .get_gloas_envelope_data()
+            .await
+            .ok_or_else(|| AnyhowError::msg("envelope data not available"))?;
+
+        // Build envelope with placeholder state_root (will be set after processing)
+        let envelope = ExecutionPayloadEnvelope {
+            payload: deneb_payload.into(),
+            execution_requests: execution_requests_data,
+            builder_index,
+            beacon_block_root,
+            slot: self.beacon_state.slot(),
+            blob_kzg_commitments,
+            state_root: H256::zero(), // Placeholder
+        };
+
+        let signed_envelope = SignedExecutionPayloadEnvelope {
+            message: envelope,
+            signature: SignatureBytes::default(),
+        };
+
+        let BeaconState::Gloas(ref gloas_state) = *self.beacon_state else {
+            return Err(AnyhowError::msg("compute_post_execution_state_root requires Gloas state"));
+        };
+
+        let mut post_execution_state = gloas_state.clone();
+
+        gloas::process_execution_payload(
+            &self.producer_context.chain_config,
+            &self.producer_context.pubkey_cache,
+            &mut post_execution_state,
+            &signed_envelope,
+            self.producer_context.execution_engine.as_ref(),
+            NullVerifier,
+        )?;
+
+        Ok(post_execution_state.hash_tree_root())
     }
 
     async fn local_execution_payload_result(

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -156,6 +156,7 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
             voluntary_exits: Mutex::new(vec![]),
             payload_cache: Mutex::new(SizedCache::with_size(PAYLOAD_CACHE_SIZE)),
             payload_id_cache: Mutex::new(SizedCache::with_size(PAYLOAD_ID_CACHE_SIZE)),
+            cached_payload_roots: Mutex::new(SizedCache::with_size(PAYLOAD_CACHE_SIZE)),
             metrics,
             fake_execution_payloads,
         });
@@ -176,7 +177,6 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
             head_block_root,
             proposer_index,
             options,
-            cached_payload_root: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -632,6 +632,8 @@ struct ProducerContext<P: Preset, W: Wait> {
     voluntary_exits: Mutex<Vec<SignedVoluntaryExit>>,
     payload_cache: PayloadCache<P>,
     payload_id_cache: Mutex<SizedCache<(H256, Slot), PayloadId>>,
+    /// Cached payload roots keyed by beacon_block_root for envelope retrieval
+    cached_payload_roots: Mutex<SizedCache<H256, H256>>,
     metrics: Option<Arc<Metrics>>,
     fake_execution_payloads: bool,
 }
@@ -651,8 +653,6 @@ pub struct BlockBuildContext<P: Preset, W: Wait> {
     head_block_root: H256,
     proposer_index: ValidatorIndex,
     options: BlockBuildOptions,
-    /// Payload root for retrieving cached envelope data from payload_cache
-    cached_payload_root: Arc<Mutex<Option<H256>>>,
 }
 
 impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
@@ -1196,7 +1196,11 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         // External builders publish their own envelope
         if can_self_build && self.beacon_state.phase() >= Phase::Gloas {
             if let Some(ref payload) = execution_payload {
-                *self.cached_payload_root.lock().await = Some(payload.hash_tree_root());
+                self.producer_context
+                    .cached_payload_roots
+                    .lock()
+                    .await
+                    .cache_set(self.head_block_root, payload.hash_tree_root());
             }
         }
 
@@ -1894,7 +1898,12 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         ExecutionRequests<P>,
         ContiguousList<KzgCommitment, P::MaxBlobCommitmentsPerBlock>,
     )> {
-        let payload_root = (*self.cached_payload_root.lock().await)?;
+        let payload_root = *self
+            .producer_context
+            .cached_payload_roots
+            .lock()
+            .await
+            .cache_get(&self.head_block_root)?;
 
         let cached = self
             .producer_context

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -105,7 +105,7 @@ const PAYLOAD_ID_CACHE_SIZE: usize = 10;
 
 pub type ExecutionPayloadHeaderJoinHandle<P> = JoinHandle<Result<Option<SignedBuilderBid<P>>>>;
 pub type LocalExecutionPayloadJoinHandle<P> =
-    JoinHandle<Option<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>>>;
+    JoinHandle<Option<(WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>, H256)>>;
 
 type PayloadCache<P> =
     Mutex<SizedCache<H256, WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>>>;
@@ -1152,20 +1152,27 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         let can_self_build = !self.beacon_state.is_post_gloas()
             || predicates::has_builder_withdrawal_credential(self.proposer()?);
 
-        let payload_with_data = if can_self_build {
+        let (payload_with_data, payload_root) = if can_self_build {
             if let Some(handle) = local_execution_payload_handle {
-                handle
-                    .await?
-                    .map(|value| value.map(|value| value.map(Some)))
+                match handle.await? {
+                    Some((payload, root)) => (
+                        Some(payload.map(|value| value.map(Some))),
+                        Some(root),
+                    ),
+                    None => (None, None),
+                }
             } else {
-                None
+                (None, None)
             }
         } else {
             // To prevent return error in payload_with_data check
-            Some(WithClientVersions {
-                client_versions: Some(vec![ClientVersionV1::own()].into()),
-                result: WithBlobsAndMev::with_default(None),
-            })
+            (
+                Some(WithClientVersions {
+                    client_versions: Some(vec![ClientVersionV1::own()].into()),
+                    result: WithBlobsAndMev::with_default(None),
+                }),
+                None,
+            )
         };
 
         let WithClientVersions {
@@ -1193,11 +1200,9 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         };
 
         // Cache payload root for Gloas envelope retrieval later (only when self-building)
-        // External builders publish their own envelope
+        // payload_root already computed in local_execution_payload_result, no need to recompute
         if can_self_build && self.beacon_state.phase() >= Phase::Gloas {
-            if let Some(ref payload) = execution_payload {
-                *self.cached_payload_root.lock().await = Some(payload.hash_tree_root());
-            }
+            *self.cached_payload_root.lock().await = payload_root;
         }
 
         let mut without_state_root = if let Some(state) = self.beacon_state.post_gloas() {
@@ -1975,7 +1980,7 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
 
     async fn local_execution_payload_result(
         &self,
-    ) -> Result<Option<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>>> {
+    ) -> Result<Option<(WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>, H256)>> {
         let snapshot = self.producer_context.controller.snapshot();
 
         let mut payload_id = self
@@ -2070,15 +2075,16 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             .await
             .cache_set(payload_root, payload.clone());
 
-        Ok(Some(payload))
+        Ok(Some((payload, payload_root)))
     }
 
     // If the local execution engine fails, a block can still be constructed with a payload received
     // from an external block builder or even the default payload, though blocks with default
     // payloads are only valid before the Merge.
+    // Returns (payload, payload_root) to avoid recomputing hash_tree_root
     async fn local_execution_payload_option(
         &self,
-    ) -> Option<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>> {
+    ) -> Option<(WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>, H256)> {
         if self.producer_context.fake_execution_payloads {
             let slot = self.beacon_state.slot();
 
@@ -2097,9 +2103,11 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
 
                 match execution_payload {
                     Ok(payload) => {
-                        return Some(WithClientVersions::none(WithBlobsAndMev::with_default(
-                            payload,
-                        )))
+                        let payload_root = payload.hash_tree_root();
+                        return Some((
+                            WithClientVersions::none(WithBlobsAndMev::with_default(payload)),
+                            payload_root,
+                        ))
                     }
                     Err(error) => panic!("failed to produce fake payload: {error:?}"),
                 };

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -1934,16 +1934,14 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
     }
 
     /// Compute the post-execution state root for the envelope
-    pub async fn compute_post_execution_state_root(
+    pub fn compute_post_execution_state_root(
         &self,
         beacon_block_root: H256,
         builder_index: ValidatorIndex,
+        deneb_payload: DenebExecutionPayload<P>,
+        execution_requests_data: ExecutionRequests<P>,
+        blob_kzg_commitments: ContiguousList<KzgCommitment, P::MaxBlobCommitmentsPerBlock>,
     ) -> Result<H256> {
-        let (deneb_payload, execution_requests_data, blob_kzg_commitments) = self
-            .get_gloas_envelope_data()
-            .await
-            .ok_or_else(|| AnyhowError::msg("envelope data not available"))?;
-
         // Build envelope with placeholder state_root (will be set after processing)
         let envelope = ExecutionPayloadEnvelope {
             payload: deneb_payload.into(),

--- a/block_producer/src/lib.rs
+++ b/block_producer/src/lib.rs
@@ -1,4 +1,4 @@
-pub use block_producer::{BlockBuildOptions, BlockProducer, Options};
+pub use block_producer::{BlockBuildContext, BlockBuildOptions, BlockProducer, Options};
 pub use misc::{ProposerData, ValidatorBlindedBlock};
 
 mod block_producer;

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -30,7 +30,7 @@ use fork_choice_store::{
 };
 use futures::channel::{mpsc::Sender as MultiSender, oneshot::Sender as OneshotSender};
 use genesis::AnchorCheckpointProvider;
-use logging::debug_with_peers;
+use logging::{debug_with_peers, info_with_peers};
 use prometheus_metrics::Metrics;
 use pubkey_cache::PubkeyCache;
 use std_ext::ArcExt as _;
@@ -324,6 +324,42 @@ where
             true,
             DataColumnSidecarOrigin::Own,
         )
+    }
+
+    pub fn on_own_execution_payload_envelope(
+        &self,
+        wait_group: W,
+        envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
+    ) {
+        // TODO (gloas): Implement direct task spawn (from commit ad16f5c4a3e6f2d4931ea92fa35e9c4d6564ca80)
+        //
+        // This should spawn ExecutionPayloadEnvelopeTask DIRECTLY with Origin::Own
+        //
+        //   self.spawn(ExecutionPayloadEnvelopeTask {
+        //       store_snapshot: self.owned_store_snapshot(),
+        //       mutator_tx: self.owned_mutator_tx(),
+        //       wait_group,
+        //       envelope,
+        //       beacon_block_seen: true,  // we published the block ourselves
+        //    - origin: ExecutionPayloadEnvelopeOrigin::Own
+        //    - submission_time: Instant::now()
+        //
+        // 2. Task validates envelope:
+        //    - Signature check (builder domain)
+        //    - Link to block via beacon_block_root
+        //    - Builder index matches block bid
+        //
+        // 3. Mutator processes result:
+        //    - Trigger fork choice update
+        //    - Process execution payload in state transition
+        //
+        // For now, just log until task changes is merged through ad16f5c4a
+        info_with_peers!(
+            "publishing own execution payload envelope (block_root: {:?}, slot: {}, builder_index: {})",
+            envelope.message.beacon_block_root,
+            envelope.message.slot,
+            envelope.message.builder_index,
+        );
     }
 
     pub fn on_api_data_column_sidecar(

--- a/p2p/src/messages.rs
+++ b/p2p/src/messages.rs
@@ -215,6 +215,7 @@ pub enum ValidatorToP2p<P: Preset> {
     PublishBeaconBlock(Arc<SignedBeaconBlock<P>>),
     PublishBlobSidecar(Arc<BlobSidecar<P>>),
     PublishDataColumnSidecar(Arc<DataColumnSidecar<P>>),
+    PublishExecutionPayloadEnvelope(Arc<SignedExecutionPayloadEnvelope<P>>),
     PublishSingularAttestation(Arc<Attestation<P>>, SubnetId),
     PublishAggregateAndProof(Arc<SignedAggregateAndProof<P>>),
     PublishSyncCommitteeMessage(Box<(SubnetId, SyncCommitteeMessage)>),

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -62,7 +62,7 @@ use types::{
         containers::{DataColumnIdentifier, DataColumnsByRootIdentifier},
         primitives::ColumnIndex,
     },
-    gloas::containers::PayloadAttestationMessage,
+    gloas::containers::{PayloadAttestationMessage, SignedExecutionPayloadEnvelope},
     nonstandard::{Phase, RelativeEpoch, WithStatus},
     phase0::{
         consts::{FAR_FUTURE_EPOCH, GENESIS_EPOCH},
@@ -531,6 +531,9 @@ impl<P: Preset> Network<P> {
                         ValidatorToP2p::PublishDataColumnSidecar(data_column_sidecar) => {
                             self.publish_data_column_sidecar(data_column_sidecar);
                         }
+                        ValidatorToP2p::PublishExecutionPayloadEnvelope(envelope) => {
+                            self.publish_execution_payload_envelope(envelope);
+                        }
                         ValidatorToP2p::PublishSingularAttestation(attestation, subnet_id) => {
                             self.publish_singular_attestation(attestation, subnet_id);
                         }
@@ -780,6 +783,17 @@ impl<P: Preset> Network<P> {
             subnet_id,
             data_column_sidecar,
         ))));
+    }
+
+    fn publish_execution_payload_envelope(&self, envelope: Arc<SignedExecutionPayloadEnvelope<P>>) {
+        debug_with_peers!(
+            "publishing execution payload envelope (block_root: {:?}, slot: {}, builder_index: {})",
+            envelope.message.beacon_block_root,
+            envelope.message.slot,
+            envelope.message.builder_index,
+        );
+
+        self.publish(PubsubMessage::ExecutionPayload(envelope));
     }
 
     fn publish_singular_attestation(&self, attestation: Arc<Attestation<P>>, subnet_id: SubnetId) {

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,5 +1,5 @@
 pub use crate::{
-    signer::{KeyOrigin, Signer},
+    signer::{KeyOrigin, Signer, Snapshot},
     types::{ForkInfo, SigningMessage, SigningTriple},
     web3signer::Config as Web3SignerConfig,
 };

--- a/signer/src/signer.rs
+++ b/signer/src/signer.rs
@@ -348,7 +348,8 @@ impl Snapshot {
                 | SigningMessage::SyncAggregatorSelectionData(_)
                 | SigningMessage::ContributionAndProof(_)
                 | SigningMessage::ValidatorRegistration(_)
-                | SigningMessage::VoluntaryExit(_) => {
+                | SigningMessage::VoluntaryExit(_)
+                | SigningMessage::ExecutionPayloadEnvelope(_) => {
                     signable_messages.push(SigningTriple {
                         message,
                         signing_root,

--- a/signer/src/types.rs
+++ b/signer/src/types.rs
@@ -22,7 +22,9 @@ use types::{
     fulu::containers::{
         BeaconBlock as FuluBeaconBlock, BlindedBeaconBlock as FuluBlindedBeaconBlock,
     },
-    gloas::containers::{BeaconBlock as GloasBeaconBlock, PayloadAttestationData},
+    gloas::containers::{
+        BeaconBlock as GloasBeaconBlock, ExecutionPayloadEnvelope, PayloadAttestationData,
+    },
     phase0::{
         containers::{
             AttestationData, BeaconBlock as Phase0BeaconBlock, BeaconBlockHeader, Fork,
@@ -74,6 +76,7 @@ pub enum SigningMessage<'block, P: Preset> {
         epoch: Epoch,
     },
     PayloadAttestation(PayloadAttestationData),
+    ExecutionPayloadEnvelope(&'block ExecutionPayloadEnvelope<P>),
     SyncCommitteeMessage {
         beacon_block_root: H256,
         #[serde(with = "serde_utils::string_or_native")]

--- a/signer/src/web3signer/types.rs
+++ b/signer/src/web3signer/types.rs
@@ -40,6 +40,7 @@ impl<'block, P: Preset> SigningRequest<'block, P> {
             }
             SigningMessage::ValidatorRegistration(_) => MessageType::ValidatorRegistration,
             SigningMessage::VoluntaryExit(_) => MessageType::VoluntaryExit,
+            SigningMessage::ExecutionPayloadEnvelope(_) => MessageType::ExecutionPayloadEnvelope,
         };
 
         Self {
@@ -66,6 +67,7 @@ enum MessageType {
     SyncCommitteeContributionAndProof,
     ValidatorRegistration,
     VoluntaryExit,
+    ExecutionPayloadEnvelope,
 }
 
 #[derive(Debug, Deserialize)]
@@ -94,6 +96,7 @@ mod tests {
                 "SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF",
                 "VALIDATOR_REGISTRATION",
                 "VOLUNTARY_EXIT",
+                "EXECUTION_PAYLOAD_ENVELOPE",
             ],
         );
     }

--- a/transition_functions/src/lib.rs
+++ b/transition_functions/src/lib.rs
@@ -238,6 +238,7 @@ pub mod fulu {
 
 pub mod gloas {
     pub use block_processing::get_expected_withdrawals;
+    pub use execution_payload_processing::process_execution_payload;
     pub(crate) use block_processing::{process_block, process_block_for_gossip};
     pub(crate) use epoch_processing::{epoch_report, process_epoch};
     pub(crate) use slot_processing::process_slots;
@@ -246,7 +247,7 @@ pub mod gloas {
     mod block_processing;
     mod epoch_intermediates;
     mod epoch_processing;
-    mod execution_payload_processing;
+    pub mod execution_payload_processing;
     mod slot_processing;
     mod state_transition;
 }

--- a/transition_functions/src/lib.rs
+++ b/transition_functions/src/lib.rs
@@ -247,7 +247,7 @@ pub mod gloas {
     mod block_processing;
     mod epoch_intermediates;
     mod epoch_processing;
-    pub mod execution_payload_processing;
+    mod execution_payload_processing;
     mod slot_processing;
     mod state_transition;
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1150,10 +1150,13 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
                     // Compute state_root by calling process_execution_payload(verify=false)
                     // then hash_tree_root(state). This is the post-execution beacon state root
-                    let state_root = match block_build_context
-                        .compute_post_execution_state_root(beacon_block_root, proposer_index)
-                        .await
-                    {
+                    let state_root = match block_build_context.compute_post_execution_state_root(
+                        beacon_block_root,
+                        proposer_index,
+                        deneb_payload.clone(),
+                        execution_requests_data.clone(),
+                        blob_kzg_commitments.clone(),
+                    ) {
                         Ok(root) => root,
                         Err(error) => {
                             warn_with_peers!(

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1143,89 +1143,117 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                 ValidatorToP2p::PublishBeaconBlock(block.clone_arc()).send(&self.p2p_tx);
 
                 // Handle Gloas execution payload envelope (only for self-build)
-                if let Some((deneb_payload, execution_requests_data, blob_kzg_commitments)) =
-                    block_build_context.get_gloas_envelope_data().await
-                {
-                    let beacon_block_root = block.message().hash_tree_root();
-
-                    // Compute state_root by calling process_execution_payload(verify=false)
-                    // then hash_tree_root(state). This is the post-execution beacon state root
-                    let state_root = match block_build_context.compute_post_execution_state_root(
-                        beacon_block_root,
-                        proposer_index,
-                        deneb_payload.clone(),
-                        execution_requests_data.clone(),
-                        blob_kzg_commitments.clone(),
-                    ) {
-                        Ok(root) => root,
-                        Err(error) => {
-                            warn_with_peers!(
-                                "failed to compute post-execution state root (slot: {}): {error:?}",
-                                slot_head.slot(),
-                            );
-                            return Ok(());
-                        }
-                    };
-
-                    let envelope = ExecutionPayloadEnvelope {
-                        payload: deneb_payload.into(),
-                        execution_requests: execution_requests_data,
-                        builder_index: proposer_index,
-                        beacon_block_root,
-                        slot: slot_head.slot(),
-                        blob_kzg_commitments,
-                        state_root,
-                    };
-
-                    // Sign the envelope
-                    let envelope_signing_root = envelope.signing_root(&self.chain_config, &slot_head.beacon_state);
-                    let envelope_sig = match signer_snapshot
-                        .sign_without_slashing_protection(
-                            SigningMessage::ExecutionPayloadEnvelope(&envelope),
-                            envelope_signing_root,
-                            Some(slot_head.beacon_state.as_ref().into()),
-                            *public_key,
-                        )
-                        .await
-                    {
-                        Ok(signature) => SignatureBytes::from(signature),
-                        Err(error) => {
-                            warn_with_peers!(
-                                "failed to sign execution payload envelope (slot: {}, public_key: {public_key}): \
-                                {error:?}",
-                                slot_head.slot(),
-                            );
-                            return Ok(());
-                        }
-                    };
-
-                    let signed_envelope = Arc::new(SignedExecutionPayloadEnvelope {
-                        message: envelope,
-                        signature: envelope_sig,
-                    });
-
-                    info_with_peers!(
-                        "validator {} publishing execution payload envelope for block {:?} in slot {}",
-                        proposer_index,
-                        signed_envelope.message.beacon_block_root,
-                        slot_head.slot(),
-                    );
-
-                    // Publish envelope to controller and P2P
-                    self.controller.on_own_execution_payload_envelope(
-                        wait_group.clone(),
-                        signed_envelope.clone_arc(),
-                    );
-
-                    ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope)
-                        .send(&self.p2p_tx);
-                }
+                self.publish_gloas_envelope(
+                    &block_build_context,
+                    &block,
+                    proposer_index,
+                    slot_head,
+                    &signer_snapshot,
+                    public_key,
+                    wait_group.clone(),
+                )
+                .await?;
             }
         }
 
         if let Some(metrics) = self.metrics.as_ref() {
             metrics.validator_propose_successes.inc();
         }
+
+        Ok(())
+    }
+
+    /// Publish Gloas execution payload envelope for self-build proposers.
+    /// Only publishes if envelope data is available (i.e., self-building).
+    async fn publish_gloas_envelope(
+        &self,
+        block_build_context: &block_producer::BlockBuildContext<P, W>,
+        block: &Arc<types::combined::SignedBeaconBlock<P>>,
+        proposer_index: ValidatorIndex,
+        slot_head: &SlotHead<P>,
+        signer_snapshot: &signer::Snapshot,
+        public_key: &PublicKeyBytes,
+        wait_group: W,
+    ) -> Result<()> {
+        let Some((deneb_payload, execution_requests_data, blob_kzg_commitments)) =
+            block_build_context.get_gloas_envelope_data().await
+        else {
+            return Ok(());
+        };
+
+        let beacon_block_root = block.message().hash_tree_root();
+
+        // Compute state_root by calling process_execution_payload(verify=false)
+        // then hash_tree_root(state). This is the post-execution beacon state root
+        let state_root = match block_build_context.compute_post_execution_state_root(
+            beacon_block_root,
+            proposer_index,
+            deneb_payload.clone(),
+            execution_requests_data.clone(),
+            blob_kzg_commitments.clone(),
+        ) {
+            Ok(root) => root,
+            Err(error) => {
+                warn_with_peers!(
+                    "failed to compute post-execution state root (slot: {}): {error:?}",
+                    slot_head.slot(),
+                );
+                return Ok(());
+            }
+        };
+
+        let envelope = ExecutionPayloadEnvelope {
+            payload: deneb_payload.into(),
+            execution_requests: execution_requests_data,
+            builder_index: proposer_index,
+            beacon_block_root,
+            slot: slot_head.slot(),
+            blob_kzg_commitments,
+            state_root,
+        };
+
+        // Sign the envelope
+        let envelope_signing_root =
+            envelope.signing_root(&self.chain_config, &slot_head.beacon_state);
+        let envelope_sig = match signer_snapshot
+            .sign_without_slashing_protection(
+                SigningMessage::ExecutionPayloadEnvelope(&envelope),
+                envelope_signing_root,
+                Some(slot_head.beacon_state.as_ref().into()),
+                *public_key,
+            )
+            .await
+        {
+            Ok(signature) => SignatureBytes::from(signature),
+            Err(error) => {
+                warn_with_peers!(
+                    "failed to sign execution payload envelope (slot: {}, public_key: {public_key}): \
+                    {error:?}",
+                    slot_head.slot(),
+                );
+                return Ok(());
+            }
+        };
+
+        let signed_envelope = Arc::new(SignedExecutionPayloadEnvelope {
+            message: envelope,
+            signature: envelope_sig,
+        });
+
+        info_with_peers!(
+            "validator {} publishing execution payload envelope for block {:?} in slot {}",
+            proposer_index,
+            signed_envelope.message.beacon_block_root,
+            slot_head.slot(),
+        );
+
+        // Publish envelope to controller and P2P
+        self.controller.on_own_execution_payload_envelope(
+            wait_group,
+            signed_envelope.clone_arc(),
+        );
+
+        ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope).send(&self.p2p_tx);
 
         Ok(())
     }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -1143,16 +1143,33 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                 ValidatorToP2p::PublishBeaconBlock(block.clone_arc()).send(&self.p2p_tx);
 
                 // Handle Gloas execution payload envelope (only for self-build)
-                self.publish_gloas_envelope(
-                    &block_build_context,
-                    &block,
-                    proposer_index,
-                    slot_head,
-                    &signer_snapshot,
-                    public_key,
-                    wait_group.clone(),
-                )
-                .await?;
+                if let Some(signed_envelope) = self
+                    .create_gloas_envelope(
+                        &block_build_context,
+                        &block,
+                        proposer_index,
+                        slot_head,
+                        &signer_snapshot,
+                        public_key,
+                    )
+                    .await
+                {
+                    info_with_peers!(
+                        "validator {} publishing execution payload envelope for block {:?} in slot {}",
+                        proposer_index,
+                        signed_envelope.message.beacon_block_root,
+                        slot_head.slot(),
+                    );
+
+                    // Publish envelope to controller and P2P
+                    self.controller.on_own_execution_payload_envelope(
+                        wait_group.clone(),
+                        signed_envelope.clone_arc(),
+                    );
+
+                    ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope)
+                        .send(&self.p2p_tx);
+                }
             }
         }
 
@@ -1163,9 +1180,9 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         Ok(())
     }
 
-    /// Publish Gloas execution payload envelope for self-build proposers.
-    /// Only publishes if envelope data is available (i.e., self-building).
-    async fn publish_gloas_envelope(
+    /// Create and sign Gloas execution payload envelope for self-build proposers.
+    /// Returns None if envelope data is not available (i.e., not self-building).
+    async fn create_gloas_envelope(
         &self,
         block_build_context: &block_producer::BlockBuildContext<P, W>,
         block: &Arc<types::combined::SignedBeaconBlock<P>>,
@@ -1173,13 +1190,9 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         slot_head: &SlotHead<P>,
         signer_snapshot: &signer::Snapshot,
         public_key: &PublicKeyBytes,
-        wait_group: W,
-    ) -> Result<()> {
-        let Some((deneb_payload, execution_requests_data, blob_kzg_commitments)) =
-            block_build_context.get_gloas_envelope_data().await
-        else {
-            return Ok(());
-        };
+    ) -> Option<Arc<SignedExecutionPayloadEnvelope<P>>> {
+        let (deneb_payload, execution_requests_data, blob_kzg_commitments) =
+            block_build_context.get_gloas_envelope_data().await?;
 
         let beacon_block_root = block.message().hash_tree_root();
 
@@ -1198,7 +1211,7 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                     "failed to compute post-execution state root (slot: {}): {error:?}",
                     slot_head.slot(),
                 );
-                return Ok(());
+                return None;
             }
         };
 
@@ -1231,31 +1244,14 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                     {error:?}",
                     slot_head.slot(),
                 );
-                return Ok(());
+                return None;
             }
         };
 
-        let signed_envelope = Arc::new(SignedExecutionPayloadEnvelope {
+        Some(Arc::new(SignedExecutionPayloadEnvelope {
             message: envelope,
             signature: envelope_sig,
-        });
-
-        info_with_peers!(
-            "validator {} publishing execution payload envelope for block {:?} in slot {}",
-            proposer_index,
-            signed_envelope.message.beacon_block_root,
-            slot_head.slot(),
-        );
-
-        // Publish envelope to controller and P2P
-        self.controller.on_own_execution_payload_envelope(
-            wait_group,
-            signed_envelope.clone_arc(),
-        );
-
-        ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope).send(&self.p2p_tx);
-
-        Ok(())
+        }))
     }
 
     /// See:

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -71,10 +71,11 @@ use types::{
         AggregateAndProof as ElectraAggregateAndProof,
         SignedAggregateAndProof as ElectraSignedAggregateAndProof, SingleAttestation,
     },
-    gloas::containers::{PayloadAttestationData, PayloadAttestationMessage},
-    nonstandard::{
-        KzgProofs, OwnAttestation, Phase, SyncCommitteeEpoch, WithBlobsAndMev, WithStatus,
+    gloas::containers::{
+        ExecutionPayloadEnvelope, PayloadAttestationData, PayloadAttestationMessage,
+        SignedExecutionPayloadEnvelope,
     },
+    nonstandard::{KzgProofs, OwnAttestation, Phase, SyncCommitteeEpoch, WithBlobsAndMev, WithStatus},
     phase0::{
         consts::GENESIS_SLOT,
         containers::{
@@ -1139,7 +1140,83 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                 self.controller
                     .on_own_block(wait_group.clone(), block.clone_arc());
 
-                ValidatorToP2p::PublishBeaconBlock(block).send(&self.p2p_tx);
+                ValidatorToP2p::PublishBeaconBlock(block.clone_arc()).send(&self.p2p_tx);
+
+                // Handle Gloas execution payload envelope (only for self-build)
+                if let Some((deneb_payload, execution_requests_data, blob_kzg_commitments)) =
+                    block_build_context.get_gloas_envelope_data().await
+                {
+                    let beacon_block_root = block.message().hash_tree_root();
+
+                    // Compute state_root by calling process_execution_payload(verify=false)
+                    // then hash_tree_root(state). This is the post-execution beacon state root
+                    let state_root = match block_build_context
+                        .compute_post_execution_state_root(beacon_block_root, proposer_index)
+                        .await
+                    {
+                        Ok(root) => root,
+                        Err(error) => {
+                            warn_with_peers!(
+                                "failed to compute post-execution state root (slot: {}): {error:?}",
+                                slot_head.slot(),
+                            );
+                            return Ok(());
+                        }
+                    };
+
+                    let envelope = ExecutionPayloadEnvelope {
+                        payload: deneb_payload.into(),
+                        execution_requests: execution_requests_data,
+                        builder_index: proposer_index,
+                        beacon_block_root,
+                        slot: slot_head.slot(),
+                        blob_kzg_commitments,
+                        state_root,
+                    };
+
+                    // Sign the envelope
+                    let envelope_signing_root = envelope.signing_root(&self.chain_config, &slot_head.beacon_state);
+                    let envelope_sig = match signer_snapshot
+                        .sign_without_slashing_protection(
+                            SigningMessage::ExecutionPayloadEnvelope(&envelope),
+                            envelope_signing_root,
+                            Some(slot_head.beacon_state.as_ref().into()),
+                            *public_key,
+                        )
+                        .await
+                    {
+                        Ok(signature) => SignatureBytes::from(signature),
+                        Err(error) => {
+                            warn_with_peers!(
+                                "failed to sign execution payload envelope (slot: {}, public_key: {public_key}): \
+                                {error:?}",
+                                slot_head.slot(),
+                            );
+                            return Ok(());
+                        }
+                    };
+
+                    let signed_envelope = Arc::new(SignedExecutionPayloadEnvelope {
+                        message: envelope,
+                        signature: envelope_sig,
+                    });
+
+                    info_with_peers!(
+                        "validator {} publishing execution payload envelope for block {:?} in slot {}",
+                        proposer_index,
+                        signed_envelope.message.beacon_block_root,
+                        slot_head.slot(),
+                    );
+
+                    // Publish envelope to controller and P2P
+                    self.controller.on_own_execution_payload_envelope(
+                        wait_group.clone(),
+                        signed_envelope.clone_arc(),
+                    );
+
+                    ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope)
+                        .send(&self.p2p_tx);
+                }
             }
         }
 
@@ -2037,7 +2114,7 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
             let doppelganger_protection = self
                 .doppelganger_protection
-                .as_deref()
+                .as_deref() 
                 .map(DoppelgangerProtection::load);
 
             own_members


### PR DESCRIPTION
Add complete self-build flow for Gloas phase where validator creates execution payload bid, embeds it in beacon block, and publishes signed execution payload envelope separately.

Validator responsibilities:
- Request block producer to fetch payload and create unsigned bid
- Sign ExecutionPayloadBid and pass to block producer
- Sign RANDAO reveal for block building
- Sign final BeaconBlock
- Retrieve cached envelope_data from block producer
- Build and sign ExecutionPayloadEnvelope
- Publish signed block and envelope via P2P

Block producer responsibilities:
- Fetch execution payload from EL (single fetch)
- Create unsigned ExecutionPayloadBid from payload
- Cache envelope_data (payload, execution_requests, commitments)
- Embed signed bid into block body
- Build block with state root
- Provide cached envelope_data to validator on request

roughly follows this flow
``` [V] ProposeBlock (Self-Build)
   ├─ [V→BN] build_execution_payload_bid_and_cache_envelope_data
   │   ├─ [BN→EL] notify_forkchoice_updated → payload_id
   │   ├─ [BN→EL] get_execution_payload(payload_id) → ExecutionPayload
   │   ├─ [BN] prepare_execution_payload_bid
   │   └─ [BN] cache envelope_data
   ├─ [V] sign(ExecutionPayloadBid) → SignedExecutionPayloadBid
   ├─ [V→BN] build_blinded_beacon_block(randao_reveal, signed_bid)
   │   └─ [BN] prepare_gloas_block_with_bid (embed signed_bid)
   ├─ [V] sign(BeaconBlock) → SignedBeaconBlock
   ├─ [V→BN] PublishBeaconBlock
   │   └─ [P2P] gossip SignedBeaconBlock
   └─ [V] SubmitEnvelope
       ├─ [V→BN] get_cached_envelope_data
       ├─ [V] sign(ExecutionPayloadEnvelope) → SignedEnvelope
       └─ [V→P2P] PublishExecutionPayloadEnvelope
           └─ [P2P] publish_execution_payload_envelope ```
           