### PR TITLE
Fixed grandine docker image build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,10 +193,12 @@ jobs:
         run: |
           mkdir -p ./target/x86_64-unknown-linux-gnu/compact/
           mv ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-x64/grandine-${{ env.GRANDINE_VERSION }}-linux-x64 ./target/x86_64-unknown-linux-gnu/compact/grandine
+          chmod +x ./target/x86_64-unknown-linux-gnu/compact/grandine
           mv ./artifacts/lib-linux-x64/libgrandine.so ./target/x86_64-unknown-linux-gnu/compact/libgrandine.so
           
           mkdir -p ./target/aarch64-unknown-linux-gnu/compact
           mv ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64 ./target/aarch64-unknown-linux-gnu/compact/grandine
+          chmod +x ./target/aarch64-unknown-linux-gnu/compact/grandine
           mv ./artifacts/lib-linux-arm64/libgrandine.so ./target/aarch64-unknown-linux-gnu/compact/libgrandine.so
           
           mkdir -p ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net9.0/

--- a/Makefile
+++ b/Makefile
@@ -211,10 +211,6 @@ ifneq ($(strip $(DOCKER_SUFFIX)),)
 override DOCKER_SUFFIX := -$(DOCKER_SUFFIX)
 endif
 
-ifneq ($(strip $(GRANDINE_VERSION)),)
-override DOCKER_SUFFIX := -$(GRANDINE_VERSION)
-endif
-
 .PHONY: docker
 docker: grandine-docker nethermind-docker
 


### PR DESCRIPTION
This PR:
* Fixes copied `grandine` binary mode. Previously, binary without execute permission was copied in docker image, so image won't work at all.
* Removes needless image version suffixes: now it publishes "unstable" tag instead of "unstable-26da0ae".