### PR TITLE
Refactor execution payload envelope validation and handling in fork-choice

### DIFF
--- a/eip_7594/src/lib.rs
+++ b/eip_7594/src/lib.rs
@@ -29,8 +29,10 @@ use types::{
         containers::{DataColumnSidecar as FuluDataColumnSidecar, MatrixEntry},
         primitives::{BlobCommitmentsInclusionProof, CellsAndKzgProofs, ColumnIndex, CustodyIndex},
     },
-    gloas::containers::DataColumnSidecar as GloasDataColumnSidecar,
-    nonstandard::{BlockOrDataColumnSidecar, Phase},
+    gloas::containers::{
+        DataColumnSidecar as GloasDataColumnSidecar, SignedExecutionPayloadEnvelope,
+    },
+    nonstandard::{BlockOrData, Phase},
     phase0::{
         containers::SignedBeaconBlockHeader,
         primitives::{Gwei, NodeId, Slot, SubnetId, ValidatorIndex},
@@ -366,6 +368,18 @@ pub fn construct_data_column_sidecars_post_gloas<P: Preset>(
     get_data_column_sidecars_post_gloas(root, slot, kzg_commitments, cells_and_kzg_proofs)
 }
 
+pub fn construct_data_column_sidecars_from_payload_envelope<P: Preset>(
+    envelope: &SignedExecutionPayloadEnvelope<P>,
+    cells_and_kzg_proofs: &[CellsAndKzgProofs<P>],
+) -> Result<Vec<Arc<DataColumnSidecar<P>>>> {
+    get_data_column_sidecars_post_gloas(
+        envelope.block_root(),
+        envelope.slot(),
+        envelope.blob_kzg_commitments(),
+        cells_and_kzg_proofs,
+    )
+}
+
 pub fn construct_fulu_data_column_sidecars<P: Preset>(
     signed_block: &SignedBeaconBlock<P>,
     cells_and_kzg_proofs: &[CellsAndKzgProofs<P>],
@@ -463,7 +477,7 @@ pub fn try_convert_to_cells_and_kzg_proofs<P: Preset>(
 }
 
 pub async fn construct_data_column_sidecars_from_blobs<P: Preset>(
-    block_or_sidecar: BlockOrDataColumnSidecar<P>,
+    block_or_data: BlockOrData<P>,
     received_blobs: Vec<Blob<P>>,
     cells_proofs: Vec<KzgProof>,
     kzg_backend: KzgBackend,
@@ -477,12 +491,18 @@ pub async fn construct_data_column_sidecars_from_blobs<P: Preset>(
         let cells_and_kzg_proofs =
             try_convert_to_cells_and_kzg_proofs::<P>(&received_blobs, &cells_proofs, kzg_backend)?;
 
-        let data_column_sidecars = match block_or_sidecar {
-            BlockOrDataColumnSidecar::Block(block) => {
+        let data_column_sidecars = match block_or_data {
+            BlockOrData::Block(block) => {
                 construct_fulu_data_column_sidecars(&block, &cells_and_kzg_proofs)?
             }
-            BlockOrDataColumnSidecar::Sidecar(sidecar) => {
+            BlockOrData::Sidecar(sidecar) => {
                 construct_data_column_sidecars_from_sidecar(&sidecar, &cells_and_kzg_proofs)?
+            }
+            BlockOrData::Envelope(envelope) => {
+                construct_data_column_sidecars_from_payload_envelope(
+                    &envelope,
+                    &cells_and_kzg_proofs,
+                )?
             }
         };
 

--- a/eth1_api/src/eth1_api/http_api.rs
+++ b/eth1_api/src/eth1_api/http_api.rs
@@ -385,17 +385,7 @@ impl Eth1Api {
                 .await?
                 .result
             }
-            Phase::Deneb | Phase::Electra | Phase::Fulu => {
-                self.execute(
-                    ENGINE_FORKCHOICE_UPDATED_V3,
-                    params,
-                    Some(ENGINE_FORKCHOICE_UPDATED_TIMEOUT),
-                    None,
-                )
-                .await?
-                .result
-            }
-            Phase::Gloas => {
+            Phase::Deneb | Phase::Electra | Phase::Fulu | Phase::Gloas => {
                 self.execute(
                     ENGINE_FORKCHOICE_UPDATED_V3,
                     params,

--- a/eth1_api/src/execution_blob_fetcher.rs
+++ b/eth1_api/src/execution_blob_fetcher.rs
@@ -24,7 +24,7 @@ use types::{
         containers::{DataColumnIdentifier, DataColumnsByRootIdentifier},
         primitives::ColumnIndex,
     },
-    nonstandard::BlockOrDataColumnSidecar,
+    nonstandard::BlockOrData,
     phase0::primitives::Slot,
     preset::Preset,
     traits::SignedBeaconBlock as _,
@@ -76,10 +76,10 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
                         peer_id,
                     }) => self.get_blobs_v1(block, blob_identifiers, peer_id).await,
                     EngineGetBlobsParams::V2(EngineGetBlobsV2Params {
-                        block_or_sidecar,
+                        block_or_data,
                         data_column_identifiers,
                     }) => {
-                        self.get_blobs_v2(block_or_sidecar, data_column_identifiers)
+                        self.get_blobs_v2(block_or_data, data_column_identifiers)
                             .await
                     }
                 },
@@ -214,14 +214,15 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
     #[expect(clippy::too_many_lines)]
     async fn get_blobs_v2(
         &self,
-        block_or_sidecar: BlockOrDataColumnSidecar<P>,
+        block_or_data: BlockOrData<P>,
         data_column_identifiers: Vec<DataColumnIdentifier>,
     ) {
-        let slot = block_or_sidecar.slot();
-        let block_root = block_or_sidecar.block_root();
+        let slot = block_or_data.slot();
+        let block_root = block_or_data.block_root();
 
-        // TODO: (gloas): block can be imported before data available
-        if self.controller.contains_block(block_root)
+        if self
+            .controller
+            .contains_block_and_data_available(block_root)
             || self
                 .controller
                 .is_sidecars_construction_started(&block_root)
@@ -232,8 +233,7 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
             return;
         }
 
-        // TODO: (gloas): get `blob_kzg_commitments` from post-gloas payload envelope
-        let Some(kzg_commitments) = block_or_sidecar.kzg_commitments() else {
+        let Some(kzg_commitments) = block_or_data.kzg_commitments() else {
             return;
         };
 
@@ -303,7 +303,7 @@ impl<P: Preset, W: Wait> ExecutionBlobFetcher<P, W> {
 
                             let reconstruction_result =
                                 eip_7594::construct_data_column_sidecars_from_blobs(
-                                    block_or_sidecar,
+                                    block_or_data,
                                     received_blobs,
                                     cells_proofs,
                                     self.controller.store_config().kzg_backend,

--- a/execution_engine/src/types.rs
+++ b/execution_engine/src/types.rs
@@ -31,7 +31,7 @@ use types::{
         ConsolidationRequest, DepositRequest, ExecutionRequests, WithdrawalRequest,
     },
     fulu::containers::DataColumnIdentifier,
-    nonstandard::{BlockOrDataColumnSidecar, KzgProofs, Phase, WithBlobsAndMev},
+    nonstandard::{BlockOrData, KzgProofs, Phase, WithBlobsAndMev},
     phase0::primitives::{
         ExecutionAddress, ExecutionBlockHash, ExecutionBlockNumber, Gwei, H256, UnixSeconds,
         ValidatorIndex,
@@ -1036,7 +1036,7 @@ impl<P: Preset> From<EngineGetBlobsV1Params<P>> for EngineGetBlobsParams<P> {
 }
 
 pub struct EngineGetBlobsV2Params<P: Preset> {
-    pub block_or_sidecar: BlockOrDataColumnSidecar<P>,
+    pub block_or_data: BlockOrData<P>,
     pub data_column_identifiers: Vec<DataColumnIdentifier>,
 }
 

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -29,7 +29,7 @@ use fork_choice_store::{
 };
 use futures::channel::{mpsc::Sender as MultiSender, oneshot::Sender as OneshotSender};
 use genesis::AnchorCheckpointProvider;
-use logging::{debug_with_peers, info_with_peers};
+use logging::debug_with_peers;
 use prometheus_metrics::Metrics;
 use pubkey_cache::PubkeyCache;
 use scc::HashMap as SccHashMap;
@@ -47,7 +47,7 @@ use types::{
     gloas::containers::{
         PayloadAttestationMessage, SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope,
     },
-    nonstandard::ValidationOutcome,
+    nonstandard::{BlockOrEnvelope, ValidationOutcome},
     phase0::primitives::{ExecutionBlockHash, H256, Slot, SubnetId},
     preset::Preset,
     traits::SignedBeaconBlock as _,
@@ -357,36 +357,11 @@ where
     pub fn on_own_execution_payload_envelope(
         &self,
         wait_group: W,
-        envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
+        execution_payload_envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
     ) {
-        // TODO (gloas): Implement direct task spawn (from commit ad16f5c4a3e6f2d4931ea92fa35e9c4d6564ca80)
-        //
-        // This should spawn ExecutionPayloadEnvelopeTask DIRECTLY with Origin::Own
-        //
-        //   self.spawn(ExecutionPayloadEnvelopeTask {
-        //       store_snapshot: self.owned_store_snapshot(),
-        //       mutator_tx: self.owned_mutator_tx(),
-        //       wait_group,
-        //       envelope,
-        //       beacon_block_seen: true,  // we published the block ourselves
-        //    - origin: ExecutionPayloadEnvelopeOrigin::Own
-        //    - submission_time: Instant::now()
-        //
-        // 2. Task validates envelope:
-        //    - Signature check (builder domain)
-        //    - Link to block via beacon_block_root
-        //    - Builder index matches block bid
-        //
-        // 3. Mutator processes result:
-        //    - Trigger fork choice update
-        //    - Process execution payload in state transition
-        //
-        // For now, just log until task changes is merged through ad16f5c4a
-        info_with_peers!(
-            "publishing own execution payload envelope (block_root: {:?}, slot: {}, builder_index: {})",
-            envelope.message.beacon_block_root,
-            envelope.message.slot,
-            envelope.message.builder_index,
+        self.spawn_execution_payload_envelope_task(
+            execution_payload_envelope,
+            ExecutionPayloadEnvelopeOrigin::Own,
         );
     }
 
@@ -745,13 +720,13 @@ where
         &self,
         wait_group: W,
         block_root: H256,
-        block: Arc<SignedBeaconBlock<P>>,
+        block_or_envelope: BlockOrEnvelope<P>,
         data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
     ) {
         MutatorMessage::ReconstructedMissingColumns {
             wait_group,
             block_root,
-            block,
+            block_or_envelope,
             data_column_sidecars,
         }
         .send(&self.mutator_tx)

--- a/fork_choice_control/src/helpers.rs
+++ b/fork_choice_control/src/helpers.rs
@@ -394,7 +394,7 @@ impl<P: Preset> Context<P> {
                     assert_eq!(block_with_missing_blobs, *block);
                 }
                 EngineGetBlobsParams::V2(EngineGetBlobsV2Params {
-                    block_or_sidecar,
+                    block_or_data,
                     data_column_identifiers,
                 }) => {
                     assert!(
@@ -403,7 +403,7 @@ impl<P: Preset> Context<P> {
                             .all(|id| id.block_root == block_root)
                     );
                     assert!(!data_column_identifiers.is_empty());
-                    assert_eq!(block_or_sidecar.block_root(), block_root);
+                    assert_eq!(block_or_data.block_root(), block_root);
                 }
             },
             _ => panic!("ExecutionServiceMessage::GetBlobs expected"),

--- a/fork_choice_control/src/messages.rs
+++ b/fork_choice_control/src/messages.rs
@@ -24,7 +24,8 @@ use types::{
     },
     deneb::containers::{BlobIdentifier, BlobSidecar},
     fulu::{containers::DataColumnIdentifier, primitives::ColumnIndex},
-    gloas::containers::PayloadAttestationMessage,
+    gloas::containers::{PayloadAttestationMessage, SignedExecutionPayloadEnvelope},
+    nonstandard::BlockOrEnvelope,
     phase0::{
         containers::Checkpoint,
         primitives::{ExecutionBlockHash, H256, Slot, ValidatorIndex},
@@ -210,7 +211,7 @@ pub enum MutatorMessage<P: Preset, W> {
     ReconstructedMissingColumns {
         wait_group: W,
         block_root: H256,
-        block: Arc<SignedBeaconBlock<P>>,
+        block_or_envelope: BlockOrEnvelope<P>,
         data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
     },
 }
@@ -261,6 +262,13 @@ pub enum PoolMessage<P: Preset, W> {
         block_root: H256,
         block: Arc<SignedBeaconBlock<P>>,
         origin: BlockOrigin,
+        slot: Slot,
+    },
+    ReconstructDataColumnsForEnvelope {
+        wait_group: W,
+        block_root: H256,
+        envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
+        origin: ExecutionPayloadEnvelopeOrigin,
         slot: Slot,
     },
 }

--- a/fork_choice_control/src/misc.rs
+++ b/fork_choice_control/src/misc.rs
@@ -14,7 +14,6 @@ use fork_choice_store::{
 };
 use scc::HashMap as SccHashMap;
 use serde::Serialize;
-use ssz::H256;
 use strum::IntoStaticStr;
 use tokio::sync::broadcast::Sender;
 use tracing::Span;
@@ -188,18 +187,6 @@ pub struct PendingExecutionPayloadEnvelope<P: Preset> {
     pub submission_time: Instant,
 }
 
-impl<P: Preset> PendingExecutionPayloadEnvelope<P> {
-    #[must_use]
-    pub fn slot(&self) -> Slot {
-        self.execution_payload_envelope.message.slot
-    }
-
-    #[must_use]
-    pub fn block_root(&self) -> H256 {
-        self.execution_payload_envelope.message.beacon_block_root
-    }
-}
-
 pub struct VerifyAggregateAndProofResult<P: Preset> {
     pub result: Result<AggregateAndProofAction<P>>,
     pub origin: AggregateAndProofOrigin<GossipId>,
@@ -275,6 +262,14 @@ pub enum BlockDataColumnAvailability {
     AnyPending,
     Missing(Vec<ColumnIndex>),
     Irrelevant,
+}
+
+#[derive(Debug)]
+pub enum EnvelopeDataColumnAvailability {
+    Complete,
+    CompleteWithReconstruction,
+    AnyPending,
+    Missing(Vec<ColumnIndex>),
 }
 
 pub type SidecarsPendingReconstruction<P> =

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -59,8 +59,8 @@ use types::{
     combined::{BeaconState, DataColumnSidecar, ExecutionPayloadParams, SignedBeaconBlock},
     deneb::containers::{BlobIdentifier, BlobSidecar},
     fulu::{containers::DataColumnIdentifier, primitives::ColumnIndex},
-    gloas::containers::CombinedPayloadAttestation,
-    nonstandard::{PayloadStatus, RelativeEpoch, ValidationOutcome},
+    gloas::containers::{CombinedPayloadAttestation, SignedExecutionPayloadEnvelope},
+    nonstandard::{BlockOrEnvelope, PayloadStatus, Phase, RelativeEpoch, ValidationOutcome},
     phase0::{
         containers::Checkpoint,
         primitives::{ExecutionBlockHash, H256, Slot, ValidatorIndex},
@@ -78,11 +78,12 @@ use crate::{
         SyncMessage, ValidatorMessage,
     },
     misc::{
-        BlockBlobAvailability, BlockDataColumnAvailability, Delayed, MutatorRejectionReason,
-        PendingAggregateAndProof, PendingAttestation, PendingBlobSidecar, PendingBlock,
-        PendingChainLink, PendingDataColumnSidecar, PendingExecutionPayloadEnvelope,
-        ProcessingTimings, ReorgSource, VerifyAggregateAndProofResult, VerifyAttestationResult,
-        VerifyPayloadAttestationResult, WaitingForCheckpointState,
+        BlockBlobAvailability, BlockDataColumnAvailability, Delayed,
+        EnvelopeDataColumnAvailability, MutatorRejectionReason, PendingAggregateAndProof,
+        PendingAttestation, PendingBlobSidecar, PendingBlock, PendingChainLink,
+        PendingDataColumnSidecar, PendingExecutionPayloadEnvelope, ProcessingTimings, ReorgSource,
+        VerifyAggregateAndProofResult, VerifyAttestationResult, VerifyPayloadAttestationResult,
+        WaitingForCheckpointState,
     },
     storage::Storage,
     tasks::{
@@ -334,7 +335,7 @@ where
                     origin,
                     submission_time,
                 } => self.handle_execution_payload_envelope(
-                    &wait_group,
+                    wait_group,
                     result,
                     origin,
                     submission_time,
@@ -378,12 +379,12 @@ where
                 MutatorMessage::ReconstructedMissingColumns {
                     wait_group,
                     block_root,
-                    block,
+                    block_or_envelope,
                     data_column_sidecars,
                 } => self.handle_reconstructed_missing_columns(
                     &wait_group,
                     block_root,
-                    &block,
+                    block_or_envelope,
                     data_column_sidecars,
                 ),
             }
@@ -482,43 +483,66 @@ where
         if tick.is_end_of_interval() {
             let head = self.store.head();
 
-            // TODO: (gloas): get `execution_payload` from post-gloas payload envelope
-            if head.is_optimistic()
-                && let Some(execution_payload) = head.block.as_ref().clone().execution_payload()
-            {
-                // TODO: (gloas): get `blob_kzg_commitments` from post-gloas payload envelope
-                let params =
-                    if let Some(body) = head.block.message().body().with_blob_kzg_commitments() {
-                        let versioned_hashes = body
-                            .blob_kzg_commitments()
-                            .iter()
-                            .copied()
-                            .map(misc::kzg_commitment_to_versioned_hash)
-                            .collect();
+            if head.is_optimistic() {
+                let payload_params_opt = if head.block.phase() >= Phase::Gloas {
+                    self.execution_payload_envelope_by_root(head.block_root)?
+                        .map(|envelope| {
+                            let versioned_hashes = envelope
+                                .blob_kzg_commitments()
+                                .iter()
+                                .copied()
+                                .map(misc::kzg_commitment_to_versioned_hash)
+                                .collect();
 
-                        // TODO: (gloas): get `execution_requests` from post-gloas payload envelope
-                        if let Some(body) = body.with_execution_requests() {
-                            Some(ExecutionPayloadParams::Electra {
+                            let params = Some(ExecutionPayloadParams::Electra {
                                 versioned_hashes,
                                 parent_beacon_block_root: head.block.message().parent_root(),
-                                execution_requests: body.execution_requests().clone(),
-                            })
-                        } else {
-                            Some(ExecutionPayloadParams::Deneb {
-                                versioned_hashes,
-                                parent_beacon_block_root: head.block.message().parent_root(),
-                            })
+                                execution_requests: envelope.message.execution_requests.clone(),
+                            });
+
+                            (envelope.message.payload.clone().into(), params)
+                        })
+                } else {
+                    if let Some(execution_payload) = head.block.as_ref().clone().execution_payload()
+                    {
+                        let mut params = None;
+                        if let Some(body) = head.block.message().body().with_blob_kzg_commitments()
+                        {
+                            let versioned_hashes = body
+                                .blob_kzg_commitments()
+                                .iter()
+                                .copied()
+                                .map(misc::kzg_commitment_to_versioned_hash)
+                                .collect();
+
+                            params = if let Some(body) = body.with_execution_requests() {
+                                Some(ExecutionPayloadParams::Electra {
+                                    versioned_hashes,
+                                    parent_beacon_block_root: head.block.message().parent_root(),
+                                    execution_requests: body.execution_requests().clone(),
+                                })
+                            } else {
+                                Some(ExecutionPayloadParams::Deneb {
+                                    versioned_hashes,
+                                    parent_beacon_block_root: head.block.message().parent_root(),
+                                })
+                            }
                         }
+
+                        Some((execution_payload, params))
                     } else {
                         None
-                    };
+                    }
+                };
 
-                self.execution_engine.notify_new_payload(
-                    head.block_root,
-                    execution_payload,
-                    params,
-                    None,
-                )?;
+                if let Some((execution_payload, params)) = payload_params_opt {
+                    self.execution_engine.notify_new_payload(
+                        head.block_root,
+                        execution_payload,
+                        params,
+                        None,
+                    )?;
+                }
             }
         }
 
@@ -858,7 +882,7 @@ where
 
                                 self.request_blobs_from_execution_engine(
                                     EngineGetBlobsV2Params {
-                                        block_or_sidecar: pending_block.block.clone_arc().into(),
+                                        block_or_data: pending_block.block.clone_arc().into(),
                                         data_column_identifiers,
                                     }
                                     .into(),
@@ -1719,7 +1743,7 @@ where
 
                         self.request_blobs_from_execution_engine(
                             EngineGetBlobsV2Params {
-                                block_or_sidecar: data_column_sidecar.clone_arc().into(),
+                                block_or_data: data_column_sidecar.clone_arc().into(),
                                 data_column_identifiers,
                             }
                             .into(),
@@ -1801,6 +1825,7 @@ where
                 }
             }
             Ok(DataColumnSidecarAction::DelayUntilParent(data_column_sidecar)) => {
+                // Delay until parent block imported only for Fulu data column sidecar
                 let Some(parent_root) = data_column_sidecar
                     .pre_gloas()
                     .map(|sidecar| sidecar.signed_block_header.message.parent_root)
@@ -1815,7 +1840,6 @@ where
                     submission_time,
                 };
 
-                // TODO: (gloas): gloas block can be imported without sidecars
                 if self.store.contains_block(parent_root) {
                     self.retry_data_column_sidecar(wait_group, pending_data_column_sidecar, None);
                 } else {
@@ -1883,7 +1907,7 @@ where
     #[expect(clippy::too_many_lines)]
     fn handle_execution_payload_envelope(
         &mut self,
-        wait_group: &W,
+        wait_group: W,
         result: Result<ExecutionPayloadEnvelopeAction<P>>,
         origin: ExecutionPayloadEnvelopeOrigin,
         submission_time: Instant,
@@ -1913,7 +1937,10 @@ where
                     self.send_to_p2p(P2pMessage::Accept(gossip_id));
                 }
 
-                reply_to_http_api(sender, Ok(ValidationOutcome::Accept));
+                reply_payload_envelope_validation_result_to_http_api(
+                    sender,
+                    Ok(ValidationOutcome::Accept),
+                );
             }
             Ok(ExecutionPayloadEnvelopeAction::Ignore(publishable)) => {
                 if let Some(metrics) = self.metrics.as_ref() {
@@ -1926,7 +1953,10 @@ where
                     self.send_to_p2p(P2pMessage::Ignore(gossip_id));
                 }
 
-                reply_to_http_api(sender, Ok(ValidationOutcome::Ignore(publishable)));
+                reply_payload_envelope_validation_result_to_http_api(
+                    sender,
+                    Ok(ValidationOutcome::Ignore(publishable)),
+                );
             }
             Ok(ExecutionPayloadEnvelopeAction::DelayUntilBeaconBlock(
                 execution_payload_envelope,
@@ -1966,7 +1996,7 @@ where
                         .existing_state_at_slot(&self.store, beacon_block_root, slot)
                 {
                     self.retry_execution_payload_envelope(
-                        wait_group.clone(),
+                        wait_group,
                         pending_envelope,
                         Some(state),
                     );
@@ -1983,37 +2013,152 @@ where
                         .push(pending_envelope);
                 }
             }
-            Ok(ExecutionPayloadEnvelopeAction::DelayUntilData(execution_payload_envelope)) => {
+            Ok(ExecutionPayloadEnvelopeAction::DelayUntilData(
+                execution_payload_envelope,
+                state,
+            )) => {
                 if let Some(metrics) = self.metrics.as_ref() {
                     metrics.register_mutator_execution_payload_envelope(&["delayed_until_data"]);
                 }
 
+                let slot = execution_payload_envelope.slot();
+                let block_root = execution_payload_envelope.block_root();
                 let pending_payload_envelope = PendingExecutionPayloadEnvelope {
                     execution_payload_envelope,
                     origin,
                     submission_time,
                 };
-                if self.store.is_data_available_for_envelope(
+
+                let envelope_data_column_availability = self.envelope_data_column_availability(
                     &pending_payload_envelope.execution_payload_envelope,
-                ) {
-                    self.retry_execution_payload_envelope(
-                        wait_group.clone(),
-                        pending_payload_envelope,
-                        None,
-                    );
-                } else {
-                    let slot = pending_payload_envelope.slot();
-                    let block_root = pending_payload_envelope.block_root();
+                    self.delayed_until_state
+                        .get(&(block_root, state.slot()))
+                        .iter()
+                        .flat_map(|delayed| delayed.data_column_sidecars.iter())
+                        .map(|pending| pending.data_column_sidecar.as_ref()),
+                );
 
-                    debug_with_peers!(
-                        "execution payload envelope delayed until data available \
-                         (block_root: {block_root:?}, slot: {slot})",
-                    );
+                debug_with_peers!(
+                    "data availability for block: {:?} with origin: {:?} at slot: {}: {envelope_data_column_availability:?}",
+                    block_root,
+                    pending_payload_envelope.origin,
+                    slot,
+                );
 
-                    self.delay_execution_payload_envelope_until_data(
-                        block_root,
-                        pending_payload_envelope,
-                    );
+                // Reuse `BlockDataColumnAvailability` state for DA of payload envelope since there
+                // is no significant changes
+                match envelope_data_column_availability {
+                    EnvelopeDataColumnAvailability::Complete => {
+                        self.retry_execution_payload_envelope(
+                            wait_group,
+                            pending_payload_envelope,
+                            None,
+                        );
+                    }
+                    EnvelopeDataColumnAvailability::AnyPending => {
+                        self.delay_execution_payload_envelope_until_data(
+                            block_root,
+                            pending_payload_envelope,
+                        );
+
+                        self.take_delayed_until_state(block_root, state.slot())
+                            .unwrap_or_default()
+                            .data_column_sidecars
+                            .into_iter()
+                            .for_each(|pending_data_column| {
+                                self.retry_data_column_sidecar(
+                                    wait_group.clone(),
+                                    pending_data_column,
+                                    Some(state.clone_arc()),
+                                );
+                            });
+                    }
+                    EnvelopeDataColumnAvailability::CompleteWithReconstruction => {
+                        if let Some(gossip_id) = pending_payload_envelope.origin.gossip_id() {
+                            self.send_to_p2p(P2pMessage::Accept(gossip_id));
+                        }
+
+                        if self
+                            .store
+                            .indices_of_missing_data_columns_for_envelope(
+                                &pending_payload_envelope.execution_payload_envelope,
+                            )
+                            .is_empty()
+                        {
+                            self.retry_execution_payload_envelope(
+                                wait_group,
+                                pending_payload_envelope,
+                                None,
+                            );
+                        } else {
+                            if !matches!(
+                                pending_payload_envelope.origin,
+                                ExecutionPayloadEnvelopeOrigin::Own
+                            ) && !self.store.is_sidecars_construction_started(&block_root)
+                            {
+                                self.send_to_pool(PoolMessage::ReconstructDataColumnsForEnvelope {
+                                    wait_group,
+                                    block_root,
+                                    envelope: pending_payload_envelope
+                                        .execution_payload_envelope
+                                        .clone_arc(),
+                                    origin: pending_payload_envelope.origin.clone(),
+                                    slot,
+                                })
+                            }
+
+                            self.delay_execution_payload_envelope_until_data(
+                                block_root,
+                                pending_payload_envelope,
+                            );
+                        }
+                    }
+                    EnvelopeDataColumnAvailability::Missing(missing_column_indices) => {
+                        debug_with_peers!(
+                            "payload envelope delayed until sufficient data column sidecars are available \
+                             (missing columns: {missing_column_indices:?}, block root: {block_root:?})",
+                        );
+
+                        if let Some(gossip_id) = pending_payload_envelope.origin.gossip_id() {
+                            self.send_to_p2p(P2pMessage::Accept(gossip_id));
+                        }
+
+                        let pending_payload_envelope =
+                            reply_delayed_payload_envelope_validation_result(
+                                pending_payload_envelope,
+                                Ok(ValidationOutcome::Ignore(false)),
+                            );
+
+                        if self.store.is_forward_synced()
+                            && !self.store.has_requested_blobs_from_el(&block_root)
+                            && !self.store.is_sidecars_construction_started(&block_root)
+                        {
+                            self.store_mut()
+                                .mark_requested_blobs_from_el(block_root, slot);
+                            self.update_store_snapshot();
+
+                            let data_column_identifiers = missing_column_indices
+                                .into_iter()
+                                .map(|index| DataColumnIdentifier { block_root, index })
+                                .collect_vec();
+
+                            self.request_blobs_from_execution_engine(
+                                EngineGetBlobsV2Params {
+                                    block_or_data: pending_payload_envelope
+                                        .execution_payload_envelope
+                                        .clone_arc()
+                                        .into(),
+                                    data_column_identifiers,
+                                }
+                                .into(),
+                            );
+                        }
+
+                        self.delay_execution_payload_envelope_until_data(
+                            block_root,
+                            pending_payload_envelope,
+                        );
+                    }
                 }
             }
             Err(error) => {
@@ -2033,7 +2178,7 @@ where
                     ));
                 }
 
-                reply_to_http_api(sender, Err(anyhow!(source)));
+                reply_payload_envelope_validation_result_to_http_api(sender, Err(anyhow!(source)));
             }
         }
 
@@ -2328,10 +2473,15 @@ where
         &mut self,
         wait_group: &W,
         block_root: H256,
-        block: &SignedBeaconBlock<P>,
+        block_or_envelope: BlockOrEnvelope<P>,
         mut data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
     ) {
-        let missing_indices = self.store.indices_of_missing_data_columns(block);
+        let missing_indices = match block_or_envelope {
+            BlockOrEnvelope::Block(block) => self.store.indices_of_missing_data_columns(&block),
+            BlockOrEnvelope::Envelope(envelope) => self
+                .store
+                .indices_of_missing_data_columns_for_envelope(&envelope),
+        };
 
         if missing_indices.is_empty() {
             return;
@@ -3244,13 +3394,13 @@ where
 
     fn delay_execution_payload_envelope_until_block(
         &mut self,
-        wait_group: &W,
+        wait_group: W,
         pending_execution_payload_envelope: PendingExecutionPayloadEnvelope<P>,
         beacon_block_root: H256,
     ) {
         if self.store.contains_block(beacon_block_root) {
             self.retry_execution_payload_envelope(
-                wait_group.clone(),
+                wait_group,
                 pending_execution_payload_envelope,
                 None,
             );
@@ -3440,6 +3590,7 @@ where
         else {
             return;
         };
+
         self.delayed_until_block
             .entry(parent_root)
             .or_default()
@@ -3852,7 +4003,7 @@ where
 
         self.delayed_until_data
             .retain(|_, pending_payload_envelope| {
-                if pending_payload_envelope.slot() > finalized_slot {
+                if pending_payload_envelope.execution_payload_envelope.slot() > finalized_slot {
                     return true;
                 }
 
@@ -4492,14 +4643,14 @@ where
         block: &SignedBeaconBlock<P>,
         mut pending_data_columns_for_block: impl Iterator<Item = &'column DataColumnSidecar<P>>,
     ) -> BlockDataColumnAvailability {
-        if !block.phase().is_peerdas_activated() {
-            return BlockDataColumnAvailability::Irrelevant;
-        }
-
-        // TODO: (gloas): get `blob_kzg_commitments` from post-gloas payload envelope
         let Some(body) = block.message().body().with_blob_kzg_commitments() else {
             return BlockDataColumnAvailability::Irrelevant;
         };
+
+        // Only check DA with payload envelope for post-Gloas block
+        if block.phase() >= Phase::Gloas {
+            return BlockDataColumnAvailability::Irrelevant;
+        }
 
         let missing_indices = self.store.indices_of_missing_data_columns(block);
 
@@ -4532,6 +4683,56 @@ where
 
         BlockDataColumnAvailability::Missing(missing_indices)
     }
+
+    fn envelope_data_column_availability<'column>(
+        &self,
+        envelope: &SignedExecutionPayloadEnvelope<P>,
+        mut pending_data_columns_for_block: impl Iterator<Item = &'column DataColumnSidecar<P>>,
+    ) -> EnvelopeDataColumnAvailability {
+        let missing_indices = self
+            .store
+            .indices_of_missing_data_columns_for_envelope(envelope);
+
+        if missing_indices.is_empty() {
+            return EnvelopeDataColumnAvailability::Complete;
+        }
+
+        let any_pending_columns = pending_data_columns_for_block.any(|data_column_sidecar| {
+            missing_indices.contains(&data_column_sidecar.index())
+                && data_column_sidecar.kzg_commitments() == envelope.blob_kzg_commitments()
+        });
+
+        if any_pending_columns {
+            return EnvelopeDataColumnAvailability::AnyPending;
+        }
+
+        let available_columns_count = self
+            .store
+            .sampling_columns_count()
+            .saturating_sub(missing_indices.len());
+
+        if available_columns_count * 2 >= P::NumberOfColumns::USIZE
+            && (self.store.is_forward_synced()
+                || !self.store.store_config().sync_without_reconstruction)
+        {
+            return EnvelopeDataColumnAvailability::CompleteWithReconstruction;
+        }
+
+        EnvelopeDataColumnAvailability::Missing(missing_indices)
+    }
+
+    fn execution_payload_envelope_by_root(
+        &self,
+        block_root: H256,
+    ) -> Result<Option<Arc<SignedExecutionPayloadEnvelope<P>>>> {
+        match self
+            .store
+            .cached_execution_payload_envelope_by_root(block_root)
+        {
+            Some(envelope) => Ok(Some(envelope.clone_arc())),
+            None => self.storage.execution_payload_envelope_by_root(block_root),
+        }
+    }
 }
 
 fn reply_to_http_api(
@@ -4553,6 +4754,19 @@ fn reply_block_validation_result_to_http_api(
         && let Err(reply) = sender.try_send(reply)
     {
         debug_with_peers!("reply to HTTP API failed because the receiver was dropped: {reply:?}");
+    }
+}
+
+fn reply_payload_envelope_validation_result_to_http_api(
+    sender: Option<MultiSender<Result<ValidationOutcome>>>,
+    reply: Result<ValidationOutcome>,
+) {
+    if let Some(mut sender) = sender {
+        if let Err(reply) = sender.try_send(reply) {
+            debug_with_peers!(
+                "reply to HTTP API failed because the receiver was dropped: {reply:?}"
+            );
+        }
     }
 }
 
@@ -4582,6 +4796,33 @@ fn reply_delayed_block_validation_result<P: Preset>(
             origin,
             processing_timings,
             tracing_span,
+        }
+    }
+}
+
+fn reply_delayed_payload_envelope_validation_result<P: Preset>(
+    pending_envelope: PendingExecutionPayloadEnvelope<P>,
+    reply: Result<ValidationOutcome>,
+) -> PendingExecutionPayloadEnvelope<P> {
+    let PendingExecutionPayloadEnvelope {
+        execution_payload_envelope,
+        origin,
+        submission_time,
+    } = pending_envelope;
+
+    if let ExecutionPayloadEnvelopeOrigin::Api(Some(sender)) = origin {
+        reply_payload_envelope_validation_result_to_http_api(Some(sender), reply);
+
+        PendingExecutionPayloadEnvelope {
+            execution_payload_envelope,
+            origin: ExecutionPayloadEnvelopeOrigin::Api(None),
+            submission_time,
+        }
+    } else {
+        PendingExecutionPayloadEnvelope {
+            execution_payload_envelope,
+            origin,
+            submission_time,
         }
     }
 }

--- a/fork_choice_control/src/queries.rs
+++ b/fork_choice_control/src/queries.rs
@@ -431,6 +431,11 @@ where
         self.store_snapshot().contains_block(block_root)
     }
 
+    pub fn contains_block_and_data_available(&self, block_root: H256) -> bool {
+        self.store_snapshot()
+            .contains_block_and_data_available(block_root)
+    }
+
     pub fn block_by_root(
         &self,
         block_root: H256,
@@ -561,7 +566,7 @@ where
             .filter_map(|block_root| {
                 // Check cache then fallback to database
                 match snapshot.cached_execution_payload_envelope(block_root) {
-                    Some(envelope) => Some(Ok(envelope)),
+                    Some(envelope) => Some(Ok(envelope.clone_arc())),
                     None => storage
                         .execution_payload_envelope_by_root(block_root)
                         .transpose(),
@@ -570,6 +575,19 @@ where
             .collect::<Result<Vec<_>>>()?;
 
         Ok(envelopes)
+    }
+
+    pub fn execution_payload_envelope_by_root(
+        &self,
+        block_root: H256,
+    ) -> Result<Option<Arc<SignedExecutionPayloadEnvelope<P>>>> {
+        let snapshot = self.snapshot();
+        let storage = self.storage();
+
+        match snapshot.cached_execution_payload_envelope(block_root) {
+            Some(envelope) => Ok(Some(envelope.clone_arc())),
+            None => storage.execution_payload_envelope_by_root(block_root),
+        }
     }
 
     pub fn blocks_by_root(
@@ -1293,7 +1311,7 @@ impl<P: Preset> Snapshot<'_, P> {
     pub(crate) fn cached_execution_payload_envelope(
         &self,
         block_root: H256,
-    ) -> Option<Arc<SignedExecutionPayloadEnvelope<P>>> {
+    ) -> Option<&Arc<SignedExecutionPayloadEnvelope<P>>> {
         self.store_snapshot
             .cached_execution_payload_envelope_by_root(block_root)
     }

--- a/fork_choice_store/src/error.rs
+++ b/fork_choice_store/src/error.rs
@@ -204,6 +204,11 @@ pub enum Error<P: Preset> {
     PayloadEnvelopeInvalidBlock {
         payload_envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
     },
+    #[error("payload envelope validation with pre-Gloas state: (envelope_slot: {envelope_slot}, state_slot: {state_slot})")]
+    PayloadEnvelopeWithPreGloasState {
+        envelope_slot: Slot,
+        state_slot: Slot,
+    },
     #[error("terminal PoW block has incorrect hash: {block:?}")]
     TerminalBlockHashMismatch { block: Arc<SignedBeaconBlock<P>> },
     #[error(

--- a/fork_choice_store/src/execution_payload_envelope_cache.rs
+++ b/fork_choice_store/src/execution_payload_envelope_cache.rs
@@ -12,8 +12,8 @@ pub struct ExecutionPayloadEnvelopeCache<P: Preset> {
 }
 
 impl<P: Preset> ExecutionPayloadEnvelopeCache<P> {
-    pub fn get(&self, block_root: H256) -> Option<Arc<SignedExecutionPayloadEnvelope<P>>> {
-        Some(self.envelopes.get(&block_root)?.0.clone_arc())
+    pub fn get(&self, block_root: H256) -> Option<&Arc<SignedExecutionPayloadEnvelope<P>>> {
+        Some(&self.envelopes.get(&block_root)?.0)
     }
 
     pub fn insert(&mut self, envelope: Arc<SignedExecutionPayloadEnvelope<P>>) {

--- a/fork_choice_store/src/misc.rs
+++ b/fork_choice_store/src/misc.rs
@@ -1001,33 +1001,30 @@ pub enum PartialAttestationAction {
     DelayUntilSlot,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, AsRefStr)]
 pub enum ExecutionPayloadEnvelopeOrigin {
     BackSync,
     Gossip(GossipId),
     Requested(PeerId),
     Own,
+    Api(Option<Sender<Result<ValidationOutcome>>>),
 }
 
 impl ExecutionPayloadEnvelopeOrigin {
     #[must_use]
-    pub fn split(
-        self,
-    ) -> (
-        Option<GossipId>,
-        Option<OneshotSender<Result<ValidationOutcome>>>,
-    ) {
+    pub fn split(self) -> (Option<GossipId>, Option<Sender<Result<ValidationOutcome>>>) {
         match self {
             Self::Gossip(gossip_id) => (Some(gossip_id), None),
+            Self::Api(sender) => (None, sender),
             Self::BackSync | Self::Requested(_) | Self::Own => (None, None),
         }
     }
 
     #[must_use]
-    pub fn gossip_id(self) -> Option<GossipId> {
+    pub fn gossip_id(&self) -> Option<GossipId> {
         match self {
-            Self::Gossip(gossip_id) => Some(gossip_id),
-            Self::BackSync | Self::Requested(_) | Self::Own => None,
+            Self::Gossip(gossip_id) => Some(gossip_id.clone()),
+            Self::BackSync | Self::Requested(_) | Self::Own | Self::Api(_) => None,
         }
     }
 
@@ -1035,7 +1032,7 @@ impl ExecutionPayloadEnvelopeOrigin {
     pub const fn gossip_id_ref(&self) -> Option<&GossipId> {
         match self {
             Self::Gossip(gossip_id) => Some(gossip_id),
-            Self::BackSync | Self::Requested(_) | Self::Own => None,
+            Self::BackSync | Self::Requested(_) | Self::Own | Self::Api(_) => None,
         }
     }
 
@@ -1048,7 +1045,7 @@ impl ExecutionPayloadEnvelopeOrigin {
     #[must_use]
     pub const fn verify_signatures(&self) -> bool {
         match self {
-            Self::BackSync | Self::Gossip(_) | Self::Requested(_) => true,
+            Self::BackSync | Self::Gossip(_) | Self::Requested(_) | Self::Api(_) => true,
             Self::Own => false,
         }
     }
@@ -1056,6 +1053,11 @@ impl ExecutionPayloadEnvelopeOrigin {
     #[must_use]
     pub const fn is_from_back_sync(&self) -> bool {
         matches!(self, Self::BackSync)
+    }
+
+    #[must_use]
+    pub const fn is_requested(&self) -> bool {
+        matches!(self, Self::Requested(_))
     }
 }
 
@@ -1065,7 +1067,7 @@ pub enum ExecutionPayloadEnvelopeAction<P: Preset> {
     Ignore(Publishable),
     DelayUntilBeaconBlock(Arc<SignedExecutionPayloadEnvelope<P>>, H256),
     DelayUntilState(Arc<SignedExecutionPayloadEnvelope<P>>, H256, Slot),
-    DelayUntilData(Arc<SignedExecutionPayloadEnvelope<P>>),
+    DelayUntilData(Arc<SignedExecutionPayloadEnvelope<P>>, Arc<BeaconState<P>>),
 }
 
 impl<P: Preset> ExecutionPayloadEnvelopeAction<P> {

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -411,7 +411,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
     pub fn cached_execution_payload_envelope_by_root(
         &self,
         block_root: H256,
-    ) -> Option<Arc<SignedExecutionPayloadEnvelope<P>>> {
+    ) -> Option<&Arc<SignedExecutionPayloadEnvelope<P>>> {
         self.execution_payload_envelope_cache.get(block_root)
     }
 
@@ -519,6 +519,29 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
     pub fn contains_block(&self, block_root: H256) -> bool {
         self.contains_unfinalized_block(block_root)
             || self.finalized_indices.contains_key(&block_root)
+    }
+
+    // Pre-Gloas: once block imported into fork choice, data is also available,
+    // Post-Gloas: block can be imported without data availability check
+    // For Pre-Gloas block, checking `Self::contains_block` is enough,
+    // but for Post-Gloas, an additional data availability check is required
+    #[must_use]
+    pub fn contains_block_and_data_available(&self, block_root: H256) -> bool {
+        let is_block_imported = self.contains_block(block_root);
+        let is_pre_gloas = self
+            .block(block_root)
+            .map(|chain_link| chain_link.value.phase() < Phase::Gloas)
+            .unwrap_or(false);
+
+        is_block_imported
+            && (is_pre_gloas
+                || self
+                    .cached_execution_payload_envelope_by_root(block_root)
+                    .map(|envelope| {
+                        self.indices_of_missing_data_columns_for_envelope(envelope)
+                            .is_empty()
+                    })
+                    .unwrap_or(false))
     }
 
     fn contains_unfinalized_block(&self, block_root: H256) -> bool {
@@ -1212,7 +1235,9 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             return Ok(action);
         }
 
+        // Start from Gloas, block can be imported without data availability check
         if self.should_check_data_availability_at_slot(block.message().slot())
+            && !state.is_post_gloas()
             && data_availability_policy.check()
         {
             if state.phase().is_peerdas_activated() {
@@ -2445,9 +2470,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         // i.e. already have all the data columns validated
         // The exception to this is data column sidecars from custody group column backfill,
         // where additional columns are being downloaded for blocks already in fork choice.
-        // TODO: (gloas): gloas block can be imported without sidecars, change this to
-        // `contains_block_and_sidecars` new function
-        if validate_block_presence && self.contains_block(block_root) {
+        if validate_block_presence && self.contains_block_and_data_available(block_root) {
             return Ok(DataColumnSidecarAction::Ignore(false));
         }
 
@@ -2689,21 +2712,16 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             ));
         };
 
-        if origin.verify_signatures() {
-            // [REJECT] The builder signature envelope.signature is valid
-            SingleVerifier.verify_singular(
-                envelope.message.signing_root(&self.chain_config, &state),
-                envelope.signature,
-                self.pubkey_cache
-                    .get_or_insert(*accessors::public_key(&state, builder_index)?)?,
-                SignatureKind::ExecutionPayloadEnvelope,
-            )?;
-        }
-
         // > Check if blob data is available
         // > If not, this payload MAY be queued and subsequently considered when blob data becomes available
-        if !self.is_data_available_for_envelope(&envelope) {
-            return Ok(ExecutionPayloadEnvelopeAction::DelayUntilData(envelope));
+        if self.should_check_data_availability_at_slot(slot)
+            && !self
+                .indices_of_missing_data_columns_for_envelope(&envelope)
+                .is_empty()
+        {
+            return Ok(ExecutionPayloadEnvelopeAction::DelayUntilData(
+                envelope, state,
+            ));
         }
 
         // [IGNORE] The envelope's beacon_block_root has been seen (via gossip or non-gossip sources)
@@ -2763,6 +2781,31 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
                 expected: Box::new(bid.block_hash),
             },
         );
+
+        if origin.verify_signatures() {
+            let Some(post_gloas_state) = state.post_gloas() else {
+                return Err(Error::<P>::PayloadEnvelopeWithPreGloasState {
+                    envelope_slot: slot,
+                    state_slot: state.slot(),
+                }
+                .into());
+            };
+
+            // Verify signature with proposer key if proposer choose to self-build
+            let pubkey = if builder_index == BUILDER_INDEX_SELF_BUILD {
+                *accessors::public_key(&state, block.message().proposer_index())?
+            } else {
+                post_gloas_state.builders().get(builder_index)?.pubkey
+            };
+
+            // [REJECT] The builder signature envelope.signature is valid
+            SingleVerifier.verify_singular(
+                envelope.message.signing_root(&self.chain_config, &state),
+                envelope.signature,
+                self.pubkey_cache.get_or_insert(pubkey)?,
+                SignatureKind::ExecutionPayloadEnvelope,
+            )?;
+        }
 
         Ok(ExecutionPayloadEnvelopeAction::Accept(envelope))
     }
@@ -4482,11 +4525,8 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         &self,
         block: &SignedBeaconBlock<P>,
     ) -> Vec<ColumnIndex> {
-        let phase = block.phase();
         let block = block.message();
 
-        // TODO: (gloas): get `blob_kzg_commitments` from post-gloas payload envelope
-        //
         // `block.phase` has already been checked
         let Some(body) = block.body().with_blob_kzg_commitments() else {
             return vec![];
@@ -4501,43 +4541,39 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         self.sampling_columns
             .iter()
             .filter(|index| {
-                if phase >= Phase::Gloas {
-                    !self
-                        .accepted_gloas_data_column_sidecars
-                        .get(&(block.slot(), block_root, **index))
-                        .is_some_and(|kzg_commitments| {
-                            kzg_commitments == body.blob_kzg_commitments()
-                        })
-                } else {
-                    !self
-                        .accepted_data_column_sidecars
-                        .get(&(block.slot(), block.proposer_index(), **index))
-                        .is_some_and(|kzg_commitments| {
-                            kzg_commitments.get(&block_root) == Some(body.blob_kzg_commitments())
-                        })
-                }
+                !self
+                    .accepted_data_column_sidecars
+                    .get(&(block.slot(), block.proposer_index(), **index))
+                    .is_some_and(|kzg_commitments| {
+                        kzg_commitments.get(&block_root) == Some(body.blob_kzg_commitments())
+                    })
             })
             .copied()
             .collect()
     }
 
-    pub fn is_data_available_for_envelope(
+    pub fn indices_of_missing_data_columns_for_envelope(
         &self,
         envelope: &SignedExecutionPayloadEnvelope<P>,
-    ) -> bool {
-        let slot = envelope.message.slot;
-        let block_root = envelope.message.beacon_block_root;
-        let blob_kzg_commitments = &envelope.message.blob_kzg_commitments;
-
+    ) -> Vec<ColumnIndex> {
+        let blob_kzg_commitments = envelope.blob_kzg_commitments();
         if blob_kzg_commitments.is_empty() {
-            return true;
+            return vec![];
         }
 
-        self.sampling_columns.iter().all(|index| {
-            self.accepted_gloas_data_column_sidecars
-                .get(&(slot, block_root, *index))
-                .is_some_and(|kzg_commitments| kzg_commitments == blob_kzg_commitments)
-        })
+        let slot = envelope.slot();
+        let block_root = envelope.block_root();
+
+        self.sampling_columns
+            .iter()
+            .filter(|&column_index| {
+                !self
+                    .accepted_gloas_data_column_sidecars
+                    .get(&(slot, block_root, *column_index))
+                    .is_some_and(|kzg_commitments| kzg_commitments == blob_kzg_commitments)
+            })
+            .copied()
+            .collect()
     }
 
     pub fn register_rejected_block(&mut self, block_root: H256) {

--- a/operation_pools/src/blob_reconstruction_pool/manager.rs
+++ b/operation_pools/src/blob_reconstruction_pool/manager.rs
@@ -7,14 +7,14 @@ use fork_choice_control::Wait;
 use prometheus_metrics::Metrics;
 use std_ext::ArcExt as _;
 use types::{
-    combined::SignedBeaconBlock,
+    nonstandard::BlockOrEnvelope,
     phase0::primitives::{H256, Slot},
     preset::Preset,
 };
 
 use crate::{blob_reconstruction_pool::tasks::ReconstructDataColumnSidecarsTask, misc::PoolTask};
 
-pub type ReconstructionParams<P, W> = (W, H256, Arc<SignedBeaconBlock<P>>, Slot);
+pub type ReconstructionParams<P, W> = (W, H256, BlockOrEnvelope<P>, Slot);
 
 pub struct Manager<P: Preset, W: Wait> {
     controller: ApiController<P, W>,
@@ -42,8 +42,10 @@ impl<P: Preset, W: Wait> Manager<P, W> {
         let mut reconstructions = self.scheduled_reconstructions.split_off(&Instant::now());
         core::mem::swap(&mut self.scheduled_reconstructions, &mut reconstructions);
 
-        for (wait_group, block_root, block, slot) in reconstructions.into_values().flatten() {
-            self.spawn_reconstruction(wait_group, block_root, block, slot);
+        for (wait_group, block_root, block_or_envelope, slot) in
+            reconstructions.into_values().flatten()
+        {
+            self.spawn_reconstruction(wait_group, block_root, block_or_envelope, slot);
         }
     }
 
@@ -51,21 +53,21 @@ impl<P: Preset, W: Wait> Manager<P, W> {
         &mut self,
         wait_group: W,
         block_root: H256,
-        block: Arc<SignedBeaconBlock<P>>,
+        block_or_envelope: BlockOrEnvelope<P>,
         slot: Slot,
         delay: Duration,
     ) {
         self.scheduled_reconstructions
             .entry(Instant::now() + delay)
             .or_default()
-            .push((wait_group, block_root, block, slot));
+            .push((wait_group, block_root, block_or_envelope, slot));
     }
 
     pub fn spawn_reconstruction(
         &self,
         wait_group: W,
         block_root: H256,
-        block: Arc<SignedBeaconBlock<P>>,
+        block_or_envelope: BlockOrEnvelope<P>,
         slot: Slot,
     ) {
         self.controller
@@ -75,7 +77,7 @@ impl<P: Preset, W: Wait> Manager<P, W> {
             controller: self.controller.clone_arc(),
             wait_group,
             block_root,
-            block,
+            block_or_envelope,
             metrics: self.metrics.clone(),
         })
     }

--- a/operation_pools/src/blob_reconstruction_pool/tasks.rs
+++ b/operation_pools/src/blob_reconstruction_pool/tasks.rs
@@ -9,7 +9,7 @@ use prometheus_metrics::Metrics;
 use tap::Tap as _;
 use typenum::Unsigned as _;
 use types::{
-    combined::SignedBeaconBlock, fulu::containers::DataColumnIdentifier, phase0::primitives::H256,
+    fulu::containers::DataColumnIdentifier, nonstandard::BlockOrEnvelope, phase0::primitives::H256,
     preset::Preset,
 };
 
@@ -18,7 +18,7 @@ pub struct ReconstructDataColumnSidecarsTask<P: Preset, W: Wait> {
     pub controller: ApiController<P, W>,
     pub wait_group: W,
     pub block_root: H256,
-    pub block: Arc<SignedBeaconBlock<P>>,
+    pub block_or_envelope: BlockOrEnvelope<P>,
     pub metrics: Option<Arc<Metrics>>,
 }
 
@@ -30,7 +30,7 @@ impl<P: Preset, W: Wait> PoolTask for ReconstructDataColumnSidecarsTask<P, W> {
             controller,
             wait_group,
             block_root,
-            block,
+            block_or_envelope,
             metrics,
         } = self;
 
@@ -113,7 +113,12 @@ impl<P: Preset, W: Wait> PoolTask for ReconstructDataColumnSidecarsTask<P, W> {
             Ok(data_column_sidecars) => {
                 info_with_peers!("reconstructed missing data columns for block: {block_root:?}");
 
-                controller.on_reconstruction(wait_group, block_root, block, data_column_sidecars);
+                controller.on_reconstruction(
+                    wait_group,
+                    block_root,
+                    block_or_envelope,
+                    data_column_sidecars,
+                );
 
                 if let Some(metrics) = metrics.as_ref() {
                     metrics

--- a/operation_pools/src/manager.rs
+++ b/operation_pools/src/manager.rs
@@ -92,7 +92,25 @@ impl<P: Preset, W: Wait> Manager<P, W> {
                             };
 
                             self.blob_reconstruction_pool
-                                .schedule_reconstruction(wait_group, block_root, block, slot, delay);
+                                .schedule_reconstruction(wait_group, block_root, block.into(), slot, delay);
+                        }
+                        PoolMessage::ReconstructDataColumnsForEnvelope {
+                            wait_group,
+                            block_root,
+                            envelope,
+                            origin,
+                            slot,
+                        } => {
+                            // We don't want to reconstruct blobs on each envelope during sync
+                            // if it downloads data columns relatively fast
+                            let delay = if origin.is_requested() {
+                                RECONSTRUCTION_START_DELAY_SYNCING
+                            } else {
+                                self.reconstruction_delay
+                            };
+
+                            self.blob_reconstruction_pool
+                                .schedule_reconstruction(wait_group, block_root, envelope.into(), slot, delay);
                         }
                     }
                 }

--- a/p2p/src/back_sync.rs
+++ b/p2p/src/back_sync.rs
@@ -376,14 +376,20 @@ impl<P: Preset> Batch<P> {
     ) -> Result<Vec<Arc<DataColumnSidecar<P>>>> {
         let block = block.message();
 
-        // TODO: (gloas): get `blob_kzg_commitments` from post-gloas payload envelope
-        //
-        // `block.phase` has already been checked
-        let Some(body) = block.body().with_blob_kzg_commitments() else {
-            return Ok(vec![]);
-        };
+        // `block.phase` has already been checked (post-Fulu)
+        // False, in case there is blobs in block/envelope, or no envelope has been accepted
+        let no_data = block
+            .body()
+            .with_blob_kzg_commitments()
+            .map(|body| body.blob_kzg_commitments().is_empty())
+            .or_else(|| {
+                self.execution_payload_envelopes
+                    .get(&block.hash_tree_root())
+                    .map(|envelope| envelope.blob_kzg_commitments().is_empty())
+            })
+            .unwrap_or_default();
 
-        if body.blob_kzg_commitments().is_empty() {
+        if no_data {
             return Ok(vec![]);
         }
 

--- a/p2p/src/block_sync_service.rs
+++ b/p2p/src/block_sync_service.rs
@@ -512,9 +512,7 @@ impl<P: Preset> BlockSyncService<P> {
                                 SyncDirection::Forward => {
                                     let data_column_sidecar_slot = data_column_sidecar.slot();
 
-                                    // TODO: (gloas): gloas block can be imported without the
-                                    // sidecars, this should change to `contains_block_and_sidecars`
-                                    if !self.controller.contains_block(data_column_identifier.block_root)
+                                    if !self.controller.contains_block_and_data_available(data_column_identifier.block_root)
                                         && self.register_new_received_data_column_sidecar(
                                             data_column_identifier,
                                             data_column_sidecar_slot,
@@ -1406,9 +1404,11 @@ impl<P: Preset> BlockSyncService<P> {
             columns: indices,
         } = data_columns_by_root;
 
-        // TODO: (gloas): gloas block can be imported without the sidecars
-        if self.controller.contains_block(block_root) {
-            debug_with_peers!("block {block_root:?} already imported into the fork choice");
+        if self
+            .controller
+            .contains_block_and_data_available(block_root)
+        {
+            debug_with_peers!("data is already available for block {block_root:?}");
             return Ok(());
         }
 
@@ -1500,10 +1500,13 @@ impl<P: Preset> BlockSyncService<P> {
             return Ok(());
         };
 
-        // TODO: (gloas): gloas block can be imported without consider data availability
         let missing_column_by_indices = missing_column_indices_by_root
             .into_iter()
-            .filter(|(block_root, _)| !self.controller.contains_block(*block_root))
+            .filter(|(block_root, _)| {
+                !self
+                    .controller
+                    .contains_block_and_data_available(*block_root)
+            })
             .fold(HashMap::new(), |mut acc, (block_root, indices)| {
                 for index in indices {
                     acc.entry(index)

--- a/types/src/nonstandard.rs
+++ b/types/src/nonstandard.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     electra::containers::ExecutionRequests,
     fulu::containers::DataColumnIdentifier,
+    gloas::containers::SignedExecutionPayloadEnvelope,
     phase0::{
         containers::SignedBeaconBlockHeader,
         primitives::{Gwei, H256, Slot, Uint256, UnixSeconds, ValidatorIndex},
@@ -208,6 +209,12 @@ impl AttestationOutcome {
     }
 }
 
+#[derive(Clone, Debug, From)]
+pub enum BlockOrEnvelope<P: Preset> {
+    Block(Arc<SignedBeaconBlock<P>>),
+    Envelope(Arc<SignedExecutionPayloadEnvelope<P>>),
+}
+
 #[derive(Clone, Debug)]
 pub struct BlobSidecarWithId<P: Preset> {
     pub blob_sidecar: Arc<BlobSidecar<P>>,
@@ -376,17 +383,19 @@ impl<P: Preset> KzgProofs<P> {
 }
 
 #[derive(Clone, Debug, From)]
-pub enum BlockOrDataColumnSidecar<P: Preset> {
+pub enum BlockOrData<P: Preset> {
     Block(Arc<SignedBeaconBlock<P>>),
     Sidecar(Arc<DataColumnSidecar<P>>),
+    Envelope(Arc<SignedExecutionPayloadEnvelope<P>>),
 }
 
-impl<P: Preset> BlockOrDataColumnSidecar<P> {
+impl<P: Preset> BlockOrData<P> {
     #[must_use]
     pub fn slot(&self) -> Slot {
         match self {
             Self::Block(block) => block.message().slot(),
             Self::Sidecar(sidecar) => sidecar.slot(),
+            Self::Envelope(envelope) => envelope.slot(),
         }
     }
 
@@ -395,6 +404,7 @@ impl<P: Preset> BlockOrDataColumnSidecar<P> {
         match self {
             Self::Block(block) => block.message().hash_tree_root(),
             Self::Sidecar(sidecar) => sidecar.beacon_block_root(),
+            Self::Envelope(envelope) => envelope.block_root(),
         }
     }
 
@@ -405,6 +415,7 @@ impl<P: Preset> BlockOrDataColumnSidecar<P> {
             Self::Sidecar(sidecar) => sidecar
                 .pre_gloas()
                 .map(|sidecar| sidecar.signed_block_header),
+            Self::Envelope(_) => None,
         }
     }
 
@@ -418,6 +429,7 @@ impl<P: Preset> BlockOrDataColumnSidecar<P> {
                 .with_blob_kzg_commitments()
                 .map(BlockBodyWithBlobKzgCommitments::blob_kzg_commitments),
             Self::Sidecar(sidecar) => Some(sidecar.kzg_commitments()),
+            Self::Envelope(envelope) => Some(envelope.blob_kzg_commitments()),
         }
     }
 }

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -81,8 +81,8 @@ use types::{
         SignedExecutionPayloadEnvelope,
     },
     nonstandard::{
-        CustodyMode, KzgProofs, OwnAttestation, Phase, SyncCommitteeEpoch, WithBlobsAndMev,
-        WithStatus,
+        BlockOrData, CustodyMode, KzgProofs, OwnAttestation, Phase, SyncCommitteeEpoch,
+        WithBlobsAndMev, WithStatus,
     },
     phase0::{
         consts::GENESIS_SLOT,
@@ -1075,17 +1075,11 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
                 let block = Arc::new(*beacon_block);
 
-                if let Some(blobs) = block_blobs
-                    && !blobs.is_empty()
-                {
-                    self.publish_blob_data(&wait_group, slot_head, &block, blobs, block_proofs)
-                        .await?;
-                }
-
                 // Handle Gloas execution payload envelope (only for self-build)
-                if let Some(envelope) = block_build_context
-                    .compute_execution_payload_envelope(beacon_block_root)
-                    .await?
+                let signed_envelope_opt = if slot_head.phase() >= Phase::Gloas
+                    && let Some(envelope) = block_build_context
+                        .compute_execution_payload_envelope(beacon_block_root)
+                        .await?
                 {
                     self.publish_execution_payload_envelope(
                         &wait_group,
@@ -1096,7 +1090,37 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                         &signer_snapshot,
                         public_key,
                     )
-                    .await?;
+                    .await?
+                } else {
+                    None
+                };
+
+                // Assuming after Gloas if proposer doesn't self build, `block_blobs` always None
+                if let Some(blobs) = block_blobs
+                    && !blobs.is_empty()
+                {
+                    if slot_head.phase().is_peerdas_activated() {
+                        // If proposer self build the payload, so they have to publish data as well
+                        if let Some(signed_envelope) = signed_envelope_opt {
+                            self.publish_data_column_sidecars(
+                                &wait_group,
+                                signed_envelope.into(),
+                                blobs,
+                                block_proofs,
+                            )
+                            .await?;
+                        } else {
+                            self.publish_data_column_sidecars(
+                                &wait_group,
+                                block.clone_arc().into(),
+                                blobs,
+                                block_proofs,
+                            )
+                            .await?;
+                        }
+                    } else {
+                        self.publish_blob_sidecars(&wait_group, &block, blobs, block_proofs)?;
+                    }
                 }
 
                 self.controller
@@ -1195,72 +1219,63 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         Ok(signed_block)
     }
 
-    async fn publish_blob_data(
+    async fn publish_data_column_sidecars(
         &self,
         wait_group: &W,
-        slot_head: &SlotHead<P>,
+        block_or_data: BlockOrData<P>,
+        blobs: ContiguousList<Blob<P>, P::MaxBlobCommitmentsPerBlock>,
+        block_proofs: Option<KzgProofs<P>>,
+    ) -> Result<()> {
+        let data_column_sidecars = eip_7594::construct_data_column_sidecars_from_blobs(
+            block_or_data,
+            blobs.to_vec(),
+            block_proofs
+                .unwrap_or_else(KzgProofs::empty_fulu)
+                .into_iter()
+                .collect_vec(),
+            self.controller.store_config().kzg_backend,
+            self.metrics.clone(),
+        )
+        .await?;
+
+        for data_column_sidecar in data_column_sidecars {
+            if self
+                .controller
+                .sampling_columns()
+                .into_iter()
+                .contains(&data_column_sidecar.index())
+            {
+                self.controller
+                    .on_own_data_column_sidecar(wait_group.clone(), data_column_sidecar.clone_arc())
+                    .await;
+            }
+
+            ValidatorToP2p::PublishDataColumnSidecar(data_column_sidecar).send(&self.p2p_tx);
+        }
+
+        Ok(())
+    }
+
+    fn publish_blob_sidecars(
+        &self,
+        wait_group: &W,
         block: &Arc<SignedBeaconBlock<P>>,
         blobs: ContiguousList<Blob<P>, P::MaxBlobCommitmentsPerBlock>,
         block_proofs: Option<KzgProofs<P>>,
     ) -> Result<()> {
-        if self
-            .chain_config
-            .phase_at_slot::<P>(slot_head.slot())
-            .is_peerdas_activated()
-        {
-            let timer = self
-                .metrics
-                .as_ref()
-                .map(|metrics| metrics.data_column_sidecar_computation.start_timer());
+        for blob_sidecar in misc::construct_blob_sidecars(
+            block,
+            blobs.into_iter(),
+            block_proofs
+                .unwrap_or_else(KzgProofs::empty_deneb)
+                .into_iter(),
+        )? {
+            let blob_sidecar = Arc::new(blob_sidecar);
 
-            let block = block.clone_arc();
-            let kzg_backend = self.controller.store_config().kzg_backend;
+            self.controller
+                .on_own_blob_sidecar(wait_group.clone(), blob_sidecar.clone_arc());
 
-            let data_column_sidecars = tokio::task::spawn_blocking(move || {
-                let cells_and_kzg_proofs = eip_7594::try_convert_to_cells_and_kzg_proofs::<P>(
-                    blobs.as_ref(),
-                    block_proofs.unwrap_or_else(KzgProofs::empty_fulu).as_ref(),
-                    kzg_backend,
-                )?;
-
-                eip_7594::construct_fulu_data_column_sidecars(&block, &cells_and_kzg_proofs)
-            })
-            .await??;
-
-            prometheus_metrics::stop_and_record(timer);
-
-            for data_column_sidecar in data_column_sidecars {
-                if self
-                    .controller
-                    .sampling_columns()
-                    .into_iter()
-                    .contains(&data_column_sidecar.index())
-                {
-                    self.controller
-                        .on_own_data_column_sidecar(
-                            wait_group.clone(),
-                            data_column_sidecar.clone_arc(),
-                        )
-                        .await;
-                }
-
-                ValidatorToP2p::PublishDataColumnSidecar(data_column_sidecar).send(&self.p2p_tx);
-            }
-        } else {
-            for blob_sidecar in misc::construct_blob_sidecars(
-                block,
-                blobs.into_iter(),
-                block_proofs
-                    .unwrap_or_else(KzgProofs::empty_deneb)
-                    .into_iter(),
-            )? {
-                let blob_sidecar = Arc::new(blob_sidecar);
-
-                self.controller
-                    .on_own_blob_sidecar(wait_group.clone(), blob_sidecar.clone_arc());
-
-                ValidatorToP2p::PublishBlobSidecar(blob_sidecar).send(&self.p2p_tx);
-            }
+            ValidatorToP2p::PublishBlobSidecar(blob_sidecar).send(&self.p2p_tx);
         }
 
         Ok(())
@@ -1277,7 +1292,7 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         proposer_index: ValidatorIndex,
         signer_snapshot: &Snapshot,
         public_key: &PublicKeyBytes,
-    ) -> Result<()> {
+    ) -> Result<Option<Arc<SignedExecutionPayloadEnvelope<P>>>> {
         // Sign the envelope
         let envelope_sig = match signer_snapshot
             .sign_without_slashing_protection(
@@ -1296,7 +1311,7 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                     slot_head.slot(),
                 );
 
-                return Ok(());
+                return Ok(None);
             }
         };
 
@@ -1316,9 +1331,10 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
         self.controller
             .on_own_execution_payload_envelope(wait_group.clone(), signed_envelope.clone_arc());
 
-        ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope).send(&self.p2p_tx);
+        ValidatorToP2p::PublishExecutionPayloadEnvelope(signed_envelope.clone_arc())
+            .send(&self.p2p_tx);
 
-        Ok(())
+        Ok(Some(signed_envelope))
     }
 
     /// See:


### PR DESCRIPTION
This PR (last commit) update payload envelope handling to check data availability with the envelope `ExecutionPayloadEnvelopeAction::DelayUntilData`, follow the same flow as `BlockAction::DelayUntilBlobs`. it also add support for request `engine_getBlobsV2` with the envelope, and introduce `Store::contains_block_and_data_available` for more precise check in post-Gloas block. This also fix data column sidecars publishing when self-build payload.