### PR TITLE
Add tracing instrumentation to Beacon API

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -54,6 +54,7 @@ disallowed-methods = [
 
     { path = 'axum::Router::nest', reason = 'specify full resource paths for searchability' },
 
+    { path = 'itertools::Itertools::format', reason = 'use itertools::join as itertools::format panics when used with tracing' },
     { path = 'itertools::repeat_n', reason = 'use core::iter::repeat_n' },
 ]
 disallowed-types = [

--- a/http_api/src/block_id.rs
+++ b/http_api/src/block_id.rs
@@ -4,6 +4,7 @@ use eth1_api::ApiController;
 use fork_choice_control::Wait;
 use genesis::AnchorCheckpointProvider;
 use http_api_utils::BlockId;
+use tracing::instrument;
 use types::{
     combined::SignedBeaconBlock, nonstandard::WithStatus, phase0::primitives::H256, preset::Preset,
     traits::SignedBeaconBlock as _,
@@ -11,6 +12,7 @@ use types::{
 
 use crate::error::Error;
 
+#[instrument(level = "debug", skip_all, fields(%block_id))]
 pub fn block<P: Preset, W: Wait>(
     block_id: BlockId,
     controller: &ApiController<P, W>,
@@ -32,6 +34,7 @@ pub fn block<P: Preset, W: Wait>(
     .ok_or(Error::BlockNotFound)
 }
 
+#[instrument(level = "debug", skip_all, fields(%block_id))]
 pub fn block_root<P: Preset, W: Wait>(
     block_id: BlockId,
     controller: &ApiController<P, W>,

--- a/http_api/src/error.rs
+++ b/http_api/src/error.rs
@@ -16,6 +16,7 @@ use serde::{Serialize, Serializer};
 use ssz::{H256, ReadError};
 use thiserror::Error;
 use tokio::task::JoinError;
+use tracing::instrument;
 use types::{
     altair::primitives::SubcommitteeIndex,
     deneb::primitives::{BlobIndex, VersionedHash},
@@ -197,6 +198,7 @@ impl Serialize for Error {
 }
 
 impl IntoResponse for Error {
+    #[instrument(skip_all, level = "debug")]
     fn into_response(self) -> Response {
         let status_code = self.status_code();
         let body = Json(self.body()).into_response();

--- a/http_api/src/misc.rs
+++ b/http_api/src/misc.rs
@@ -54,6 +54,7 @@ use types::{
             SignedAggregateAndProof as Phase0SignedAggregateAndProof,
             SignedBeaconBlock as Phase0SignedBeaconBlock,
         },
+        primitives::Slot,
     },
     preset::Preset,
 };
@@ -463,6 +464,19 @@ pub enum SignedAPIBlock<P: Preset> {
 }
 
 impl<P: Preset> SignedAPIBlock<P> {
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::Phase0(block) => block.message.slot,
+            Self::Altair(block) => block.message.slot,
+            Self::Bellatrix(block) => block.message.slot,
+            Self::Capella(block) => block.message.slot,
+            Self::Deneb(block) => block.signed_block.message.slot,
+            Self::Electra(block) => block.signed_block.message.slot,
+            Self::Fulu(block) => block.signed_block.message.slot,
+            Self::Gloas(block) => block.signed_block.message.slot,
+        }
+    }
+
     pub fn split(self) -> SignedBeaconBlockWithBlobsAndProofs<P> {
         match self {
             Self::Phase0(block) => (block.into(), None, None),

--- a/http_api/src/response.rs
+++ b/http_api/src/response.rs
@@ -10,6 +10,7 @@ use mime::APPLICATION_OCTET_STREAM;
 use serde::Serialize;
 use ssz::SszWrite;
 use tap::Pipe as _;
+use tracing::instrument;
 use types::{bellatrix::primitives::Wei, nonstandard::Phase, phase0::primitives::H256};
 
 use crate::error::Error;
@@ -54,6 +55,7 @@ pub struct EthResponse<T, M = (), F = AlwaysJson> {
 }
 
 impl<T: Serialize, M: Serialize> IntoResponse for EthResponse<T, M, AlwaysJson> {
+    #[instrument(skip_all, level = "debug")]
     fn into_response(self) -> Response {
         let run = || {
             let response_headers = self.response_headers()?;
@@ -66,6 +68,7 @@ impl<T: Serialize, M: Serialize> IntoResponse for EthResponse<T, M, AlwaysJson> 
 }
 
 impl<T: SszWrite + Serialize, M: Serialize> IntoResponse for EthResponse<T, M, JsonOrSsz> {
+    #[instrument(skip_all, level = "debug")]
     fn into_response(self) -> Response {
         let run = || {
             let response_headers = self.response_headers()?;

--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -465,6 +465,7 @@ pub struct ValidatorLivenessResponse {
 }
 
 /// `GET /eth/v1/beacon/genesis`
+#[instrument(skip_all, level = "debug", name = "http_api::genesis")]
 pub async fn genesis<P: Preset>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -481,6 +482,7 @@ pub async fn genesis<P: Preset>(
 }
 
 /// `GET /eth/v1/builder/states/{state_id}/expected_withdrawals`
+#[instrument(skip_all, level = "debug", name = "http_api::expected_withdrawals")]
 pub async fn expected_withdrawals<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -522,6 +524,7 @@ pub async fn expected_withdrawals<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/root`
+#[instrument(skip_all, level = "debug", name = "http_api::state_root")]
 pub async fn state_root<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -541,6 +544,7 @@ pub async fn state_root<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/fork`
+#[instrument(skip_all, level = "debug", name = "http_api::state_fork")]
 pub async fn state_fork<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -558,6 +562,11 @@ pub async fn state_fork<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/finality_checkpoints`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::state_finality_checkpoints"
+)]
 pub async fn state_finality_checkpoints<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -581,6 +590,7 @@ pub async fn state_finality_checkpoints<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/validators`
+#[instrument(skip_all, level = "debug", name = "http_api::get_state_validators")]
 pub async fn get_state_validators<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -596,6 +606,7 @@ pub async fn get_state_validators<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/states/{state_id}/validators`
+#[instrument(skip_all, level = "debug", name = "http_api::post_state_validators")]
 pub async fn post_state_validators<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -611,6 +622,12 @@ pub async fn post_state_validators<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/states/{state_id}/validator_identities`
+#[expect(clippy::type_complexity)]
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::state_validator_identities"
+)]
 pub async fn state_validator_identities<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -663,6 +680,7 @@ pub async fn state_validator_identities<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/validators/{validator_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::state_validator")]
 pub async fn state_validator<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -702,6 +720,11 @@ pub async fn state_validator<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/validator_balances`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::get_state_validator_balances"
+)]
 pub async fn get_state_validator_balances<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -717,6 +740,11 @@ pub async fn get_state_validator_balances<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/states/{state_id}/validator_balances`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::post_state_validator_balances"
+)]
 pub async fn post_state_validator_balances<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -731,6 +759,7 @@ pub async fn post_state_validator_balances<P: Preset, W: Wait>(
     )
 }
 
+#[instrument(skip_all, level = "debug")]
 fn state_validator_balances<P: Preset, W: Wait>(
     controller: &ApiController<P, W>,
     anchor_checkpoint_provider: &AnchorCheckpointProvider<P>,
@@ -764,6 +793,7 @@ fn state_validator_balances<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/committees`
+#[instrument(skip_all, level = "debug", name = "http_api::state_committees")]
 pub async fn state_committees<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -836,6 +866,7 @@ pub async fn state_committees<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/sync_committees`
+#[instrument(skip_all, level = "debug", name = "http_api::state_sync_committees")]
 pub async fn state_sync_committees<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -892,6 +923,7 @@ pub async fn state_sync_committees<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/proposer_lookahead`
+#[instrument(skip_all, level = "debug", name = "http_api::state_proposer_lookahead")]
 pub async fn state_proposer_lookahead<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -918,6 +950,11 @@ pub async fn state_proposer_lookahead<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/pending_consolidations`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::state_pending_consolidations"
+)]
 pub async fn state_pending_consolidations<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -943,6 +980,7 @@ pub async fn state_pending_consolidations<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/pending_deposits`
+#[instrument(skip_all, level = "debug", name = "http_api::state_pending_deposits")]
 pub async fn state_pending_deposits<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -968,6 +1006,11 @@ pub async fn state_pending_deposits<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/pending_partial_withdrawals`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::state_pending_partial_withdrawals"
+)]
 pub async fn state_pending_partial_withdrawals<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -993,6 +1036,7 @@ pub async fn state_pending_partial_withdrawals<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/states/{state_id}/randao`
+#[instrument(skip_all, level = "debug", name = "http_api::state_randao")]
 pub async fn state_randao<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1034,6 +1078,7 @@ pub async fn state_randao<P: Preset, W: Wait>(
 //                      [Lighthouse]:        https://github.com/sigp/lighthouse/blob/441fc1691b69f9edc4bbdc6665f3efab16265c9b/beacon_node/http_api/src/lib.rs#L1129-L1136
 //                      [Nimbus]:            https://github.com/status-im/nimbus-eth2/blob/d19ffcaa0d9505d81a83d7be0049154cae871c7b/beacon_chain/rpc/rest_beacon_api.nim#L781-L822
 /// `GET /eth/v1/beacon/headers`
+#[instrument(skip_all, level = "debug", name = "http_api::block_headers")]
 pub async fn block_headers<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     EthQuery(query): EthQuery<BlockHeadersQuery>,
@@ -1100,6 +1145,7 @@ pub async fn block_headers<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/headers/{block_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::block_id_headers")]
 pub async fn block_id_headers<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1128,6 +1174,7 @@ pub async fn block_id_headers<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/beacon/blocks/{block_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::block")]
 pub async fn block<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1149,6 +1196,7 @@ pub async fn block<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/blocks/{block_id}/root`
+#[instrument(skip_all, level = "debug", name = "http_api::block_root")]
 pub async fn block_root<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1166,6 +1214,7 @@ pub async fn block_root<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/blocks/{block_id}/attestations`
+#[instrument(skip_all, level = "debug", name = "http_api::block_attestations")]
 pub async fn block_attestations<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1188,6 +1237,7 @@ pub async fn block_attestations<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/beacon/blocks/{block_id}/attestations`
+#[instrument(skip_all, level = "debug", name = "http_api::block_attestations_v2")]
 pub async fn block_attestations_v2<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1211,6 +1261,7 @@ pub async fn block_attestations_v2<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/blinded_blocks/{block_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::blinded_block")]
 pub async fn blinded_block<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1236,6 +1287,8 @@ pub async fn blinded_block<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/blob_sidecars/{block_id}`
+#[expect(clippy::type_complexity)]
+#[instrument(skip_all, level = "debug", name = "http_api::blob_sidecars")]
 pub async fn blob_sidecars<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(metrics): State<Option<Arc<Metrics>>>,
@@ -1317,6 +1370,7 @@ pub async fn blob_sidecars<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/blobs/{block_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::blobs")]
 pub async fn blobs<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(metrics): State<Option<Arc<Metrics>>>,
@@ -1415,13 +1469,10 @@ pub async fn blobs<P: Preset, W: Wait>(
 
 /// `POST /eth/v1/beacon/blocks`
 #[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api"
-    ),
-    name = "http_api",
     skip_all,
+    level = "debug",
+    name = "http_api::publish_block",
+    fields(slot = %signed_api_block.slot())
 )]
 pub async fn publish_block<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
@@ -1485,14 +1536,10 @@ pub async fn publish_block<P: Preset, W: Wait>(
 
 /// `POST /eth/v1/beacon/blinded_blocks`
 #[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api",
-        block_slot = %signed_blinded_block.message().slot()
-    ),
-    name = "http_api",
     skip_all,
+    level = "debug",
+    name = "http_api::publish_blinded_block",
+    fields(slot = %signed_blinded_block.message().slot())
 )]
 pub async fn publish_blinded_block<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
@@ -1568,6 +1615,12 @@ pub async fn publish_blinded_block<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v2/beacon/blinded_blocks`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::publish_blinded_block_v2",
+    fields(slot = %signed_blinded_block.message().slot())
+)]
 pub async fn publish_blinded_block_v2<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
     State(controller): State<ApiController<P, W>>,
@@ -1618,6 +1671,12 @@ pub async fn publish_blinded_block_v2<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v2/beacon/blocks`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::publish_block_v2",
+    fields(slot = %signed_api_block.slot())
+)]
 pub async fn publish_block_v2<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -1677,6 +1736,7 @@ pub async fn publish_block_v2<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/rewards/blocks/{block_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::block_rewards")]
 pub async fn block_rewards<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -1731,6 +1791,7 @@ pub async fn block_rewards<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/rewards/sync_committee/{block_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::sync_committee_rewards")]
 pub async fn sync_committee_rewards<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(controller): State<ApiController<P, W>>,
@@ -1796,6 +1857,7 @@ pub async fn sync_committee_rewards<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/pool/attestations`
+#[instrument(skip_all, level = "debug", name = "http_api::pool_attestations")]
 pub async fn pool_attestations<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(attestation_agg_pool): State<Arc<AttestationAggPool<P, W>>>,
@@ -1814,6 +1876,7 @@ pub async fn pool_attestations<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/beacon/pool/attestations`
+#[instrument(skip_all, level = "debug", name = "http_api::pool_attestations_v2")]
 pub async fn pool_attestations_v2<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(attestation_agg_pool): State<Arc<AttestationAggPool<P, W>>>,
@@ -1832,6 +1895,11 @@ pub async fn pool_attestations_v2<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/pool/proposer_slashings`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_proposer_slashing"
+)]
 pub async fn submit_pool_proposer_slashing<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -1855,6 +1923,7 @@ pub async fn submit_pool_proposer_slashing<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/pool/proposer_slashings`
+#[instrument(skip_all, level = "debug", name = "http_api::pool_proposer_slashings")]
 pub async fn pool_proposer_slashings<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
 ) -> Result<EthResponse<Vec<ProposerSlashing>>, Error> {
@@ -1864,6 +1933,11 @@ pub async fn pool_proposer_slashings<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/pool/voluntary_exits`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_voluntary_exit"
+)]
 pub async fn submit_pool_voluntary_exit<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -1887,6 +1961,7 @@ pub async fn submit_pool_voluntary_exit<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/pool/voluntary_exits`
+#[instrument(skip_all, level = "debug", name = "http_api::pool_voluntary_exits")]
 pub async fn pool_voluntary_exits<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
 ) -> Result<EthResponse<Vec<SignedVoluntaryExit>>, Error> {
@@ -1896,6 +1971,11 @@ pub async fn pool_voluntary_exits<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/pool/attester_slashings`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_attester_slashing"
+)]
 pub async fn submit_pool_attester_slashing<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -1921,6 +2001,11 @@ pub async fn submit_pool_attester_slashing<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v2/beacon/pool/attester_slashings`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_attester_slashing_v2"
+)]
 pub async fn submit_pool_attester_slashing_v2<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -1944,6 +2029,7 @@ pub async fn submit_pool_attester_slashing_v2<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/pool/attester_slashings`
