### PR TITLE
Implemented EL client version in nethermind plugin

### DIFF
--- a/bindings/c/src/arrays.rs
+++ b/bindings/c/src/arrays.rs
@@ -1,6 +1,8 @@
 use std::fmt::{self, Debug};
 
-use ethereum_types::H64;
+use anyhow::{Context, Error};
+use eth1_api::ClientCode;
+use ethereum_types::{H32, H64};
 use primitive_types::{H160, H256, H384};
 use ssz::Uint256;
 
@@ -111,5 +113,73 @@ impl Into<H64> for CH64 {
 impl From<H64> for CH64 {
     fn from(value: H64) -> Self {
         Self(value.0)
+    }
+}
+
+#[derive(Clone, Default)]
+#[repr(C)]
+pub struct CH32([u8; 4]);
+
+impl Debug for CH32 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CH32")
+            .field(&format!("0x{}", hex::encode(self.0)))
+            .finish()
+    }
+}
+
+impl Into<H32> for CH32 {
+    fn into(self) -> H32 {
+        H32(self.0)
+    }
+}
+
+impl From<H32> for CH32 {
+    fn from(value: H32) -> Self {
+        Self(value.0)
+    }
+}
+
+#[derive(Clone, Default)]
+#[repr(C)]
+pub struct CH16([u8; 2]);
+
+impl Debug for CH16 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CH16")
+            .field(&format!("0x{}", hex::encode(self.0)))
+            .finish()
+    }
+}
+
+impl Into<[u8; 2]> for CH16 {
+    fn into(self) -> [u8; 2] {
+        self.0
+    }
+}
+
+impl TryFrom<ClientCode> for CH16 {
+    type Error = Error;
+
+    fn try_from(value: ClientCode) -> Result<Self, Self::Error> {
+        let str = value.as_str();
+
+        let bytes: [u8; 2] = str
+            .as_bytes()
+            .try_into()
+            .context("client code is not valid 2-byte ASCII string")?;
+
+        Ok(Self(bytes))
+    }
+}
+
+impl TryInto<ClientCode> for CH16 {
+    type Error = Error;
+
+    fn try_into(self) -> Result<ClientCode, Self::Error> {
+        let str =
+            str::from_utf8(&self.0).context("client code cannot be converted to UTF-8 string")?;
+
+        str.parse().context("invalid code")
     }
 }

--- a/bindings/c/src/containers.rs
+++ b/bindings/c/src/containers.rs
@@ -1,5 +1,7 @@
 use std::{ffi::CString, sync::Arc};
 
