### PR TITLE
Short tags for nethermind-grandine docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,8 @@ endif
 	docker buildx imagetools create -t $(DOCKER_REPO):$(DOCKER_LABEL)$(DOCKER_SUFFIX)-nethermind-$(NETHERMIND_VERSION) \
 		$(DOCKER_REPO):$(DOCKER_LABEL)-amd64$(DOCKER_SUFFIX)-nethermind-$(NETHERMIND_VERSION) \
 		$(DOCKER_REPO):$(DOCKER_LABEL)-arm64$(DOCKER_SUFFIX)-nethermind-$(NETHERMIND_VERSION)
+	docker buildx imagetools create -t $(DOCKER_REPO):$(DOCKER_LABEL)$(DOCKER_SUFFIX)-nethermind \
+		$(DOCKER_REPO):$(DOCKER_LABEL)$(DOCKER_SUFFIX)-nethermind-$(NETHERMIND_VERSION)
 ifeq ($(DOCKER_LABEL),stable)
 	docker buildx imagetools create -t $(DOCKER_REPO):$(GRANDINE_VERSION)-nethermind-$(NETHERMIND_VERSION) \
 		$(DOCKER_REPO):$(DOCKER_LABEL)$(DOCKER_SUFFIX)-nethermind-$(NETHERMIND_VERSION)


### PR DESCRIPTION
Implemented additional, shorted tags for nethermind-grandine docker images, which do not include nethermind version:

* sifraitech/grandine:stable-nethermind
* sifraitech/grandine:unstable-nethermind