+#[instrument(skip_all, level = "debug", name = "http_api::pool_attester_slashings")]
 pub async fn pool_attester_slashings<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
 ) -> Result<EthResponse<Vec<AttesterSlashing<P>>>, Error> {
@@ -1953,6 +2039,11 @@ pub async fn pool_attester_slashings<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/beacon/pool/attester_slashings`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::pool_attester_slashings_v2"
+)]
 pub async fn pool_attester_slashings_v2<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(controller): State<ApiController<P, W>>,
@@ -1982,15 +2073,7 @@ pub async fn pool_attester_slashings_v2<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/pool/attestations`
-#[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api",
-    ),
-    name = "http_api",
-    skip_all
-)]
+#[instrument(skip_all, level = "debug", name = "http_api::submit_pool_attestations")]
 pub async fn submit_pool_attestations<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -2007,6 +2090,11 @@ pub async fn submit_pool_attestations<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v2/beacon/pool/attestations`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_attestations_v2"
+)]
 pub async fn submit_pool_attestations_v2<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(event_channels): State<Arc<EventChannels<P>>>,
@@ -2028,6 +2116,11 @@ pub async fn submit_pool_attestations_v2<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/beacon/pool/sync_committees`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_sync_committees"
+)]
 pub async fn submit_pool_sync_committees<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(sync_committee_agg_pool): State<Arc<SyncCommitteeAggPool<P, W>>>,
