### PR TITLE
Change docker image tag push order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ override DOCKER_SUFFIX := -$(DOCKER_SUFFIX)
 endif
 
 .PHONY: docker
-docker: grandine-docker nethermind-docker
+docker: nethermind-docker grandine-docker
 
 # ----- GRANDINE DOCKER -----
 


### PR DESCRIPTION
Reordered docker build scripts in Makefile, so that nethermind-related images are pushed first, and then grandine binaries. That is needed so in dockerhub standard image tags appear first, and nethermind after.