### PR TITLE
Fix test script in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ download-spec-tests:
 
 .PHONY: test
 test: download-spec-tests
-	cargo test --release --features stub-grandine-version $(EXCLUDES)
+	cargo test --release --features default-networks,stub-grandine-version $(EXCLUDES)
 
 .PHONY: release
 release:


### PR DESCRIPTION
After merging #476, `test` script inside Makefile broke -- as feature `default-networks` was not provided. This PR fixes that.