@@ -2097,6 +2190,11 @@ pub async fn submit_pool_sync_committees<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/beacon/pool/bls_to_execution_changes`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::pool_bls_to_execution_changes"
+)]
 pub async fn pool_bls_to_execution_changes(
     State(bls_to_execution_change_pool): State<Arc<BlsToExecutionChangePool>>,
 ) -> Result<EthResponse<Vec<SignedBlsToExecutionChange>>, Error> {
@@ -2108,6 +2206,11 @@ pub async fn pool_bls_to_execution_changes(
 }
 
 /// `POST /eth/v1/beacon/pool/bls_to_execution_change`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::submit_pool_bls_to_execution_change"
+)]
 pub async fn submit_pool_bls_to_execution_change(
     State(bls_to_execution_change_pool): State<Arc<BlsToExecutionChangePool>>,
     EthJson(json_vec): EthJson<Vec<Value>>,
@@ -2150,6 +2253,7 @@ pub async fn submit_pool_bls_to_execution_change(
 }
 
 /// `GET /eth/v1/config/fork_schedule`
+#[instrument(skip_all, level = "debug", name = "http_api::fork_schedule")]
 pub async fn fork_schedule<P: Preset>(
     State(chain_config): State<Arc<ChainConfig>>,
 ) -> EthResponse<Vec<Fork>> {
@@ -2168,6 +2272,7 @@ pub async fn fork_schedule<P: Preset>(
 }
 
 /// `GET /eth/v1/config/spec`
+#[instrument(skip_all, level = "debug", name = "http_api::config_spec")]
 pub async fn config_spec<P: Preset>(
     State(chain_config): State<Arc<ChainConfig>>,
 ) -> EthResponse<FullConfig> {
@@ -2175,6 +2280,7 @@ pub async fn config_spec<P: Preset>(
 }
 
 /// `GET /eth/v1/config/deposit_contract`
+#[instrument(skip_all, level = "debug", name = "http_api::deposit_contract")]
 pub async fn deposit_contract(
     State(chain_config): State<Arc<ChainConfig>>,
 ) -> EthResponse<DepositContractResponse> {
@@ -2185,6 +2291,7 @@ pub async fn deposit_contract(
 }
 
 /// `GET /eth/v1/debug/fork_choice`
+#[instrument(skip_all, level = "debug", name = "http_api::debug_fork_choice")]
 pub async fn debug_fork_choice<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
 ) -> Json<ForkChoiceContext> {
@@ -2194,6 +2301,12 @@ pub async fn debug_fork_choice<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/debug/beacon/data_column_sidecars/{block_id}`
+#[expect(clippy::type_complexity)]
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::debug_beacon_data_column_sidecars"
+)]
 pub async fn debug_beacon_data_column_sidecars<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -2270,6 +2383,7 @@ pub async fn debug_beacon_data_column_sidecars<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/debug/beacon/states/{state_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::beacon_state")]
 pub async fn beacon_state<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -2291,6 +2405,7 @@ pub async fn beacon_state<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/debug/beacon/heads`
+#[instrument(skip_all, level = "debug", name = "http_api::beacon_heads")]
 pub async fn beacon_heads<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
 ) -> EthResponse<Vec<ForkTip>> {
@@ -2343,6 +2458,7 @@ pub async fn beacon_events<P: Preset>(
 }
 
 /// `GET /eth/v1/node/identity`
+#[instrument(skip_all, level = "debug", name = "http_api::node_identity")]
 pub async fn node_identity<P: Preset>(
     State(api_to_p2p_tx): State<UnboundedSender<ApiToP2p<P>>>,
 ) -> Result<EthResponse<NodeIdentity>, Error> {
@@ -2356,6 +2472,7 @@ pub async fn node_identity<P: Preset>(
 }
 
 /// `GET /eth/v1/node/peers`
+#[instrument(skip_all, level = "debug", name = "http_api::node_peers")]
 pub async fn node_peers<P: Preset>(
     State(api_to_p2p_tx): State<UnboundedSender<ApiToP2p<P>>>,
     EthQuery(query): EthQuery<NodePeersQuery>,
@@ -2371,6 +2488,7 @@ pub async fn node_peers<P: Preset>(
 }
 
 /// `GET /eth/v1/node/peers/{peer_id}`
+#[instrument(skip_all, level = "debug", name = "http_api::node_peer")]
 pub async fn node_peer<P: Preset>(
     State(api_to_p2p_tx): State<UnboundedSender<ApiToP2p<P>>>,
     EthPath(peer_id): EthPath<PeerId>,
@@ -2385,6 +2503,7 @@ pub async fn node_peer<P: Preset>(
 }
 
 /// `GET /eth/v1/node/peer_count`
+#[instrument(skip_all, level = "debug", name = "http_api::node_peer_count")]
 pub async fn node_peer_count<P: Preset>(
     State(api_to_p2p_tx): State<UnboundedSender<ApiToP2p<P>>>,
 ) -> Result<EthResponse<NodePeerCountResponse>, Error> {
@@ -2398,6 +2517,7 @@ pub async fn node_peer_count<P: Preset>(
 }
 
 /// `GET /eth/v1/node/version`
+#[instrument(skip_all, level = "debug", name = "http_api::node_version")]
 pub async fn node_version(State(network_config): State<Arc<NetworkConfig>>) -> Response {
     let data = NodeVersionResponse {
         version: network_config.identify_agent_version.as_deref(),
@@ -2407,6 +2527,7 @@ pub async fn node_version(State(network_config): State<Arc<NetworkConfig>>) -> R
 }
 
 /// `GET /eth/v1/node/syncing`
+#[instrument(skip_all, level = "debug", name = "http_api::node_syncing_status")]
 pub async fn node_syncing_status<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(eth1_api): State<Arc<Eth1Api>>,
@@ -2432,6 +2553,7 @@ pub async fn node_syncing_status<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/node/health`
+#[instrument(skip_all, level = "debug", name = "http_api::node_health")]
 pub async fn node_health<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(is_synced): State<Arc<SyncedStatus>>,
@@ -2447,6 +2569,11 @@ pub async fn node_health<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/validator/duties/attester/{epoch}`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_attester_duties"
+)]
 pub async fn validator_attester_duties<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -2524,6 +2651,11 @@ pub async fn validator_attester_duties<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/validator/duties/proposer/{epoch}`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_proposer_duties"
+)]
 pub async fn validator_proposer_duties<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(controller): State<ApiController<P, W>>,
