### PR TITLE
Fixed build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ download-spec-tests:
 test: download-spec-tests
 	cargo test --release --features stub-grandine-version $(EXCLUDES)
 
+.PHONY: minimal
+minimal:
+	cargo build --profile compact --bin grandine --features preset-minimal $(FEATURES) $(EXCLUDES)
+
 .PHONY: release
 release:
 ifeq ($(TARGET),)

--- a/scripts/build/minimal.sh
+++ b/scripts/build/minimal.sh
@@ -1,11 +1,3 @@
 #!/bin/sh
 
-exec cargo build                \
-    --bin      grandine         \
-    --features default-networks \
-    --features preset-minimal   \
-    --features tracing          \
-    --profile  compact          \
-    --workspace                 \
-    --exclude zkvm_host         \
-    --exclude zkvm_guest_risc0
+exec make minimal

--- a/scripts/build/release.sh
+++ b/scripts/build/release.sh
@@ -1,10 +1,3 @@
 #!/bin/sh
 
-exec cargo build                \
-    --bin      grandine         \
-    --features default-networks \
-    --features tracing          \
-    --profile  compact          \
-    --workspace                 \
-    --exclude zkvm_host         \
-    --exclude zkvm_guest_risc0
+exec make release


### PR DESCRIPTION
Updated both build/minimal.sh and build/release.sh scripts to use targets from Makefile. These scripts are used for building ethpandaops/grandine images.