### PR TITLE
Disable check for --eth1-rpc-urls in embedded mode

### DIFF
--- a/runtime/src/grandine_args.rs
+++ b/runtime/src/grandine_args.rs
@@ -1149,7 +1149,8 @@ impl GrandineArgs {
 
         let predefined_network = network.predefined_network();
 
-        if predefined_network.is_none() && eth1_rpc_urls.is_empty() {
+        if cfg!(not(feature = "embed")) && predefined_network.is_none() && eth1_rpc_urls.is_empty()
+        {
             ensure!(
                 genesis_state_file.is_some(),
                 Error::MissingEth1RpcUrlsForCustomWithoutGenesisState,

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -359,7 +359,7 @@ pub async fn run_after_genesis<P: Preset>(
         sync_to_metrics_tx = Some(sync_tx);
 
         let eth1_connection_data = Eth1ConnectionData {
-            sync_eth1_connected: !eth1_config.eth1_rpc_urls.is_empty(),
+            sync_eth1_connected: cfg!(feature = "embed") || !eth1_config.eth1_rpc_urls.is_empty(),
             sync_eth1_fallback_connected: false,
         };
 
@@ -1039,7 +1039,7 @@ impl Context {
 
         let signer_snapshot = signer.load();
 
-        if eth1_rpc_urls.is_empty() {
+        if cfg!(not(feature = "embed")) && eth1_rpc_urls.is_empty() {
             ensure!(
                 signer_snapshot.no_keys(),
                 Error::MissingEth1RpcUrlsWithValidators,


### PR DESCRIPTION
Disabled check for --eth1-rpc-urls being present, when grandine is compiled with "embed" feature. There is no need for this flag to be specified, as all engine API communication happens through FFI calls.