### PR TITLE
Update eth2_libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,7 +4280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -5114,16 +5114,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
@@ -5291,7 +5281,6 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "libp2p",
- "libp2p-gossipsub 0.50.0",
  "libp2p-mplex",
  "local-ip-address",
  "logging",
@@ -5299,8 +5288,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "prometheus-client",
- "quickcheck",
- "quickcheck_macros",
+ "proptest",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -5320,7 +5308,7 @@ dependencies = [
  "try_from_iterator",
  "typenum",
  "types",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -6651,6 +6639,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -8108,9 +8105,8 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
+version = "0.56.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "bytes",
  "either",
@@ -8121,7 +8117,7 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
- "libp2p-gossipsub 0.49.2",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
@@ -8143,8 +8139,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -8154,8 +8149,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -8165,8 +8159,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "either",
  "fnv",
@@ -8183,15 +8176,14 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.17",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "async-trait",
  "futures",
@@ -8205,39 +8197,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f58e37d8d6848e5c4c9e3c35c6f61133235bff2960c9c00a663b0849301221"
-dependencies = [
- "async-channel 2.5.0",
- "asynchronous-codec",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "getrandom 0.2.16",
- "hashlink 0.9.1",
- "hex_fmt",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.5",
- "regex",
- "serde",
- "sha2",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=5acdf89a65d64098f9346efa5769e57bcd19dea9#5acdf89a65d64098f9346efa5769e57bcd19dea9"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec",
@@ -8249,7 +8210,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.16",
- "hashlink 0.10.0",
+ "hashlink 0.11.0",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
@@ -8268,8 +8229,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -8298,10 +8258,8 @@ dependencies = [
  "hkdf",
  "k256",
  "multihash",
- "p256 0.13.2",
  "quick-protobuf",
  "rand 0.8.5",
- "sec1 0.7.3",
  "serde",
  "sha2",
  "thiserror 2.0.17",
@@ -8311,9 +8269,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
+version = "0.49.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -8340,8 +8297,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "hickory-proto 0.25.2",
@@ -8351,19 +8307,19 @@ dependencies = [
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
+version = "0.17.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-swarm",
@@ -8375,8 +8331,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4019ba30c4e42b776113e9778071691fe3f34bf23b6b3bf0dfcf29d801f3d"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -8388,14 +8343,13 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-noise"
 version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -8417,8 +8371,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e659439578fc6d305da8303834beb9d62f155f40e7f5b9d81c9f2b2c69d1926"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -8433,8 +8386,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8446,7 +8398,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.14",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8454,18 +8406,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa762e5215919a34e31c35d4b18bf2e18566ecab7f8a3d39535f4a3068f8b62"
+version = "0.47.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
+ "hashlink 0.11.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru 0.12.5",
  "multistream-select",
  "rand 0.8.5",
  "smallvec",
@@ -8477,8 +8428,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "heck 0.5.0",
  "quote 1.0.42",
@@ -8487,16 +8437,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4e030c52c46c8d01559b2b8ca9b7c4185f10576016853129ca1fe5cd1a644"
+version = "0.44.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tracing",
 ]
@@ -8504,8 +8453,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -8522,9 +8470,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+version = "0.6.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8538,8 +8485,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "either",
  "futures",
@@ -8996,7 +8942,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -9020,7 +8966,7 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -9038,15 +8984,14 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -11150,7 +11095,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "cfg-if",
- "env_logger 0.11.8",
+ "env_logger",
  "getrandom 0.2.16",
  "hex",
  "lazy_static",
@@ -11604,9 +11549,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
 dependencies = [
  "dtoa",
  "itoa",
@@ -11616,9 +11561,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2 1.0.104",
  "quote 1.0.42",
@@ -11867,36 +11812,13 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger 0.8.4",
- "log",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "quickcheck_macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71ee38b42f8459a88d3362be6f9b841ad2d5421844f61eb1c59c11bff3ac14a"
-dependencies = [
- "proc-macro2 1.0.104",
- "quote 1.0.42",
- "syn 2.0.112",
+ "thiserror 2.0.17",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -13272,8 +13194,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/libp2p/rust-libp2p.git#5bad680f71a88be9a028e349770195d8a72356ce"
 dependencies = [
  "futures",
  "pin-project",
@@ -16314,12 +16235,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
@@ -17724,7 +17639,7 @@ dependencies = [
  "bytemuck",
  "elf",
  "enum-map",
- "env_logger 0.11.8",
+ "env_logger",
  "eyre",
  "hashbrown 0.14.5",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,9 +364,9 @@ jwt-simple = { version = '0.12', default-features = false, features = ['pure-rus
 kzg = { git = 'https://github.com/grandinetech/rust-kzg.git' }
 lazy_static = '1'
 libmdbx = { git = 'https://github.com/paradigmxyz/reth.git', package = 'reth-libmdbx', rev = '6f8e7258f4733279080e4bd8345ce50538a40d6e' }
-libp2p = { version = '0.56', default-features = false, features = ['metrics', 'dns', 'ecdsa', 'identify', 'macros', 'noise', 'plaintext', 'secp256k1', 'serde', 'tcp', 'tokio', 'yamux', 'quic', 'upnp'] }
-libp2p-mplex = '0.43'
-libp2p-identity = { version = '0.2.10', features = ['peerid'] }
+libp2p = { git = 'https://github.com/libp2p/rust-libp2p.git', default-features = false, features = ['metrics', 'dns', 'identify', 'macros', 'noise', 'plaintext', 'secp256k1', 'serde', 'tcp', 'tokio', 'yamux', 'quic', 'upnp', 'gossipsub'] }
+libp2p-identity = { version = '0.2.13', features = ['peerid'] }
+libp2p-mplex = { git = 'https://github.com/libp2p/rust-libp2p.git' }
 local-ip-address = '0.6'
 log = '0.4'
 logroller = '0.1'
@@ -393,10 +393,9 @@ primitive-types = '0.12'
 proc-macro-crate = '3'
 proc-macro2 = '1'
 prometheus = '0.14'
-prometheus-client = '0.23'
+prometheus-client = '0.24'
+proptest = '1'
 psutil = '3'
-quickcheck = '1'
-quickcheck_macros = '1'
 quote = '1'
 rand = '0.8'
 rand_chacha = '0.3'
@@ -511,7 +510,6 @@ features = { path = 'features' }
 fork_choice_control = { path = 'fork_choice_control' }
 fork_choice_store = { path = 'fork_choice_store' }
 genesis = { path = 'genesis' }
-gossipsub = { package = 'libp2p-gossipsub', git = 'https://github.com/sigp/rust-libp2p.git', rev = '5acdf89a65d64098f9346efa5769e57bcd19dea9', features = ['metrics', 'serde'] }
 grandine_version = { path = 'grandine_version' }
 hashing = { path = 'hashing' }
 helper_functions = { path = 'helper_functions' }

--- a/zkvm/guest/risc0/guest/Cargo.lock
+++ b/zkvm/guest/risc0/guest/Cargo.lock
@@ -1866,14 +1866,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
  "bs58",
  "hkdf",
  "multihash",
- "quick-protobuf",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.16",
  "tracing",
@@ -2633,15 +2632,6 @@ dependencies = [
  "tynm",
  "typenum",
  "types",
-]
-
-[[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]


### PR DESCRIPTION
- Does not include Gloas-specific commits, but these are being worked on gloas branch