### PR TITLE
Delay blob reconstructions for a few seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8188,6 +8188,7 @@ dependencies = [
  "strum 0.27.2",
  "tap",
  "tokio",
+ "tokio-stream",
  "tracing",
  "transition_functions",
  "try_from_iterator",

--- a/fork_choice_control/src/messages.rs
+++ b/fork_choice_control/src/messages.rs
@@ -231,6 +231,7 @@ pub enum PoolMessage<P: Preset, W> {
         wait_group: W,
         block_root: H256,
         block: Arc<SignedBeaconBlock<P>>,
+        origin: BlockOrigin,
         slot: Slot,
     },
 }

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -749,6 +749,7 @@ where
                                         wait_group,
                                         block_root,
                                         block: pending_block.block.clone_arc(),
+                                        origin: pending_block.origin.clone(),
                                         slot: pending_block.block.message().slot(),
                                     })
                                 }

--- a/fork_choice_store/src/misc.rs
+++ b/fork_choice_store/src/misc.rs
@@ -211,6 +211,11 @@ impl BlockOrigin {
             Self::Api(_) => "Api",
         }
     }
+
+    #[must_use]
+    pub const fn is_requested(&self) -> bool {
+        matches!(self, Self::Requested(..))
+    }
 }
 
 #[derive(Debug, AsRefStr)]

--- a/operation_pools/Cargo.toml
+++ b/operation_pools/Cargo.toml
@@ -32,6 +32,7 @@ std_ext = { workspace = true }
 strum = { workspace = true }
 tap = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 transition_functions = { workspace = true }
 try_from_iterator = { workspace = true }

--- a/operation_pools/src/blob_reconstruction_pool/manager.rs
+++ b/operation_pools/src/blob_reconstruction_pool/manager.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use core::time::Duration;
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
 use dedicated_executor::DedicatedExecutor;
 use eth1_api::ApiController;
@@ -13,10 +14,15 @@ use types::{
 
 use crate::{blob_reconstruction_pool::tasks::ReconstructDataColumnSidecarsTask, misc::PoolTask};
 
+const RECONSTRUCTION_START_DELAY: Duration = Duration::from_secs(2);
+
+pub type ReconstructionParams<P, W> = (W, H256, Arc<SignedBeaconBlock<P>>, Slot);
+
 pub struct Manager<P: Preset, W: Wait> {
     controller: ApiController<P, W>,
     dedicated_executor: DedicatedExecutor,
     metrics: Option<Arc<Metrics>>,
+    scheduled_reconstructions: BTreeMap<Instant, Vec<ReconstructionParams<P, W>>>,
 }
 
 impl<P: Preset, W: Wait> Manager<P, W> {
@@ -30,7 +36,30 @@ impl<P: Preset, W: Wait> Manager<P, W> {
             controller,
             dedicated_executor,
             metrics,
+            scheduled_reconstructions: BTreeMap::new(),
         }
+    }
+
+    pub fn perform_scheduled_reconstructions(&mut self) {
+        let mut reconstructions = self.scheduled_reconstructions.split_off(&Instant::now());
+        core::mem::swap(&mut self.scheduled_reconstructions, &mut reconstructions);
+
+        for (wait_group, block_root, block, slot) in reconstructions.into_values().flatten() {
+            self.spawn_reconstruction(wait_group, block_root, block, slot);
+        }
+    }
+
+    pub fn schedule_reconstruction(
+        &mut self,
+        wait_group: W,
+        block_root: H256,
+        block: Arc<SignedBeaconBlock<P>>,
+        slot: Slot,
+    ) {
+        self.scheduled_reconstructions
+            .entry(Instant::now() + RECONSTRUCTION_START_DELAY)
+            .or_default()
+            .push((wait_group, block_root, block, slot));
     }
 
     pub fn spawn_reconstruction(

--- a/operation_pools/src/manager.rs
+++ b/operation_pools/src/manager.rs
@@ -1,8 +1,11 @@
+use core::time::Duration;
 use std::sync::Arc;
 
 use anyhow::Result;
 use fork_choice_control::{PoolMessage, Wait};
 use futures::{channel::mpsc::UnboundedReceiver, StreamExt as _};
+use tokio::select;
+use tokio_stream::wrappers::IntervalStream;
 use types::preset::Preset;
 
 use crate::{
@@ -36,30 +39,49 @@ impl<P: Preset, W: Wait> Manager<P, W> {
     }
 
     pub async fn run(mut self) -> Result<()> {
-        while let Some(message) = self.fork_choice_to_pool_rx.next().await {
-            match message {
-                PoolMessage::Slot(slot) => self.sync_committee_agg_pool.on_slot(slot),
-                PoolMessage::Tick(tick) => {
-                    if tick.is_start_of_epoch::<P>() {
-                        self.bls_to_execution_change_pool
-                            .discard_old_bls_to_execution_changes();
+        let mut interval =
+            IntervalStream::new(tokio::time::interval(Duration::from_millis(100))).fuse();
+
+        loop {
+            select! {
+                _ = interval.select_next_some() => {
+                    self.blob_reconstruction_pool.perform_scheduled_reconstructions();
+                },
+
+                message = self.fork_choice_to_pool_rx.select_next_some() => {
+                    match message {
+                        PoolMessage::Slot(slot) => self.sync_committee_agg_pool.on_slot(slot),
+                        PoolMessage::Tick(tick) => {
+                            if tick.is_start_of_epoch::<P>() {
+                                self.bls_to_execution_change_pool
+                                    .discard_old_bls_to_execution_changes();
+                            }
+
+                            self.attestation_agg_pool.on_tick(tick).await
+                        }
+                        PoolMessage::Stop => {
+                            self.bls_to_execution_change_pool.stop();
+
+                            break;
+                        }
+                        PoolMessage::ReconstructDataColumns {
+                            wait_group,
+                            block_root,
+                            block,
+                            origin,
+                            slot,
+                        } => {
+                            // We don't want to reconstruct blobs on each block during sync
+                            // if it downloads data columns relatively fast
+                            if origin.is_requested() {
+                                self.blob_reconstruction_pool
+                                    .schedule_reconstruction(wait_group, block_root, block, slot);
+                            } else {
+                                self.blob_reconstruction_pool
+                                    .spawn_reconstruction(wait_group, block_root, block, slot);
+                            }
+                        }
                     }
-
-                    self.attestation_agg_pool.on_tick(tick).await
-                }
-                PoolMessage::Stop => {
-                    self.bls_to_execution_change_pool.stop();
-
-                    break;
-                }
-                PoolMessage::ReconstructDataColumns {
-                    wait_group,
-                    block_root,
-                    block,
-                    slot,
-                } => {
-                    self.blob_reconstruction_pool
-                        .spawn_reconstruction(wait_group, block_root, block, slot);
                 }
             }
         }


### PR DESCRIPTION
This reduces the unnecessary amount of reconstructions when node is importing blocks relatively fast during sync.