### PR TITLE
Check accepted sidecars against block root

### DIFF
--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2108,11 +2108,15 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         // [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, sidecar.index) with valid header signature, sidecar inclusion proof, and kzg proof.
         // Adjustment: Ignore data column sidecars for unseen blocks only
-        if self.accepted_data_column_sidecars.contains_key(&(
-            block_header.slot,
-            block_header.proposer_index,
-            data_column_sidecar.index,
-        )) && !block_seen
+        if self
+            .accepted_data_column_sidecars
+            .get(&(
+                block_header.slot,
+                block_header.proposer_index,
+                data_column_sidecar.index,
+            ))
+            .is_some_and(|commitments| commitments.contains_key(&block_root))
+            && !block_seen
         {
             return Ok(DataColumnSidecarAction::Ignore(true));
         }


### PR DESCRIPTION
In case there are two conflicting blocks propose by the same proposer, any data column sidecar will be ignored if there is already accepted data column sidecar with the same index if we don't check the diff on block root