### PR TITLE
Disable nethermind build & publish for stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       commit: ${{ steps.git-vars.outputs.sha_short }}
       version: ${{ (github.event_name == 'push' && github.event.ref != 'refs/heads/develop' && github.ref_name) || steps.git-vars.outputs.sha_short }}
       nethermind: ${{ inputs.nethermind_version || steps.nethermind-tag.outputs.result }}
+      label: ${{ (github.event_name == 'push' && github.event.ref != 'refs/heads/develop' && 'stable') || 'unstable' }}
 
   build:
     name: Build binary for target ${{ matrix.target }}
@@ -139,6 +140,7 @@ jobs:
     needs: [version]
     env:
       NETHERMIND_VERSION: ${{ needs.version.outputs.nethermind }}
+    if: needs.version.outputs.label == 'unstable'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -171,6 +173,8 @@ jobs:
       GRANDINE_VERSION: ${{ needs.version.outputs.version }}
       GRANDINE_COMMIT: ${{ needs.version.outputs.commit }}
       NETHERMIND_VERSION: ${{ needs.version.outputs.nethermind }}
+      DOCKER_LABEL: ${{ needs.version.outputs.label }}
+    if: always() && needs.version.result == 'success' && needs.build.result == 'success'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -190,6 +194,7 @@ jobs:
           path: artifacts
 
       - name: Download csharp bindings
+        if: needs.version.outputs.label == 'unstable'
         uses: actions/download-artifact@v5
         with:
           name: plugin
@@ -206,7 +211,10 @@ jobs:
           mv ./artifacts/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64/grandine-${{ env.GRANDINE_VERSION }}-linux-arm64 ./target/aarch64-unknown-linux-gnu/compact/grandine
           chmod +x ./target/aarch64-unknown-linux-gnu/compact/grandine
           mv ./artifacts/lib-linux-arm64/libgrandine.so ./target/aarch64-unknown-linux-gnu/compact/libgrandine.so
-          
+      
+      - name: Move C# artifacts
+        if: needs.version.outputs.label == 'unstable'
+        run: |
           mkdir -p ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/
           mv ./artifacts/Grandine.NethermindPlugin.dll ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/
 
@@ -222,9 +230,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build & push docker images
+      - name: Build & push docker images (with nethermind integration)
+        if: needs.version.outputs.label == 'unstable'
         env:
-          DOCKER_LABEL: ${{ github.event_name == 'push' && github.event.ref != 'refs/heads/develop' && 'stable' || 'unstable' }}
           DOCKER_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && env.GRANDINE_COMMIT || '' }}
         run: |
           make docker \
@@ -233,10 +241,21 @@ jobs:
             GRANDINE_VERSION=${{ env.GRANDINE_VERSION }} \
             NETHERMIND_VERSION=${{ env.NETHERMIND_VERSION }}
 
+      - name: Build & push docker images
+        if: needs.version.outputs.label == 'stable'
+        env: 
+          DOCKER_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && env.GRANDINE_COMMIT || '' }}
+        run: |
+          make grandine-docker \
+            DOCKER_LABEL=${{ env.DOCKER_LABEL }} \
+            DOCKER_SUFFIX=${{ env.DOCKER_SUFFIX }} \
+            GRANDINE_VERSION=${{ env.GRANDINE_VERSION }}
+
   pack_nethermind:
     name: Pack nethermind release with embedded grandine
     runs-on: ubuntu-latest
     needs: [version, build_csharp_bindings, build]
+    if: needs.version.outputs.label == 'unstable'
     strategy:
       matrix:
         include:
@@ -290,7 +309,7 @@ jobs:
 
   publish:
     name: Draft release
-    if: github.event_name == 'push' && github.event.ref != 'refs/heads/develop'
+    if: always() && needs.version.outputs.label == 'stable'
     needs: [build, pack_nethermind]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Grandine-nethermind integration is not currently ready for stable release, so disabling it during automatic release.