@@ -2631,6 +2763,11 @@ async fn get_proposer_duties<P: Preset, W: Wait>(
 //
 //                      [Altair Honest Validator specification]: https://github.com/ethereum/consensus-specs/blob/0b76c8367ed19014d104e3fbd4718e73f459a748/specs/altair/validator.md#sync-committee-subnet-stability
 /// `POST /eth/v1/validator/duties/sync/{epoch}`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_sync_committee_duties"
+)]
 pub async fn validator_sync_committee_duties<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(controller): State<ApiController<P, W>>,
@@ -2717,6 +2854,11 @@ fn state_sync_committee<P: Preset>(
 }
 
 /// `GET /eth/v1/validator/aggregate_attestation`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_aggregate_attestation"
+)]
 pub async fn validator_aggregate_attestation<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(controller): State<ApiController<P, W>>,
@@ -2755,6 +2897,11 @@ pub async fn validator_aggregate_attestation<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v2/validator/aggregate_attestation`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_aggregate_attestation_v2"
+)]
 pub async fn validator_aggregate_attestation_v2<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(controller): State<ApiController<P, W>>,
@@ -2799,16 +2946,7 @@ pub async fn validator_aggregate_attestation_v2<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/validator/blinded_blocks/{slot}`
-#[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api",
-        slot = %slot
-    ),
-    name = "http_api",
-    skip_all,
-)]
+#[instrument(skip_all, level = "debug", name = "http_api::validator_blinded_block")]
 pub async fn validator_blinded_block<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
