### PR TITLE
Fix Nethermind plugin with pinned reference assemblies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,9 @@ jobs:
   build_csharp_bindings:
     name: Build C# bindings
     runs-on: ubuntu-latest
+    needs: [version]
+    env:
+      NETHERMIND_VERSION: ${{ needs.version.outputs.nethermind }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -148,7 +151,9 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Build nethermind plugin
-        run: make nethermind-plugin
+        run: | 
+          make nethermind-plugin \
+            NETHERMIND_VERSION=${{ env.NETHERMIND_VERSION }}
 
       - name: Upload C# bindings dll
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ aarch64-apple-darwin: ./target/aarch64-apple-darwin/compact/grandine ./target/aa
 
 # ------ GRANDINE-NETHERMIND INTEGRATION ------
 
-NETHERMIND_VERSION ?=
+NETHERMIND_VERSION ?= 1.36.0
 # If empty, public authentication will happen. Public auth rate limits by ip address, so may fail unexpectedly.
 GITHUB_TOKEN ?=
 
@@ -118,6 +118,7 @@ GITHUB_TOKEN ?=
 nethermind-plugin: ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/Grandine.NethermindPlugin.dll
 ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/Grandine.NethermindPlugin.dll:
 	cd ./bindings/csharp && \
+	dotnet add ./Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj package Nethermind.ReferenceAssemblies --version $(NETHERMIND_VERSION) && \
 	dotnet publish -c Release
 
 .PHONY: clean-nethermind-plugin


### PR DESCRIPTION
After 1.36.0 release, the plugin broke due to mismatched Nethermind.ReferenceAssemblies version. Now the package version is pinned to match the Nethermind release before building, preventing future version mimstaches.