### PR TITLE
Set fixed cross version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,8 @@ jobs:
 
       - name: Install cross
         if: runner.os == 'Linux'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # cross don't publish tags, so using commit hash instead
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 49cd054de9b832dfc11a4895c72b0aef533b5c6a
 
       - name: Build binary & lib
         run: make ${{ matrix.target }}


### PR DESCRIPTION
Recently [release pipeline broke], due to newly published cross version, that no longer supports rust pre 1.92 version. To avoid such problems in the future, setting fixed commit hash, while downloading cross in CI.

[release pipeline broke]: https://github.com/ArtiomTr/grandine/actions/runs/20710143689/job/59448613963