+use anyhow::{Context, Error, anyhow};
+use eth1_api::ClientVersionV1;
 use execution_engine::{
     BlobAndProofV1, BlobAndProofV2, BlobsBundleV1, BlobsBundleV2, EngineGetPayloadV2Response,
     EngineGetPayloadV3Response, EngineGetPayloadV4Response, EngineGetPayloadV5Response,
@@ -16,8 +18,8 @@ use types::{
 };
 
 use crate::{
-    arrays::{CH64, CH160, CH256, CH384},
-    generic::{CErrorMessage, COption, CVec},
+    arrays::{CH16, CH32, CH64, CH160, CH256, CH384},
+    generic::{CGrandineString, COption, CVec},
 };
 
 #[derive(Debug)]
@@ -433,7 +435,7 @@ impl Into<PayloadValidationStatus> for CPayloadValidationStatus {
 pub struct CPayloadStatusV1 {
     status: CPayloadValidationStatus,
     latest_valid_hash: COption<CH256>,
-    validation_error: CErrorMessage,
+    validation_error: CGrandineString,
 }
 
 impl Into<PayloadStatusV1> for CPayloadStatusV1 {
@@ -735,5 +737,56 @@ impl TryInto<Blob<Mainnet>> for CVec<u8> {
 
     fn try_into(self) -> Result<Blob<Mainnet>, Self::Error> {
         Ok(Box::new(self.try_into()?))
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct CClientVersionV1 {
+    code: CH16,
+    name: CGrandineString,
+    version: CGrandineString,
+    commit: CH32,
+}
+
+impl TryFrom<ClientVersionV1> for CClientVersionV1 {
+    type Error = Error;
+
+    fn try_from(value: ClientVersionV1) -> Result<Self, Self::Error> {
+        Ok(CClientVersionV1 {
+            code: value.code.try_into().context("invalid client code")?,
+            name: CString::new(value.name)
+                .context("invalid client name")?
+                .into(),
+            version: CString::new(value.version)
+                .context("invalid client version")?
+                .into(),
+            commit: value.commit.into(),
+        })
+    }
+}
+
+impl TryInto<ClientVersionV1> for CClientVersionV1 {
+    type Error = Error;
+
+    fn try_into(self) -> Result<ClientVersionV1, Self::Error> {
+        let name: Option<CString> = self.name.try_into().context("invalid client name")?;
+        let name = name
+            .ok_or(anyhow!("client name is missing"))?
+            .into_string()
+            .context("invalid client name")?;
+
+        let version: Option<CString> = self.version.try_into().context("invalid client version")?;
+        let version = version
+            .ok_or(anyhow!("client version is missing"))?
+            .into_string()
+            .context("invalid client version")?;
+
+        Ok(ClientVersionV1 {
+            code: self.code.try_into().context("invalid client code")?,
+            name,
+            version,
+            commit: self.commit.into(),
+        })
     }
 }

--- a/bindings/c/src/generic.rs
+++ b/bindings/c/src/generic.rs
@@ -20,9 +20,9 @@ pub const GRANDINE_ERROR_ENGINE_API: u32 = 2;
 
 #[repr(C)]
 #[derive(Debug)]
-pub struct CErrorMessage(*mut c_char);
+pub struct CGrandineString(*mut c_char);
 
-impl Drop for CErrorMessage {
+impl Drop for CGrandineString {
     fn drop(&mut self) {
         if self.0 != ptr::null_mut() {
             let _ = unsafe { CString::from_raw(self.0) };
@@ -30,7 +30,7 @@ impl Drop for CErrorMessage {
     }
 }
 
-impl Into<Option<CString>> for CErrorMessage {
+impl Into<Option<CString>> for CGrandineString {
     fn into(self) -> Option<CString> {
         if self.0 == ptr::null_mut() {
             None
@@ -43,7 +43,7 @@ impl Into<Option<CString>> for CErrorMessage {
     }
 }
 
-impl CErrorMessage {
+impl CGrandineString {
     pub fn empty() -> Self {
         Self(ptr::null_mut())
     }
@@ -55,11 +55,17 @@ impl CErrorMessage {
     }
 }
 
+impl From<CString> for CGrandineString {
+    fn from(value: CString) -> Self {
+        Self(value.into_raw())
+    }
+}
+
 #[repr(C)]
 pub struct CResult<T> {
     pub value: T,
     pub code: u32,
-    pub message: CErrorMessage,
+    pub message: CGrandineString,
 }
 
 impl<T: Debug> Debug for CResult<T> {
@@ -80,7 +86,7 @@ impl<T: Default> CResult<T> {
         Self {
             value,
             code: GRANDINE_SUCCESS,
-            message: CErrorMessage::empty(),
+            message: CGrandineString::empty(),
         }
     }
 
@@ -89,8 +95,8 @@ impl<T: Default> CResult<T> {
             value: Default::default(),
             code,
             message: message
-                .and_then(|v| Some(CErrorMessage(CString::new(v).ok()?.into_raw())))
-                .unwrap_or(CErrorMessage::empty()),
+                .and_then(|v| Some(CGrandineString(CString::new(v).ok()?.into_raw())))
+                .unwrap_or(CGrandineString::empty()),
         }
     }
 }

--- a/bindings/c/src/layout.rs
+++ b/bindings/c/src/layout.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 
 use crate::{
     arrays::{CH256, CH384},
-    containers::{CBlobAndProofV1, CBlobAndProofV2, CTransaction, CWithdrawalV1},
-    generic::{COption, CVec},
+    containers::{CBlobAndProofV1, CBlobAndProofV2, CClientVersionV1, CTransaction, CWithdrawalV1},
+    generic::{CGrandineString, COption, CVec},
 };
 
 #[repr(C)]
@@ -73,6 +73,16 @@ pub extern "C" fn grandine_layout_option_blob_and_proof_v1() -> CLayout {
 #[unsafe(no_mangle)]
 pub extern "C" fn grandine_layout_blob_and_proof_v2() -> CLayout {
     CLayout::new(Layout::new::<CBlobAndProofV2>())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn grandine_layout_string() -> CLayout {
+    CLayout::new(Layout::new::<CGrandineString>())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn grandine_layout_client_version() -> CLayout {
+    CLayout::new(Layout::new::<CClientVersionV1>())
 }
 
 // this is just straight copy-paste from rust std library

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -1,11 +1,12 @@
 use std::{
     alloc::{self, Layout},
-    ffi::{CStr, c_char, c_void},
+    ffi::{CStr, CString, c_char, c_void},
 };
 
 use allocator as _;
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::{Error as ClapError, Parser};
+use eth1_api::ClientVersionV1;
 use execution_engine::{
     BlobAndProofV1, EngineGetPayloadV1Response, EngineGetPayloadV2Response,
     EngineGetPayloadV3Response, EngineGetPayloadV4Response, EngineGetPayloadV5Response,
@@ -23,13 +24,13 @@ use web3::types::{BlockNumber, H64, H256};
 use crate::{
     arrays::{CH64, CH256},
     containers::{
-        CBlobAndProofV1, CBlobAndProofV2, CEngineGetPayloadV2Response, CEngineGetPayloadV3Response,
-        CEngineGetPayloadV4Response, CEngineGetPayloadV5Response, CExecutionPayloadV1,
-        CExecutionPayloadV2, CExecutionPayloadV3, CExecutionRequests, CForkChoiceStateV1,
-        CForkChoiceUpdatedResponse, CPayloadAttributesV1, CPayloadAttributesV2,
+        CBlobAndProofV1, CBlobAndProofV2, CClientVersionV1, CEngineGetPayloadV2Response,
+        CEngineGetPayloadV3Response, CEngineGetPayloadV4Response, CEngineGetPayloadV5Response,
+        CExecutionPayloadV1, CExecutionPayloadV2, CExecutionPayloadV3, CExecutionRequests,
+        CForkChoiceStateV1, CForkChoiceUpdatedResponse, CPayloadAttributesV1, CPayloadAttributesV2,
         CPayloadAttributesV3, CPayloadStatusV1,
     },
-    generic::{CErrorMessage, COption, CResult, CVec, GRANDINE_ERROR_GENERIC},
+    generic::{CGrandineString, COption, CResult, CVec, GRANDINE_ERROR_GENERIC},
     layout::{CLayout, repeat_layout},
 };
 
@@ -82,6 +83,10 @@ pub struct CEmbedAdapter {
     engine_get_blobs_v2: unsafe extern "C" fn(
         versioned_hashes: CVec<CH256>,
     ) -> CResult<COption<CVec<CBlobAndProofV2>>>,
+    engine_exchange_capabilities:
+        unsafe extern "C" fn(capabilities: CVec<CGrandineString>) -> CResult<CVec<CGrandineString>>,
+    engine_get_client_version_v1:
+        unsafe extern "C" fn(version: CClientVersionV1) -> CResult<CVec<CClientVersionV1>>,
 }
 
 impl eth1_api::EmbedAdapter for CEmbedAdapter {
@@ -304,6 +309,49 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
             ))
         })
     }
+
+    fn engine_exchange_capabilities(&self, capabilities: &[&str]) -> Result<Vec<String>> {
+        let capabilities = capabilities
+            .iter()
+            .map(|v| CString::new(*v).map(Into::into))
+            .collect::<Result<_, _>>()
+            .context("invalid capabilities")?;
+
+        let result = unsafe { (self.engine_exchange_capabilities)(capabilities) };
+        let result: Result<_> = result.into();
+
+        result.and_then(|v| {
+            v.into_iter()
+                .map(|v| {
+                    let str: Option<CString> = v.into();
+
+                    let Some(str) = str else {
+                        bail!("invalid capability - null is not a valid value");
+                    };
+
+                    let str = str.to_str()?;
+
+                    Ok(str.to_owned())
+                })
+                .collect()
+        })
+    }
+
+    fn engine_get_client_version_v1(
+        &self,
+        own_version: ClientVersionV1,
+    ) -> Result<Vec<ClientVersionV1>> {
+        let result = unsafe { (self.engine_get_client_version_v1)(own_version.try_into()?) };
+
+        let result: Result<_> = result.into();
+
+        result.and_then(|versions| {
+            versions
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_, _>>()
+        })
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -334,8 +382,8 @@ pub extern "C" fn grandine_vec_alloc(item_layout: CLayout, size: usize) -> *mut 
 /// Copies string to a pointer managed by grandine.
 /// CErrorMessage must be passed back to grandine, where it will be automatically cleaned up.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn grandine_error_message(str: *const c_char) -> CErrorMessage {
-    unsafe { CErrorMessage::new(str) }
+pub unsafe extern "C" fn grandine_string(str: *const c_char) -> CGrandineString {
+    unsafe { CGrandineString::new(str) }
 }
 
 #[unsafe(no_mangle)]

--- a/bindings/csharp/.editorconfig
+++ b/bindings/csharp/.editorconfig
@@ -379,9 +379,11 @@ dotnet_naming_style.s_camelcase.capitalization = camel_case
 #### C# Diagnostics ####
 [*.cs]
 
-dotnet_diagnostic.SA1600.severity = silent
-dotnet_diagnostic.SA1009.severity = silent
-dotnet_diagnostic.SA1011.severity = silent
-dotnet_diagnostic.SA1633.severity = silent
-dotnet_diagnostic.SA1601.severity = silent
 dotnet_diagnostic.CS1591.severity = silent
+
+dotnet_diagnostic.SA1009.severity = silent
+dotnet_diagnostic.SA1010.severity = silent
+dotnet_diagnostic.SA1011.severity = silent
+dotnet_diagnostic.SA1600.severity = silent
+dotnet_diagnostic.SA1601.severity = silent
+dotnet_diagnostic.SA1633.severity = silent

--- a/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
+++ b/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="9.0.0" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.4.0" />
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.35.8" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineClient.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineClient.cs
@@ -48,6 +48,12 @@ internal delegate CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1Delegate(
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2Delegate(CVec_CH256 versionedHashes);
 
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate CResult_CVec_CGrandineString EngineExchangeCapabilitiesDelegate(CVec_CGrandineString clCapabilities);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate CResult_CVec_CClientVersionV1 EngineGetClientVersionV1Delegate(CClientVersionV1 clVersion);
+
 public class GrandineClient : IAsyncDisposable
 {
     private static bool initialized = false;
@@ -66,6 +72,8 @@ public class GrandineClient : IAsyncDisposable
     private readonly EngineGetPayloadV5Delegate engineGetPayloadV5;
     private readonly EngineGetBlobsV1Delegate engineGetBlobsV1;
     private readonly EngineGetBlobsV2Delegate engineGetBlobsV2;
+    private readonly EngineExchangeCapabilitiesDelegate engineExchangeCapabilities;
+    private readonly EngineGetClientVersionV1Delegate engineGetClientVersionV1;
 
     private readonly IGrandineEngineApi engineApi;
     private Task? process;
@@ -96,6 +104,8 @@ public class GrandineClient : IAsyncDisposable
             this.engineGetPayloadV5 = this.engineApi.EngineGetPayloadV5;
             this.engineGetBlobsV1 = this.engineApi.EngineGetBlobsV1;
             this.engineGetBlobsV2 = this.engineApi.EngineGetBlobsV2;
+            this.engineExchangeCapabilities = this.engineApi.EngineExchangeCapabilities;
+            this.engineGetClientVersionV1 = this.engineApi.EngineGetClientVersionV1;
             IntPtr engine_newPayloadV1Ptr = Marshal.GetFunctionPointerForDelegate(this.engineNewPayloadV1);
             IntPtr engine_newPayloadV2Ptr = Marshal.GetFunctionPointerForDelegate(this.engineNewPayloadV2);
             IntPtr engine_newPayloadV3Ptr = Marshal.GetFunctionPointerForDelegate(this.engineNewPayloadV3);
@@ -110,6 +120,8 @@ public class GrandineClient : IAsyncDisposable
             IntPtr engine_getPayloadV5Ptr = Marshal.GetFunctionPointerForDelegate(this.engineGetPayloadV5);
             IntPtr engine_getBlobsV1Ptr = Marshal.GetFunctionPointerForDelegate(this.engineGetBlobsV1);
             IntPtr engine_getBlobsV2Ptr = Marshal.GetFunctionPointerForDelegate(this.engineGetBlobsV2);
+            IntPtr engine_exchangeCapabilitiesPtr = Marshal.GetFunctionPointerForDelegate(this.engineExchangeCapabilities);
+            IntPtr engine_getClientVersionV1 = Marshal.GetFunctionPointerForDelegate(this.engineGetClientVersionV1);
             res = NativeMethods.grandine_set_execution_layer_adapter(new CEmbedAdapter
             {
                 engine_new_payload_v1 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV1, CResult_CPayloadStatusV1>)engine_newPayloadV1Ptr,
@@ -126,6 +138,8 @@ public class GrandineClient : IAsyncDisposable
                 engine_get_payload_v5 = (delegate* unmanaged[Cdecl]<CH64, CResult_CEngineGetPayloadV5Response>)engine_getPayloadV5Ptr,
                 engine_get_blobs_v1 = (delegate* unmanaged[Cdecl]<CVec_CH256, CResult_CVec_COption_CBlobAndProofV1>)engine_getBlobsV1Ptr,
                 engine_get_blobs_v2 = (delegate* unmanaged[Cdecl]<CVec_CH256, CResult_COption_CVec_CBlobAndProofV2>)engine_getBlobsV2Ptr,
+                engine_exchange_capabilities = (delegate* unmanaged[Cdecl]<CVec_CGrandineString, CResult_CVec_CGrandineString>)engine_exchangeCapabilitiesPtr,
+                engine_get_client_version_v1 = (delegate* unmanaged[Cdecl]<CClientVersionV1, CResult_CVec_CClientVersionV1>)engine_getClientVersionV1,
             });
         }
 

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
@@ -453,4 +453,60 @@ public class GrandineEngineApi : IGrandineEngineApi
             return CResult_COption_CVec_CBlobAndProofV2.Fail(NativeMethods.GRANDINE_ERROR_GENERIC, e.Message);
         }
     }
+
+    public CResult_CVec_CGrandineString EngineExchangeCapabilities(CVec_CGrandineString capabilities)
+    {
+        this.logger.Debug("Received engine_exchangeCapabilities request from grandine");
+
+        try
+        {
+            var outputCapabilities = this.engineRpc.engine_exchangeCapabilities(GrandineUtils.ConvertCapabilities(capabilities));
+
+            if (outputCapabilities.Result != Result.Success)
+            {
+                return CResult_CVec_CGrandineString.Fail(NativeMethods.GRANDINE_ERROR_ENGINE_API, outputCapabilities.Result.Error);
+            }
+
+            var outputCapabilitiesArray = new CVec_CGrandineString(outputCapabilities.Data.Select(capability =>
+            {
+                return new CGrandineString(capability);
+            }));
+
+            return CResult_CVec_CGrandineString.Success(outputCapabilitiesArray);
+        }
+        catch (Exception e)
+        {
+            this.logger.Error("Unexpected exception occurred during engine_exchangeCapabilities function invocation", e);
+            return CResult_CVec_CGrandineString.Fail(NativeMethods.GRANDINE_ERROR_GENERIC, e.Message);
+        }
+    }
+
+    public CResult_CVec_CClientVersionV1 EngineGetClientVersionV1(CClientVersionV1 version)
+    {
+        this.logger.Debug("Received engine_getClientVersionV1 request from grandine");
+
+        try
+        {
+            var clClientVersion = GrandineUtils.ConvertClientVersion(version);
+
+            var response = this.engineRpc.engine_getClientVersionV1(clClientVersion);
+
+            if (response.Result != Result.Success)
+            {
+                return CResult_CVec_CClientVersionV1.Fail(NativeMethods.GRANDINE_ERROR_ENGINE_API, response.Result.Error);
+            }
+
+            var clientVersions = new CVec_CClientVersionV1(response.Data.Select(version =>
+            {
+                return new CClientVersionV1(version);
+            }));
+
+            return CResult_CVec_CClientVersionV1.Success(clientVersions);
+        }
+        catch (Exception e)
+        {
+            this.logger.Error("Unexpected exception occurred during engine_exchangeCapabilities function invocation", e);
+            return CResult_CVec_CClientVersionV1.Fail(NativeMethods.GRANDINE_ERROR_GENERIC, e.Message);
+        }
+    }
 }

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineInitializationException.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineInitializationException.cs
@@ -2,7 +2,7 @@ namespace Grandine.NethermindPlugin;
 
 using Grandine.Native;
 
-public sealed class GrandineInitializationException(uint errorCode, CErrorMessage errorMessage) : Exception(errorMessage.ToString())
+public sealed class GrandineInitializationException(uint errorCode, CGrandineString errorMessage) : Exception(errorMessage.ToString())
 {
     public uint ErrorCode => errorCode;
 }

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineUtils.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineUtils.cs
@@ -1,10 +1,16 @@
 namespace Grandine.NethermindPlugin;
 
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
 using Grandine.Native;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 
 public static class GrandineUtils
@@ -243,5 +249,63 @@ public static class GrandineUtils
             Withdrawals = WithdrawalsFromNative(attr.value.withdrawals),
             ParentBeaconBlockRoot = attr.value.parent_beacon_block_root.ToHash256(),
         };
+    }
+
+    public static IEnumerable<string> ConvertCapabilities(CVec_CGrandineString capabilities)
+    {
+        var span = capabilities.AsSpan();
+        if (span.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var result = new string[span.Length];
+
+        for (int i = 0; i < span.Length; ++i)
+        {
+            result[i] = span[i].ToString();
+        }
+
+        return result;
+    }
+
+    public static ClientVersionV1 ConvertClientVersion(CClientVersionV1 version)
+    {
+        var temp = new ClientVersionV1Intermediate
+        {
+            Code = version.code.ToString(),
+            Name = version.name.ToString(),
+            Version = version.version.ToString(),
+            Commit = version.commit.ToString(),
+        };
+
+        var result = Unsafe.As<ClientVersionV1Intermediate, ClientVersionV1>(ref temp);
+
+        if (result.Code != version.code.ToString() ||
+            result.Name != version.name.ToString() ||
+            result.Version != version.version.ToString() ||
+            result.Commit != version.commit.ToString())
+        {
+            throw new UnreachableException("Construction of ClientVersionV1 failed");
+        }
+
+        return result;
+    }
+
+    // a struct needed to bypass issue on nethermind side, where their
+    // ClientVersionV1 is defined with readonly fields, without "init"
+    // attribute, and without proper constructor available - so there is no way
+    // to construct ClientVersionV1 with custom values. Thus, we use this
+    // intermediatery struct, to construct needed values & then unsafely cast it
+    // to ClientVersionV1.
+    public readonly struct ClientVersionV1Intermediate
+    {
+        public string Code { get; init; }
+
+        public string Name { get; init; }
+
+        public string Version { get; init; }
+
+        public string Commit { get; init; }
     }
 }

--- a/bindings/csharp/Grandine.NethermindPlugin/IGrandineEngineApi.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/IGrandineEngineApi.cs
@@ -31,4 +31,8 @@ public interface IGrandineEngineApi
     CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1(CVec_CH256 versionedHashes);
 
     CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2(CVec_CH256 versionedHashes);
+
+    CResult_CVec_CGrandineString EngineExchangeCapabilities(CVec_CGrandineString capabilities);
+
+    CResult_CVec_CClientVersionV1 EngineGetClientVersionV1(CClientVersionV1 version);
 }

--- a/bindings/csharp/Grandine.NethermindPlugin/NativeMethods.impl.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/NativeMethods.impl.cs
@@ -19,7 +19,7 @@ public unsafe partial struct CPayloadStatusV1
     {
         this.status = GrandineUtils.ConvertPayloadValidationStatus(status.Status);
         this.latest_valid_hash = CH256.FromOptionalHash256(status.LatestValidHash);
-        this.validation_error = new CErrorMessage(status.ValidationError);
+        this.validation_error = new CGrandineString(status.ValidationError);
     }
 }
 
@@ -234,6 +234,17 @@ public unsafe partial struct CExecutionRequests
     }
 }
 
+public unsafe partial struct CClientVersionV1
+{
+    public CClientVersionV1(ClientVersionV1 version)
+    {
+        this.code = CH16.FromClientCode(version.Code);
+        this.name = new CGrandineString(version.Name);
+        this.version = new CGrandineString(version.Version);
+        this.commit = new CH32(version.Commit);
+    }
+}
+
 public unsafe partial struct CH384
 {
     public CH384(byte[] bytes)
@@ -376,6 +387,82 @@ public unsafe partial struct CH64
     }
 
     public unsafe readonly byte[] ToArray() => this.AsSpan().ToArray();
+}
+
+public unsafe partial struct CH32
+{
+    public CH32(string value)
+    {
+        if (value.StartsWith("0x"))
+        {
+            value = value[2..];
+        }
+
+        var raw = Convert.FromHexString(value);
+
+        if (raw.Length != 4)
+        {
+            throw new ArgumentException("Hex payloadmust decode to exactly 4 bytes.");
+        }
+
+        fixed (byte* destinationPtr = this._0)
+        fixed (byte* sourcePtr = raw)
+        {
+            Buffer.MemoryCopy(sourcePtr, destinationPtr, 4, 4);
+        }
+    }
+
+    public unsafe readonly ReadOnlySpan<byte> AsSpan()
+    {
+        fixed (byte* data = this._0)
+        {
+            return new ReadOnlySpan<byte>(data, 4);
+        }
+    }
+
+    public readonly byte[] ToArray() => this.AsSpan().ToArray();
+
+    public override readonly string ToString()
+    {
+        return Convert.ToHexString(this.ToArray());
+    }
+}
+
+public unsafe partial struct CH16
+{
+    public static CH16 FromClientCode(string code)
+    {
+        if (code.Length != 2)
+        {
+            throw new ArgumentException("Client code must be exactly 2 characters long");
+        }
+
+        byte[] bytes = [(byte)code[0], (byte)code[1]];
+
+        var result = new CH16 { };
+
+        fixed (byte* sourcePtr = bytes)
+        {
+            Buffer.MemoryCopy(sourcePtr, result._0, 2, 2);
+        }
+
+        return result;
+    }
+
+    public unsafe readonly ReadOnlySpan<byte> AsSpan()
+    {
+        fixed (byte* data = this._0)
+        {
+            return new ReadOnlySpan<byte>(data, 2);
+        }
+    }
+
+    public readonly byte[] ToArray() => this.AsSpan().ToArray();
+
+    public override readonly string ToString()
+    {
+        return System.Text.Encoding.ASCII.GetString(this.ToArray());
+    }
 }
 
 public unsafe partial struct CVec_u8
@@ -764,85 +851,212 @@ public unsafe partial struct CVec_CH256
         throw new OverflowException("data_len exceeds Int32.MaxValue");
 }
 
+public unsafe partial struct CVec_CGrandineString
+{
+    public CVec_CGrandineString(nuint length)
+    {
+        if (length == 0)
+        {
+            this.data = null;
+            this.data_len = 0;
+            return;
+        }
+
+        IntPtr pointer;
+        unsafe
+        {
+            pointer = (IntPtr)NativeMethods.grandine_vec_alloc(NativeMethods.grandine_layout_string(), length);
+        }
+
+        this.data = (CGrandineString*)pointer.ToPointer();
+        this.data_len = length;
+    }
+
+    public CVec_CGrandineString(CGrandineString[] input)
+        : this((uint)input.Length)
+    {
+        if (input.Length == 0)
+        {
+            return;
+        }
+
+        unsafe
+        {
+            var ptr = (IntPtr)this.data;
+
+            for (var i = 0; i < input.Length; ++i)
+            {
+                Marshal.StructureToPtr(input[i], IntPtr.Add(ptr, i * Marshal.SizeOf<CGrandineString>()), false);
+            }
+        }
+    }
+
+    public CVec_CGrandineString(IEnumerable<CGrandineString> enumerator)
+        : this(enumerator?.ToArray() ?? Array.Empty<CGrandineString>())
+    {
+    }
+
+    public static CVec_CGrandineString Empty() => new (0);
+
+    public readonly ReadOnlySpan<CGrandineString> AsSpan()
+    {
+        if (sizeof(nuint) > sizeof(int) && this.data_len > int.MaxValue)
+        {
+            ThrowLengthTooLarge();
+        }
+
+        return new ReadOnlySpan<CGrandineString>(this.data, checked((int)this.data_len));
+    }
+
+    private static void ThrowLengthTooLarge() =>
+        throw new OverflowException("data_len exceeds Int32.MaxValue");
+}
+
+public unsafe partial struct CVec_CClientVersionV1
+{
+    public CVec_CClientVersionV1(nuint length)
+    {
+        if (length == 0)
+        {
+            this.data = null;
+            this.data_len = 0;
+            return;
+        }
+
+        IntPtr pointer;
+        unsafe
+        {
+            pointer = (IntPtr)NativeMethods.grandine_vec_alloc(NativeMethods.grandine_layout_client_version(), length);
+        }
+
+        this.data = (CClientVersionV1*)pointer.ToPointer();
+        this.data_len = length;
+    }
+
+    public CVec_CClientVersionV1(CClientVersionV1[] input)
+        : this((uint)input.Length)
+    {
+        if (input.Length == 0)
+        {
+            return;
+        }
+
+        unsafe
+        {
+            var ptr = (IntPtr)this.data;
+
+            for (var i = 0; i < input.Length; ++i)
+            {
+                Marshal.StructureToPtr(input[i], IntPtr.Add(ptr, i * Marshal.SizeOf<CClientVersionV1>()), false);
+            }
+        }
+    }
+
+    public CVec_CClientVersionV1(IEnumerable<CClientVersionV1> enumerator)
+        : this(enumerator?.ToArray() ?? Array.Empty<CClientVersionV1>())
+    {
+    }
+
+    public static CVec_CClientVersionV1 Empty() => new (0);
+}
+
 public unsafe partial struct CResult_COption_CVec_CBlobAndProofV2
 {
     public static CResult_COption_CVec_CBlobAndProofV2 Success(COption_CVec_CBlobAndProofV2 value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_COption_CVec_CBlobAndProofV2 Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_COption_CVec_CBlobAndProofV2 Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_COption_CVec_CBlobAndProofV2 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_COption_CVec_CBlobAndProofV2 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CVec_COption_CBlobAndProofV1
 {
     public static CResult_CVec_COption_CBlobAndProofV1 Success(CVec_COption_CBlobAndProofV1 value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CVec_COption_CBlobAndProofV1 Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CVec_COption_CBlobAndProofV1 Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CVec_COption_CBlobAndProofV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CVec_COption_CBlobAndProofV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CEngineGetPayloadV5Response
 {
     public static CResult_CEngineGetPayloadV5Response Success(CEngineGetPayloadV5Response value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CEngineGetPayloadV5Response Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CEngineGetPayloadV5Response Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CEngineGetPayloadV5Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CEngineGetPayloadV5Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CEngineGetPayloadV4Response
 {
     public static CResult_CEngineGetPayloadV4Response Success(CEngineGetPayloadV4Response value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CEngineGetPayloadV4Response Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CEngineGetPayloadV4Response Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CEngineGetPayloadV4Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CEngineGetPayloadV4Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CEngineGetPayloadV3Response
 {
     public static CResult_CEngineGetPayloadV3Response Success(CEngineGetPayloadV3Response value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CEngineGetPayloadV3Response Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CEngineGetPayloadV3Response Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CEngineGetPayloadV3Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CEngineGetPayloadV3Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CEngineGetPayloadV2Response
 {
     public static CResult_CEngineGetPayloadV2Response Success(CEngineGetPayloadV2Response value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CEngineGetPayloadV2Response Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CEngineGetPayloadV2Response Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CEngineGetPayloadV2Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CEngineGetPayloadV2Response Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CExecutionPayloadV1
 {
     public static CResult_CExecutionPayloadV1 Success(CExecutionPayloadV1 value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CExecutionPayloadV1 Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CExecutionPayloadV1 Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CExecutionPayloadV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CExecutionPayloadV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CForkChoiceUpdatedResponse
 {
     public static CResult_CForkChoiceUpdatedResponse Success(CForkChoiceUpdatedResponse value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CForkChoiceUpdatedResponse Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CForkChoiceUpdatedResponse Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CForkChoiceUpdatedResponse Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CForkChoiceUpdatedResponse Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct CResult_CPayloadStatusV1
 {
     public static CResult_CPayloadStatusV1 Success(CPayloadStatusV1 value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
 
-    public static CResult_CPayloadStatusV1 Fail(uint errorCode) => new () { code = errorCode, message = CErrorMessage.Empty };
+    public static CResult_CPayloadStatusV1 Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
 
-    public static CResult_CPayloadStatusV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CErrorMessage(message) };
+    public static CResult_CPayloadStatusV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
+}
+
+public unsafe partial struct CResult_CVec_CGrandineString
+{
+    public static CResult_CVec_CGrandineString Success(CVec_CGrandineString value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
+
+    public static CResult_CVec_CGrandineString Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
+
+    public static CResult_CVec_CGrandineString Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
+}
+
+public unsafe partial struct CResult_CVec_CClientVersionV1
+{
+    public static CResult_CVec_CClientVersionV1 Success(CVec_CClientVersionV1 value) => new () { code = NativeMethods.GRANDINE_SUCCESS, value = value };
+
+    public static CResult_CVec_CClientVersionV1 Fail(uint errorCode) => new () { code = errorCode, message = CGrandineString.Empty };
+
+    public static CResult_CVec_CClientVersionV1 Fail(uint errorCode, string? message) => new () { code = errorCode, message = new CGrandineString(message) };
 }
 
 public unsafe partial struct COption_CVec_CBlobAndProofV2
@@ -859,9 +1073,9 @@ public unsafe partial struct COption_CBlobAndProofV1
     public static COption_CBlobAndProofV1 Some(CBlobAndProofV1 value) => new () { is_something = true, value = value };
 }
 
-public unsafe partial struct CErrorMessage
+public unsafe partial struct CGrandineString
 {
-    public CErrorMessage(string? message)
+    public CGrandineString(string? message)
     {
         if (message == null)
         {
@@ -874,13 +1088,13 @@ public unsafe partial struct CErrorMessage
             fixed (byte* bytesPtr = strBytes)
             unsafe
             {
-                var msg = NativeMethods.grandine_error_message(bytesPtr);
+                var msg = NativeMethods.grandine_string(bytesPtr);
                 this._0 = msg._0;
             }
         }
     }
 
-    public static CErrorMessage Empty => new (null);
+    public static CGrandineString Empty => new (null);
 
     public override readonly string ToString()
     {

--- a/eth1_api/src/eth1_api/embed_api.rs
+++ b/eth1_api/src/eth1_api/embed_api.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use arc_swap::ArcSwap;
 use core::ops::RangeInclusive;
 use either::Either;
 use enum_iterator::Sequence as _;
@@ -17,10 +18,10 @@ use serde::Deserialize;
 use ssz::H256;
 use static_assertions::const_assert_eq;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     sync::{Arc, OnceLock},
 };
-use std_ext::CopyExt;
+use std_ext::{ArcExt, CopyExt};
 use thiserror::Error;
 use types::{
     combined::{ExecutionPayload, ExecutionPayloadParams},
@@ -35,7 +36,7 @@ use types::{
 use web3::types::{BlockId, BlockNumber, Filter, FilterBuilder, Log, U64};
 
 use crate::{
-    ClientVersions, Eth1ApiToMetrics, WithClientVersions,
+    ClientVersionV1, ClientVersions, Eth1ApiToMetrics, WithClientVersions,
     auth::Auth,
     deposit_event::DepositEvent,
     endpoints::Endpoint,
@@ -118,6 +119,12 @@ pub trait EmbedAdapter: Send + Sync {
         &self,
         versioned_hashes: Vec<VersionedHash>,
     ) -> Result<Option<Vec<BlobAndProofV2<Mainnet>>>>;
+
+    fn engine_exchange_capabilities(&self, capabilities: &[&str]) -> Result<Vec<String>>;
+    fn engine_get_client_version_v1(
+        &self,
+        own_version: ClientVersionV1,
+    ) -> Result<Vec<ClientVersionV1>>;
 }
 
 static CURRENT_ADAPTER: OnceLock<Arc<Box<dyn EmbedAdapter>>> = OnceLock::new();
@@ -145,6 +152,8 @@ pub fn set_adapter(adapter: Box<dyn EmbedAdapter>) -> Result<()> {
 pub struct Eth1Api {
     config: Arc<Config>,
     pub(crate) metrics: Option<Arc<Metrics>>,
+    versions: ArcSwap<ClientVersions>,
+    capabilities: ArcSwap<HashSet<String>>,
 }
 
 impl Eth1Api {
@@ -157,15 +166,27 @@ impl Eth1Api {
         _eth1_api_to_metrics_tx: Option<UnboundedSender<Eth1ApiToMetrics>>,
         metrics: Option<Arc<Metrics>>,
     ) -> Self {
-        Self { config, metrics }
+        Self {
+            config,
+            metrics,
+            versions: ArcSwap::from_pointee(vec![]),
+            capabilities: ArcSwap::from_pointee(HashSet::new()),
+        }
     }
 
-    // TODO: Add support for ClientVersions in Nethermind plugin
+    pub(crate) fn set_capabilities(&self, capabilities: HashSet<String>) {
+        self.capabilities.store(Arc::new(capabilities));
+    }
+
+    pub(crate) fn set_client_versions(&self, versions: ClientVersions) {
+        self.versions.store(Arc::new(versions));
+    }
+
     pub fn client_versions(&self) -> impl Iterator<Item = Arc<ClientVersions>> {
-        core::iter::empty()
+        core::iter::once(self.versions.load().clone_arc())
     }
 
-    async fn exec<T: Send + Sync + 'static>(
+    pub async fn exec<T: Send + Sync + 'static>(
         &self,
         fun: impl FnOnce(&Box<dyn EmbedAdapter>) -> Result<T> + Send + Sync + 'static,
     ) -> Result<T> {
@@ -569,7 +590,7 @@ impl Eth1Api {
         &self,
         payload_id: PayloadId,
     ) -> Result<WithClientVersions<WithBlobsAndMev<ExecutionPayload<P>, P>>> {
-        match payload_id {
+        let result: WithBlobsAndMev<ExecutionPayload<P>, P> = match payload_id {
             PayloadId::Bellatrix(payload_id) => {
                 let _timer = self.metrics.as_ref().map(|metrics| {
                     prometheus_metrics::start_timer_vec(
@@ -587,7 +608,7 @@ impl Eth1Api {
                     value.downcast_ref().ok_or(Error::InvalidPreset)?;
                 let value = value.clone();
 
-                Ok(WithClientVersions::none(value).map(Into::into))
+                value.into()
             }
             PayloadId::Capella(payload_id) => {
                 let _timer = self.metrics.as_ref().map(|metrics| {
@@ -606,7 +627,7 @@ impl Eth1Api {
                     value.downcast_ref().ok_or(Error::InvalidPreset)?;
                 let value = value.clone();
 
-                Ok(WithClientVersions::none(value).map(Into::into))
+                value.into()
             }
             PayloadId::Deneb(payload_id) => {
                 let _timer = self.metrics.as_ref().map(|metrics| {
@@ -625,7 +646,7 @@ impl Eth1Api {
                     value.downcast_ref().ok_or(Error::InvalidPreset)?;
                 let value = value.clone();
 
-                Ok(WithClientVersions::none(value).map(Into::into))
+                value.into()
             }
             PayloadId::Electra(payload_id) => {
                 let _timer = self.metrics.as_ref().map(|metrics| {
@@ -644,7 +665,7 @@ impl Eth1Api {
                     value.downcast_ref().ok_or(Error::InvalidPreset)?;
                 let value = value.clone();
 
-                Ok(WithClientVersions::none(value).map(Into::into))
+                value.into()
             }
             PayloadId::Fulu(payload_id) | PayloadId::Gloas(payload_id) => {
                 let _timer = self.metrics.as_ref().map(|metrics| {
@@ -663,9 +684,14 @@ impl Eth1Api {
                     value.downcast_ref().ok_or(Error::InvalidPreset)?;
                 let value = value.clone();
 
-                Ok(WithClientVersions::none(value).map(Into::into))
+                value.into()
             }
-        }
+        };
+
+        Ok(WithClientVersions {
+            client_versions: Some(self.versions.load().clone_arc()),
+            result,
+        })
     }
 
     pub(crate) async fn get_blobs_v1<P: Preset>(

--- a/eth1_api/src/misc.rs
+++ b/eth1_api/src/misc.rs
@@ -1,3 +1,4 @@
+use core::{convert::Infallible, str::FromStr};
 use std::sync::Arc;
 
 use anyhow::{Result, ensure};
@@ -58,6 +59,32 @@ impl ClientCode {
     }
 }
 
+impl FromStr for ClientCode {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "BU" => Self::Besu,
+            "EJ" => Self::EthereumJS,
+            "EG" => Self::Erigon,
+            "GE" => Self::GoEthereum,
+            "GR" => Self::Grandine,
+            "LH" => Self::Lighthouse,
+            "LS" => Self::Lodestar,
+            "NM" => Self::Nethermind,
+            "NB" => Self::Nimbus,
+            "TE" => Self::TrinExecution,
+            "TK" => Self::Teku,
+            "PM" => Self::Prysm,
+            "RH" => Self::Reth,
+            other => {
+                info_with_peers!("received unknown client code from execution client: {other}");
+                Self::Unknown(other.to_owned())
+            }
+        })
+    }
+}
+
 impl Serialize for ClientCode {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -85,27 +112,7 @@ impl<'de> Deserialize<'de> for ClientCode {
             where
                 E: serde::de::Error,
             {
-                Ok(match value {
-                    "BU" => ClientCode::Besu,
-                    "EJ" => ClientCode::EthereumJS,
-                    "EG" => ClientCode::Erigon,
-                    "GE" => ClientCode::GoEthereum,
-                    "GR" => ClientCode::Grandine,
-                    "LH" => ClientCode::Lighthouse,
-                    "LS" => ClientCode::Lodestar,
-                    "NM" => ClientCode::Nethermind,
-                    "NB" => ClientCode::Nimbus,
-                    "TE" => ClientCode::TrinExecution,
-                    "TK" => ClientCode::Teku,
-                    "PM" => ClientCode::Prysm,
-                    "RH" => ClientCode::Reth,
-                    other => {
-                        info_with_peers!(
-                            "received unknown client code from execution client: {other}"
-                        );
-                        ClientCode::Unknown(other.to_owned())
-                    }
-                })
+                value.parse().map_err(E::custom)
             }
         }
 

--- a/eth1_api/src/tasks.rs
+++ b/eth1_api/src/tasks.rs
@@ -35,7 +35,38 @@ pub fn spawn_exchange_capabilities_and_versions_task(
 
 async fn exchange_capabilities_and_versions(eth1_api: &Eth1Api) -> Result<()> {
     #[cfg(feature = "embed")]
-    return Ok(());
+    {
+        let response = eth1_api
+            .exec(|adapter| adapter.engine_exchange_capabilities(CAPABILITIES))
+            .await;
+
+        match response {
+            Ok(capabilities) => {
+                let capabilities = HashSet::from_iter(capabilities);
+
+                let supports_client_version =
+                    capabilities.contains(&ENGINE_GET_CLIENT_VERSION_V1.to_owned());
+
+                eth1_api.set_capabilities(capabilities);
+
+                info_with_peers!("updated capabilities for embedded EL");
+
+                if supports_client_version {
+                    exchange_client_versions(eth1_api).await?;
+                } else {
+                    debug_with_peers!(
+                        "cannot get client version: embedded EL does not support \
+                        {ENGINE_GET_CLIENT_VERSION_V1}",
+                    );
+                }
+            }
+            Err(error) => {
+                warn_with_peers!("unable to update capabilities for embedded el: {error:?}",);
+            }
+        }
+
+        Ok(())
+    }
 
     #[cfg(not(feature = "embed"))]
     {
@@ -93,44 +124,59 @@ async fn exchange_capabilities_and_versions(eth1_api: &Eth1Api) -> Result<()> {
     }
 }
 
+#[cfg(feature = "embed")]
+async fn exchange_client_versions(eth1_api: &Eth1Api) -> Result<()> {
+    let response = eth1_api
+        .exec(|adapter| adapter.engine_get_client_version_v1(ClientVersionV1::own()))
+        .await;
+
+    match response {
+        Ok(client_versions) => {
+            eth1_api.set_client_versions(client_versions);
+
+            info_with_peers!("updated client version for embedded EL",);
+        }
+        Err(error) => {
+            warn_with_peers!("unable to update client version for embedded EL: {error:?}",);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "embed"))]
 async fn exchange_client_versions(
     eth1_api: &Eth1Api,
     api: &Eth<Http>,
     endpoint: &Endpoint,
 ) -> Result<()> {
-    #[cfg(feature = "embed")]
-    return Ok(());
+    let response = CallFuture::new(api.transport().execute_with_headers(
+        ENGINE_GET_CLIENT_VERSION_V1,
+        vec![serde_json::to_value(ClientVersionV1::own())?],
+        eth1_api.auth.headers()?,
+        Some(ENGINE_GET_CLIENT_VERSION_V1_TIMEOUT),
+    ))
+    .await;
 
-    #[cfg(not(feature = "embed"))]
-    {
-        let response = CallFuture::new(api.transport().execute_with_headers(
-            ENGINE_GET_CLIENT_VERSION_V1,
-            vec![serde_json::to_value(ClientVersionV1::own())?],
-            eth1_api.auth.headers()?,
-            Some(ENGINE_GET_CLIENT_VERSION_V1_TIMEOUT),
-        ))
-        .await;
+    match response {
+        Ok(client_versions) => {
+            eth1_api.on_ok_response(endpoint);
+            endpoint.set_client_versions(client_versions);
 
-        match response {
-            Ok(client_versions) => {
-                eth1_api.on_ok_response(endpoint);
-                endpoint.set_client_versions(client_versions);
-
-                info_with_peers!(
-                    "updated client version for eth1 endpoint: {}",
-                    endpoint.url()
-                );
-            }
-            Err(error) => {
-                eth1_api.on_error_response(endpoint);
-
-                warn_with_peers!(
-                    "unable to update client version for eth1 endpoint: {} {error:?}",
-                    endpoint.url(),
-                );
-            }
+            info_with_peers!(
+                "updated client version for eth1 endpoint: {}",
+                endpoint.url()
+            );
         }
+        Err(error) => {
+            eth1_api.on_error_response(endpoint);
 
-        Ok(())
+            warn_with_peers!(
+                "unable to update client version for eth1 endpoint: {} {error:?}",
+                endpoint.url(),
+            );
+        }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Added two calls: `engine_exchangeCapabilities` & `engine_clientVersionV1` to grandine nethermind plugin. This is needed to include nethermind version in graffiti, as implemented in [#580].

[#580]: https://github.com/grandinetech/grandine/pull/580