### PR TITLE
Provide GITHUB_TOKEN during risc0 installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,8 @@ jobs:
             ${{ runner.os }}-zkm-toolchain-nightly-2025-06-30-
       - name: Installing ${{ matrix.backend }} zkVM
         run: ${{ matrix.install }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build step for ${{ matrix.backend }}
         if: matrix.pre_build != ''
         run: ${{ matrix.pre_build }}


### PR DESCRIPTION
Add GITHUB_TOKEN environment variable in CI pipeline, during zkvm installation. Done for risc0 to avoid ratelimits.