@@ -2879,16 +3017,7 @@ pub async fn validator_blinded_block<P: Preset, W: Wait>(
 
 /// `GET /eth/v2/validator/blocks/{slot}`
 #[expect(clippy::type_complexity)]
-#[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api",
-        slot = %slot
-    ),
-    name = "http_api",
-    skip_all,
-)]
+#[instrument(skip_all, level = "debug", name = "http_api::validator_block")]
 pub async fn validator_block<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
@@ -2939,6 +3068,8 @@ pub async fn validator_block<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v3/validator/blocks/{slot}`
+#[expect(clippy::type_complexity)]
+#[instrument(skip_all, level = "debug", name = "http_api::validator_block_v3")]
 pub async fn validator_block_v3<P: Preset, W: Wait>(
     State(chain_config): State<Arc<ChainConfig>>,
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
@@ -3029,15 +3160,9 @@ pub async fn validator_block_v3<P: Preset, W: Wait>(
 
 /// `GET /eth/v1/validator/attestation_data`
 #[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api",
-        slot = %query.slot,
-        committee_index = %query.committee_index
-    ),
-    name = "http_api",
     skip_all,
+    level = "debug",
+    name = "http_api::validator_attestation_data"
 )]
 pub async fn validator_attestation_data<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
@@ -3157,6 +3282,11 @@ pub async fn validator_attestation_data<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/validator/beacon_committee_subscriptions`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_subscribe_to_beacon_committee"
+)]
 pub async fn validator_subscribe_to_beacon_committee<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(anchor_checkpoint_provider): State<AnchorCheckpointProvider<P>>,
@@ -3220,6 +3350,11 @@ pub async fn validator_subscribe_to_beacon_committee<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/validator/sync_committee_subscriptions`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_subscribe_to_sync_committees"
+)]
 pub async fn validator_subscribe_to_sync_committees<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(subnet_service_tx): State<UnboundedSender<ToSubnetService>>,
@@ -3234,6 +3369,11 @@ pub async fn validator_subscribe_to_sync_committees<P: Preset, W: Wait>(
 }
 
 /// `GET /eth/v1/validator/sync_committee_contribution`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_sync_committee_contribution"
+)]
 pub async fn validator_sync_committee_contribution<P: Preset, W: Wait>(
     State(sync_committee_agg_pool): State<Arc<SyncCommitteeAggPool<P, W>>>,
     EthQuery(query): EthQuery<SyncCommitteeContributionQuery>,
@@ -3266,6 +3406,11 @@ pub async fn validator_sync_committee_contribution<P: Preset, W: Wait>(
 /// [the specification]: https://ethereum.github.io/beacon-APIs/
 // We box aggregates to reduce the size of various enums.
 // It's probably faster to deserialize them directly into `Vec<Box<_>>`.
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_publish_aggregate_and_proofs_v1"
+)]
 pub async fn validator_publish_aggregate_and_proofs_v1<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(api_to_p2p_tx): State<UnboundedSender<ApiToP2p<P>>>,
@@ -3285,6 +3430,11 @@ pub async fn validator_publish_aggregate_and_proofs_v1<P: Preset, W: Wait>(
 /// [the specification]: https://ethereum.github.io/beacon-APIs/
 // We box aggregates to reduce the size of various enums.
 // It's probably faster to deserialize them directly into `Vec<Box<_>>`.
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_publish_aggregate_and_proofs_v2"
+)]
 pub async fn validator_publish_aggregate_and_proofs_v2<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(api_to_p2p_tx): State<UnboundedSender<ApiToP2p<P>>>,
@@ -3380,6 +3530,11 @@ pub async fn validator_publish_contributions_and_proofs<P: Preset, W: Wait>(
 }
 
 /// `POST /eth/v1/validator/prepare_beacon_proposer`
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_prepare_beacon_proposer"
+)]
 pub async fn validator_prepare_beacon_proposer<P: Preset, W: Wait>(
     State(block_producer): State<Arc<BlockProducer<P, W>>>,
     EthJson(proposers): EthJson<Vec<ProposerData>>,
@@ -3394,6 +3549,11 @@ pub async fn validator_prepare_beacon_proposer<P: Preset, W: Wait>(
 /// This deviates from [the specification] by returning errors as [`IndexedError`].
 ///
 /// [the specification]: https://ethereum.github.io/beacon-APIs/
+#[instrument(
+    skip_all,
+    level = "debug",
+    name = "http_api::validator_register_validator"
+)]
 pub async fn validator_register_validator<P: Preset>(
     State(api_to_validator_tx): State<UnboundedSender<ApiToValidator<P>>>,
     EthJson(registrations): EthJson<Vec<SignedValidatorRegistrationV1>>,
@@ -3430,6 +3590,7 @@ pub async fn validator_register_validator<P: Preset>(
 }
 
 /// `POST /eth/v1/validator/liveness/{epoch}`
+#[instrument(skip_all, level = "debug", name = "http_api::validator_liveness")]
 pub async fn validator_liveness<P: Preset, W: Wait>(
     State(controller): State<ApiController<P, W>>,
     State(api_to_liveness_tx): State<Option<UnboundedSender<ApiToLiveness>>>,
@@ -3465,6 +3626,7 @@ pub async fn validator_sync_committee_selections() -> Error {
 }
 
 /// `POST /eth/v2/debug/tracing/log_level`
+#[instrument(skip_all, level = "debug", name = "http_api::post_log_level")]
 pub async fn post_log_level(
     State(handle): State<Option<TracingHandle>>,
     Json(req): Json<LogLevelRequest>,
@@ -3496,6 +3658,7 @@ pub async fn post_log_level(
 }
 
 /// `POST /eth/v2/debug/tracing/trace_level`
+#[instrument(skip_all, level = "debug", name = "http_api::post_trace_level")]
 pub async fn post_trace_level(
     State(handle): State<Option<TracingHandle>>,
     Json(req): Json<TraceLevelRequest>,
@@ -3598,16 +3761,7 @@ fn state_validators<P: Preset, W: Wait>(
         .finalized(finalized))
 }
 
-#[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api",
-        block_root = %block.message().hash_tree_root()
-    ),
-    name = "http_api",
-    skip_all,
-)]
+#[instrument(skip_all, level = "debug")]
 async fn publish_signed_block<P: Preset, W: Wait>(
     block: Arc<SignedBeaconBlock<P>>,
     blob_sidecars: Vec<BlobSidecar<P>>,
@@ -3663,6 +3817,7 @@ async fn publish_signed_block<P: Preset, W: Wait>(
     Ok(status_code)
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn publish_beacon_block_with_gossip_checks<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     event_channels: Arc<EventChannels<P>>,
@@ -3703,6 +3858,7 @@ async fn publish_beacon_block_with_gossip_checks<P: Preset, W: Wait>(
     Ok(None)
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn publish_beacon_block_with_gossip_checks_data_column_sidecars<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     event_channels: Arc<EventChannels<P>>,
@@ -3751,6 +3907,7 @@ async fn publish_beacon_block_with_gossip_checks_data_column_sidecars<P: Preset,
     Ok(None)
 }
 
+#[instrument(skip_all, level = "debug")]
 fn publish_block_to_network<P: Preset>(
     block: Arc<SignedBeaconBlock<P>>,
     blob_sidecars: &[Arc<BlobSidecar<P>>],
@@ -3763,6 +3920,7 @@ fn publish_block_to_network<P: Preset>(
     ApiToP2p::PublishBeaconBlock(block).send(api_to_p2p_tx);
 }
 
+#[instrument(skip_all, level = "debug")]
 fn publish_block_to_network_with_data_column_sidecars<P: Preset>(
     block: Arc<SignedBeaconBlock<P>>,
     data_column_sidecars: &[Arc<DataColumnSidecar<P>>],
@@ -3776,6 +3934,7 @@ fn publish_block_to_network_with_data_column_sidecars<P: Preset>(
 }
 
 // TODO(feature/fulu): merge with `publish_signed_block`
+#[instrument(skip_all, level = "debug")]
 async fn publish_signed_block_with_data_column_sidecar<P: Preset, W: Wait>(
     block: Arc<SignedBeaconBlock<P>>,
     data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
@@ -3834,6 +3993,7 @@ async fn publish_signed_block_with_data_column_sidecar<P: Preset, W: Wait>(
     Ok(status_code)
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn publish_signed_block_v2<P: Preset, W: Wait>(
     block: Arc<SignedBeaconBlock<P>>,
     blob_sidecars: Vec<BlobSidecar<P>>,
@@ -3928,6 +4088,7 @@ async fn publish_signed_block_v2<P: Preset, W: Wait>(
 }
 
 // TODO(feature/fulu): merge with `publish_signed_block_v2`
+#[instrument(skip_all, level = "debug")]
 async fn publish_signed_block_v2_with_data_column_sidecar<P: Preset, W: Wait>(
     block: Arc<SignedBeaconBlock<P>>,
     data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
@@ -4031,6 +4192,7 @@ async fn publish_signed_block_v2_with_data_column_sidecar<P: Preset, W: Wait>(
     Ok(status_code)
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn get_pool_attestations<P: Preset, W: Wait>(
     attestation_agg_pool: Arc<AttestationAggPool<P, W>>,
     slot: Slot,
@@ -4066,6 +4228,7 @@ async fn get_pool_attestations<P: Preset, W: Wait>(
         .collect()
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn wait_for_validation<P: Preset>(
     attestation: Arc<Attestation<P>>,
     index: usize,
@@ -4081,6 +4244,7 @@ async fn wait_for_validation<P: Preset>(
 }
 
 #[expect(clippy::type_complexity)]
+#[instrument(skip_all, level = "debug")]
 fn build_attestation_item<P: Preset, W: Wait>(
     controller: &ApiController<P, W>,
     index: usize,
@@ -4127,15 +4291,7 @@ fn build_attestation_item<P: Preset, W: Wait>(
     ))
 }
 
-#[instrument(
-    parent = None,
-    level = "trace",
-    fields(
-        service = "http_api"
-    ),
-    name = "http_api",
-    skip_all,
-)]
+#[instrument(skip_all, level = "debug")]
 async fn submit_attestations_to_pool<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     event_channels: Arc<EventChannels<P>>,
@@ -4246,6 +4402,7 @@ async fn submit_attestations_to_pool<P: Preset, W: Wait>(
     Ok(())
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn submit_blob_sidecar<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     blob_sidecar: Arc<BlobSidecar<P>>,
@@ -4257,6 +4414,7 @@ async fn submit_blob_sidecar<P: Preset, W: Wait>(
     receiver.await?
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn submit_blob_sidecars<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     blob_sidecars: Vec<Arc<BlobSidecar<P>>>,
@@ -4282,6 +4440,7 @@ async fn submit_blob_sidecars<P: Preset, W: Wait>(
     }
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn submit_data_column_sidecar<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     data_column_sidecar: Arc<DataColumnSidecar<P>>,
@@ -4295,6 +4454,7 @@ async fn submit_data_column_sidecar<P: Preset, W: Wait>(
     receiver.await?
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn submit_data_column_sidecars<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     data_column_sidecars: Vec<Arc<DataColumnSidecar<P>>>,
@@ -4322,6 +4482,7 @@ async fn submit_data_column_sidecars<P: Preset, W: Wait>(
     }
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn wait_for_missing_blocks_with_timeout<P: Preset, W: Wait>(
     controller: &ApiController<P, W>,
     event_channels: &EventChannels<P>,
@@ -4365,6 +4526,7 @@ async fn wait_for_missing_blocks_with_timeout<P: Preset, W: Wait>(
     Ok(())
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn construct_blobs_from_data_column_sidecars<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     block: Arc<SignedBeaconBlock<P>>,
@@ -4440,6 +4602,7 @@ async fn construct_blobs_from_data_column_sidecars<P: Preset, W: Wait>(
     .await?
 }
 
+#[instrument(skip_all, level = "debug")]
 fn construct_blob_sidecars_from_blobs_and_commitments<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     block: &SignedBeaconBlock<P>,
@@ -4460,6 +4623,7 @@ fn construct_blob_sidecars_from_blobs_and_commitments<P: Preset, W: Wait>(
     })
 }
 
+#[instrument(skip_all, level = "debug")]
 async fn construct_data_column_sidecars_from_blobs<P: Preset, W: Wait>(
     controller: ApiController<P, W>,
     signed_beacon_block: Arc<SignedBeaconBlock<P>>,

--- a/http_api/src/state_id.rs
+++ b/http_api/src/state_id.rs
@@ -4,10 +4,12 @@ use eth1_api::ApiController;
 use fork_choice_control::Wait;
 use genesis::AnchorCheckpointProvider;
 use http_api_utils::StateId;
+use tracing::instrument;
 use types::{combined::BeaconState, nonstandard::WithStatus, preset::Preset};
 
 use crate::error::Error;
 
+#[instrument(level = "debug", skip_all, fields(%state_id))]
 pub fn state<P: Preset, W: Wait>(
     state_id: &StateId,
     controller: &ApiController<P, W>,

--- a/http_api/src/task.rs
+++ b/http_api/src/task.rs
@@ -23,7 +23,6 @@ use p2p::{ApiToP2p, NetworkConfig, SyncToApi, ToSubnetService};
 use prometheus_metrics::Metrics;
 use std_ext::ArcExt as _;
 use tokio::net::TcpListener;
-use tracing::instrument;
 use types::preset::Preset;
 use validator::{ApiToValidator, ValidatorConfig};
 
@@ -62,7 +61,6 @@ pub struct HttpApi<P: Preset, W: Wait> {
 }
 
 impl<P: Preset, W: Wait> HttpApi<P, W> {
-    #[instrument(parent = None, skip(self), fields(address = %self.http_api_config.address))]
     pub async fn run(self) -> Result<()> {
         let listener = self.http_api_config.listener().await?;
         self.run_internal(|_, router| router, listener).await
@@ -72,7 +70,6 @@ impl<P: Preset, W: Wait> HttpApi<P, W> {
     // Passing in `AddrIncoming` achieves 2 things:
     // - It ensures that the socket is bound and listening by the time we submit requests.
     // - It allows us to extract the port assigned by binding to port 0.
-    #[instrument(parent = None, skip_all)]
     pub(crate) async fn run_internal(
         self,
         extend_router: impl FnOnce(NormalState<P, W>, Router) -> Router + Send,

--- a/http_api_utils/src/error.rs
+++ b/http_api_utils/src/error.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use thiserror::Error;
+use tracing::instrument;
 
 use crate::{misc::Direction, traits::ApiError};
 
@@ -33,6 +34,7 @@ impl ApiError for Error {
 }
 
 impl IntoResponse for Error {
+    #[instrument(skip_all, level = "debug")]
     fn into_response(self) -> Response {
         let status_code = self.status_code();
         let extension = Extension(Arc::new(self));

--- a/http_api_utils/src/helpers.rs
+++ b/http_api_utils/src/helpers.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 
 use anyhow::{Error as AnyhowError, Result};
-use axum::{Router, error_handling::HandleErrorLayer, http::StatusCode};
+use axum::{Router, error_handling::HandleErrorLayer, extract::Request, http::StatusCode};
 use features::Feature;
 use http::{HeaderMap, HeaderValue};
 use thiserror::Error;
@@ -10,6 +10,7 @@ use tower_http::{
     cors::{AllowOrigin, CorsLayer},
     trace::TraceLayer,
 };
+use tracing::debug_span;
 use types::nonstandard::Phase;
 
 use crate::{ApiError, ETH_CONSENSUS_VERSION, logging, middleware, misc::ApiMetrics};
@@ -38,6 +39,14 @@ pub fn extend_router_with_middleware<E: ApiError + Send + Sync + 'static>(
 
     router = router.layer(
         TraceLayer::new_for_http()
+            .make_span_with(move |request: &Request<_>| {
+                debug_span!(
+                    "http_request",
+                    method = %request.method(),
+                    uri = %request.uri(),
+                    version = ?request.version(),
+                )
+            })
             .on_request(logging::log_request)
             .on_response(logging::log_response::<E>(api_metrics)),
     );

--- a/http_api_utils/src/logging.rs
+++ b/http_api_utils/src/logging.rs
@@ -13,10 +13,6 @@ use tracing::Span;
 
 use crate::{ApiError, misc::ApiMetrics};
 
-// `TraceLayer` already logs most of this out of the box, but we still use `log`.
-// We have to duplicate some of the information because `log` does not have spans.
-//
-// Enabling the `log` feature of the `tracing` crate isn't enough.
 // By default, `TraceLayer` emits events at `DEBUG` with the default target.
 // Our application filters them out.
 

--- a/http_api_utils/src/traits.rs
+++ b/http_api_utils/src/traits.rs
@@ -9,7 +9,7 @@ pub trait ApiError {
     // - <https://github.com/dtolnay/thiserror/issues/98>
     // - <https://github.com/dtolnay/thiserror/issues/214>
     fn format_sources(&self) -> impl Display + '_ {
-        self.sources().format(": ")
+        self.sources().join(": ")
     }
 
     // `StdError::sources` is not stable as of Rust 1.92.0.

--- a/runtime/src/grandine_args.rs
+++ b/runtime/src/grandine_args.rs
@@ -1192,7 +1192,7 @@ impl GrandineArgs {
         if !unknown.is_empty() {
             warn_with_peers!(
                 "unknown configuration variables: [{:?}]",
-                unknown.keys().format(", "),
+                unknown.keys().join(", "),
             );
         }
 
@@ -1530,7 +1530,7 @@ enum Error {
     MissingEth1RpcUrlsForCustomWithoutGenesisState,
     #[error(
         "{phase} variables in {preset_name} preset do not match file ({})",
-        differences.iter().format(", "),
+        differences.iter().join(", "),
     )]
     PresetMismatch {
         preset_name: PresetName,
@@ -1539,7 +1539,7 @@ enum Error {
     },
     #[error(
         "variables in configuration do not match file ({})",
-        differences.iter().format(", "),
+        differences.iter().join(", "),
     )]
     ConfigMismatch { differences: Vec<Difference> },
     #[error("--unfinalized-states-in-memory must be at least {minimum}")]

--- a/runtime/src/grandine_config.rs
+++ b/runtime/src/grandine_config.rs
@@ -131,7 +131,7 @@ impl GrandineConfig {
 
         self.storage_config.print_db_sizes();
 
-        info!("Eth1 RPC URLs: [{}]", eth1_rpc_urls.iter().format(", "));
+        info!("Eth1 RPC URLs: [{}]", eth1_rpc_urls.iter().join(", "));
         info!("graffiti: {graffiti:?}");
 
         if *disable_blockprint_graffiti {
@@ -200,7 +200,7 @@ impl GrandineConfig {
         if !web3signer_config.urls.is_empty() {
             info!(
                 "using Web3Signer API to sign validator messages (API URLs: [{}])",
-                web3signer_config.urls.iter().format(", "),
+                web3signer_config.urls.iter().join(", "),
             );
         }
 

--- a/snapshot_test_utils/src/lib.rs
+++ b/snapshot_test_utils/src/lib.rs
@@ -78,7 +78,7 @@ impl<'path> Case<'path> {
                 "{}/{} requests failed{separator}{:?}",
                 failures.len(),
                 successes.len() + failures.len(),
-                failures.into_iter().format(separator),
+                failures.into_iter().join(separator),
             );
 
             Ok(())

--- a/validator/src/api.rs
+++ b/validator/src/api.rs
@@ -45,6 +45,7 @@ use ssz::H256;
 use std_ext::ArcExt as _;
 use thiserror::Error;
 use tower_http::cors::AllowOrigin;
+use tracing::instrument;
 use types::{
     bellatrix::primitives::Gas,
     phase0::{
@@ -156,6 +157,7 @@ impl Error {
 }
 
 impl IntoResponse for Error {
+    #[instrument(skip_all, level = "debug")]
     fn into_response(self) -> Response {
         let status_code = self.status_code();
         let body = Json(self.body()).into_response();
@@ -199,6 +201,7 @@ impl<T> EthResponse<T> {
 }
 
 impl<T: Serialize> IntoResponse for EthResponse<T> {
+    #[instrument(skip_all, level = "debug")]
     fn into_response(self) -> Response {
         let run = || {
             let response_body = self.into_json();


### PR DESCRIPTION
- Add debug-level tracing info to Beacon API endpoints (for non-debug use cases, Prometheus already tracks response times)
- Create a root span upon request, recording details like URL and request method.
- Add tracing of serialization to response time. 

<img width="967" height="793" alt="response" src="https://github.com/user-attachments/assets/e0d3dca1-03e2-4139-b99c-a3aa9770a396" />
