### PR TITLE
Remove validator public keys from persisted state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,6 +5907,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "bls",
  "bytesize",
  "cached",
  "clock",
@@ -5954,6 +5955,7 @@ dependencies = [
  "tokio",
  "tracing",
  "transition_functions",
+ "try_from_iterator",
  "tynm",
  "typenum",
  "types",

--- a/fork_choice_control/Cargo.toml
+++ b/fork_choice_control/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
+bls = { workspace = true }
 cached = { workspace = true }
 clock = { workspace = true }
 crossbeam-utils = { workspace = true }
@@ -48,6 +49,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 transition_functions = { workspace = true }
+try_from_iterator = { workspace = true }
 tynm = { workspace = true }
 typenum = { workspace = true }
 types = { workspace = true }

--- a/fork_choice_control/src/controller.rs
+++ b/fork_choice_control/src/controller.rs
@@ -680,11 +680,14 @@ where
         anchor_checkpoint_provider: &AnchorCheckpointProvider<P>,
         is_exiting: &Arc<AtomicBool>,
     ) -> Result<()> {
+        let store = self.store_snapshot();
+
         self.storage.archive_back_sync_states(
             start_slot,
             end_slot,
             anchor_checkpoint_provider,
             is_exiting,
+            &store.finalized_validators(),
         )
     }
 

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -368,7 +368,7 @@ where
 
         let head_slot = self
             .storage
-            .checkpoint_state_slot()?
+            .checkpoint_state_slot(&self.store.finalized_validators())?
             .unwrap_or_else(|| last_block.message().slot());
 
         self.handle_tick(&wait_group, Tick::start_of_slot(head_slot))?;
@@ -2259,6 +2259,7 @@ where
             let store = self.owned_store();
             let storage = self.storage.clone_arc();
             let wait_group = wait_group.clone();
+            let finalized_validators = store.finalized_validators();
 
             if !unloaded.is_empty() {
                 Builder::new()
@@ -2270,7 +2271,7 @@ where
                         .iter()
                         .map(|chain_link| (chain_link.state(&store), chain_link.block_root));
 
-                    match storage.append_states(states_with_block_roots) {
+                    match storage.append_states(states_with_block_roots, &finalized_validators) {
                         Ok(slots) => {
                             debug_with_peers!(
                                 "unloaded old beacon states persisted \

--- a/fork_choice_control/src/queries.rs
+++ b/fork_choice_control/src/queries.rs
@@ -377,7 +377,10 @@ where
             return Ok(Some(with_status));
         }
 
-        if let Some(state) = self.storage().stored_state_by_state_root(state_root)? {
+        if let Some(state) = self
+            .storage()
+            .stored_state_by_state_root(state_root, &store.finalized_validators())?
+        {
             let finalized = store.is_slot_finalized(state.slot());
             return Ok(Some(WithStatus::valid(state, finalized)));
         }
@@ -682,7 +685,10 @@ where
             return Ok(state);
         }
 
-        if let Some(state) = self.storage().state_post_block(block_root)? {
+        if let Some(state) = self
+            .storage()
+            .state_post_block(block_root, &store.finalized_validators())?
+        {
             return state_cache.process_slots(pubkey_cache, &store, state, block_root, slot);
         }
 
@@ -710,7 +716,9 @@ where
                 return Ok(state);
             }
 
-            if let Some(state) = storage.state_post_block(block_root)? {
+            if let Some(state) =
+                storage.state_post_block(block_root, &store.finalized_validators())?
+            {
                 return state_cache.process_slots(&pubkey_cache, &store, state, block_root, slot);
             }
 
@@ -1198,7 +1206,10 @@ impl<P: Preset> Snapshot<'_, P> {
             }));
         }
 
-        if let Some(state) = self.storage.stored_state(slot)? {
+        if let Some(state) = self
+            .storage
+            .stored_state(slot, Some(&store.finalized_validators()))?
+        {
             let finalized = store.is_slot_finalized(state.slot());
             return Ok(Some(WithStatus::valid(state, finalized)));
         }

--- a/fork_choice_control/src/storage.rs
+++ b/fork_choice_control/src/storage.rs
@@ -2,22 +2,25 @@ use core::{cell::OnceCell, marker::PhantomData, num::NonZeroU64};
 use std::{borrow::Cow, sync::Arc};
 
 use anyhow::{Context as _, Error as AnyhowError, Result, bail, ensure};
+use bls::PublicKeyBytes;
 use database::{Database, PrefixableKey};
 use derive_more::Display;
 use fork_choice_store::{ChainLink, Store};
 use genesis::AnchorCheckpointProvider;
 use helper_functions::{accessors, misc};
-use itertools::Itertools as _;
+use itertools::{Either, Itertools as _};
 use logging::{debug_with_peers, info_with_peers, warn_with_peers};
 use nonzero_ext::nonzero;
 use pubkey_cache::PubkeyCache;
 use reqwest::Client;
-use ssz::{Ssz, SszRead, SszReadDefault, SszWrite};
+use ssz::{PersistentList, Ssz, SszRead, SszReadDefault, SszWrite};
 use std_ext::ArcExt as _;
 use thiserror::Error;
 use tracing::info;
 use transition_functions::combined;
+use try_from_iterator::TryFromIterator;
 use types::{
+    Validators,
     combined::{BeaconState, DataColumnSidecar, SignedBeaconBlock},
     config::Config,
     deneb::{
@@ -118,8 +121,8 @@ impl<P: Preset> Storage<P> {
             } => 'block: {
                 // Attempt to load local state first: either latest or from specified slot.
                 let local_state_storage = match state_slot {
-                    Some(slot) => self.load_state_by_iteration(slot)?,
-                    None => self.load_latest_state()?,
+                    Some(slot) => self.load_state_by_iteration(slot, None)?,
+                    None => self.load_latest_state(None)?,
                 };
 
                 if let Some(url) = checkpoint_sync_url {
@@ -218,20 +221,32 @@ impl<P: Preset> Storage<P> {
 
         info_with_peers!("loaded state at slot {anchor_slot}");
 
-        self.database.put_batch([
+        let mut batch = vec![
             serialize(FinalizedBlockByRoot(anchor_block_root), &anchor_block)?,
             serialize(BlockRootBySlot(anchor_slot), anchor_block_root)?,
             serialize(SlotByStateRoot(anchor_state_root), anchor_slot)?,
-            serialize(StateByBlockRoot(anchor_block_root), &anchor_state)?,
-        ])?;
+            serialize(
+                StateByBlockRoot(anchor_block_root),
+                prepare_state(anchor_state.clone_arc()),
+            )?,
+        ];
+
+        self.append_finalized_validator_pubkeys_to_batch(&mut batch, anchor_state.validators())?;
+
+        self.database.put_batch(batch)?;
 
         let state_storage = (anchor_state, anchor_block, unfinalized_blocks);
 
         Ok((state_storage, loaded_from_remote))
     }
 
-    fn load_latest_state(&self) -> Result<OptionalStateStorage<'_, P>> {
-        if let Some((state, block, blocks)) = self.load_state_and_blocks_from_checkpoint()? {
+    fn load_latest_state(
+        &self,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<OptionalStateStorage<'_, P>> {
+        if let Some((state, block, blocks)) =
+            self.load_state_and_blocks_from_checkpoint(finalized_validators)?
+        {
             Ok(OptionalStateStorage::Full((state, block, blocks)))
         } else {
             info_with_peers!(
@@ -239,7 +254,7 @@ impl<P: Preset> Storage<P> {
                  attempting to find stored state by iteration",
             );
 
-            self.load_state_by_iteration(Slot::MAX)
+            self.load_state_by_iteration(Slot::MAX, finalized_validators)
         }
     }
 
@@ -255,6 +270,11 @@ impl<P: Preset> Storage<P> {
         let mut archival_state_appended = false;
         let mut batch = vec![];
 
+        self.append_finalized_validator_pubkeys_to_batch(
+            &mut batch,
+            &store.finalized_validators(),
+        )?;
+
         let unfinalized = unfinalized.zip(core::iter::repeat(false));
         let finalized = finalized.rev().zip(core::iter::repeat(true));
 
@@ -263,7 +283,9 @@ impl<P: Preset> Storage<P> {
             .filter(|(chain_link, is_finalized)| *is_finalized || chain_link.is_valid())
             .peekable();
 
-        if let Some(StateCheckpoint { head_slot, .. }) = self.load_state_checkpoint()? {
+        if let Some(StateCheckpoint { head_slot, .. }) =
+            self.load_state_checkpoint(Some(&store.finalized_validators()))?
+        {
             store_head_slot = head_slot;
         }
 
@@ -321,7 +343,9 @@ impl<P: Preset> Storage<P> {
                         StateCheckpoint {
                             block_root,
                             head_slot: store_head_slot,
-                            state: state.get_or_init(|| chain_link.state(store)).clone_arc(),
+                            state: prepare_state(
+                                state.get_or_init(|| chain_link.state(store)).clone_arc(),
+                            ),
                         },
                     )?);
 
@@ -336,7 +360,7 @@ impl<P: Preset> Storage<P> {
 
                     batch.push(serialize(
                         StateByBlockRoot(block_root),
-                        state.get_or_init(|| chain_link.state(store)),
+                        prepare_state(state.get_or_init(|| chain_link.state(store)).clone_arc()),
                     )?);
 
                     archival_state_appended = true;
@@ -384,14 +408,21 @@ impl<P: Preset> Storage<P> {
     pub(crate) fn append_states(
         &self,
         states_with_block_roots: impl Iterator<Item = (Arc<BeaconState<P>>, H256)>,
+        finalized_validators: &Validators<P>,
     ) -> Result<Vec<Slot>> {
         let mut slots = vec![];
         let mut batch = vec![];
+        self.append_finalized_validator_pubkeys_to_batch(&mut batch, finalized_validators)?;
 
         for (state, block_root) in states_with_block_roots {
             if !self.contains_key(StateByBlockRoot(block_root))? {
+                let archival_state = state.clone_arc();
+
                 slots.push(state.slot());
-                batch.push(serialize(StateByBlockRoot(block_root), state)?);
+                batch.push(serialize(
+                    StateByBlockRoot(block_root),
+                    prepare_state(archival_state),
+                )?);
             }
         }
 
@@ -586,8 +617,13 @@ impl<P: Preset> Storage<P> {
         self.database.delete_batch(keys_to_remove)
     }
 
-    pub(crate) fn checkpoint_state_slot(&self) -> Result<Option<Slot>> {
-        if let Some(StateCheckpoint { head_slot, .. }) = self.load_state_checkpoint()? {
+    pub(crate) fn checkpoint_state_slot(
+        &self,
+        finalized_validators: &Validators<P>,
+    ) -> Result<Option<Slot>> {
+        if let Some(StateCheckpoint { head_slot, .. }) =
+            self.load_state_checkpoint(Some(finalized_validators))?
+        {
             return Ok(Some(head_slot));
         }
 
@@ -626,8 +662,19 @@ impl<P: Preset> Storage<P> {
         self.get(BlockRootBySlot(slot))
     }
 
-    fn state_by_block_root(&self, block_root: H256) -> Result<Option<Arc<BeaconState<P>>>> {
-        self.get(StateByBlockRoot(block_root))
+    fn state_by_block_root(
+        &self,
+        block_root: H256,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<Option<Arc<BeaconState<P>>>> {
+        let Some(mut state) = self.get::<Arc<BeaconState<P>>>(StateByBlockRoot(block_root))? else {
+            return Ok(None);
+        };
+
+        // Restore validators if they were removed
+        self.restore_validators_to_state(state.make_mut(), finalized_validators)?;
+
+        Ok(Some(state))
     }
 
     pub(crate) fn slot_by_state_root(&self, state_root: H256) -> Result<Option<Slot>> {
@@ -678,13 +725,18 @@ impl<P: Preset> Storage<P> {
         Ok(Some((block, block_root)))
     }
 
-    pub(crate) fn stored_state(&self, slot: Slot) -> Result<Option<Arc<BeaconState<P>>>> {
-        let (mut state, state_block, blocks) = match self.load_state_by_iteration(slot)? {
-            OptionalStateStorage::None | OptionalStateStorage::UnfinalizedOnly(_) => {
-                return Ok(None);
-            }
-            OptionalStateStorage::Full(state_storage) => state_storage,
-        };
+    pub(crate) fn stored_state(
+        &self,
+        slot: Slot,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<Option<Arc<BeaconState<P>>>> {
+        let (mut state, state_block, blocks) =
+            match self.load_state_by_iteration(slot, finalized_validators)? {
+                OptionalStateStorage::None | OptionalStateStorage::UnfinalizedOnly(_) => {
+                    return Ok(None);
+                }
+                OptionalStateStorage::Full(state_storage) => state_storage,
+            };
 
         state.set_cached_root(state_block.message().state_root());
 
@@ -710,11 +762,12 @@ impl<P: Preset> Storage<P> {
     pub(crate) fn state_post_block(
         &self,
         mut block_root: H256,
+        finalized_validators: &Validators<P>,
     ) -> Result<Option<Arc<BeaconState<P>>>> {
         let mut blocks = vec![];
 
         let mut state = loop {
-            if let Some(state) = self.state_by_block_root(block_root)? {
+            if let Some(state) = self.state_by_block_root(block_root, Some(finalized_validators))? {
                 let slot = state.slot();
 
                 ensure!(
@@ -755,9 +808,10 @@ impl<P: Preset> Storage<P> {
     pub(crate) fn stored_state_by_state_root(
         &self,
         state_root: H256,
+        finalized_validators: &Validators<P>,
     ) -> Result<Option<Arc<BeaconState<P>>>> {
         if let Some(state_slot) = self.slot_by_state_root(state_root)? {
-            return self.stored_state(state_slot);
+            return self.stored_state(state_slot, Some(finalized_validators));
         }
 
         Ok(None)
@@ -778,8 +832,11 @@ impl<P: Preset> Storage<P> {
         .context(Error::DependentRootLookupFailed)
     }
 
-    fn load_state_and_blocks_from_checkpoint(&self) -> Result<Option<StateStorage<'_, P>>> {
-        if let Some(checkpoint) = self.load_state_checkpoint()? {
+    fn load_state_and_blocks_from_checkpoint(
+        &self,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<Option<StateStorage<'_, P>>> {
+        if let Some(checkpoint) = self.load_state_checkpoint(finalized_validators)? {
             let StateCheckpoint {
                 block_root, state, ..
             } = checkpoint;
@@ -830,6 +887,7 @@ impl<P: Preset> Storage<P> {
     fn load_state_by_iteration(
         &self,
         start_from_slot: Slot,
+        finalized_validators: Option<&Validators<P>>,
     ) -> Result<OptionalStateStorage<'_, P>> {
         let results = self
             .database
@@ -852,7 +910,7 @@ impl<P: Preset> Storage<P> {
                     continue;
                 };
 
-                if let Some(state) = self.state_by_block_root(block_root)? {
+                if let Some(state) = self.state_by_block_root(block_root, finalized_validators)? {
                     let slot = state.slot();
 
                     ensure!(
@@ -882,8 +940,19 @@ impl<P: Preset> Storage<P> {
         self.get(BlockCheckpoint::<P>::KEY)
     }
 
-    fn load_state_checkpoint(&self) -> Result<Option<StateCheckpoint<P>>> {
-        self.get(StateCheckpoint::<P>::KEY)
+    fn load_state_checkpoint(
+        &self,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<Option<StateCheckpoint<P>>> {
+        let Some(mut checkpoint) = self.get::<StateCheckpoint<P>>(StateCheckpoint::<P>::KEY)?
+        else {
+            return Ok(None);
+        };
+
+        // Restore validators if they were removed
+        self.restore_validators_to_state(checkpoint.state.make_mut(), finalized_validators)?;
+
+        Ok(Some(checkpoint))
     }
 
     fn contains_key(&self, key: impl core::fmt::Display) -> Result<bool> {
@@ -919,6 +988,63 @@ impl<P: Preset> Storage<P> {
 
     pub(crate) fn epoch_at_slot(slot: Slot) -> Epoch {
         misc::compute_epoch_at_slot::<P>(slot)
+    }
+
+    fn restore_validators_to_state(
+        &self,
+        state: &mut BeaconState<P>,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<()> {
+        let finalized_validators = finalized_validators.map(|v| Ok(Either::Left(v))).unwrap_or_else(|| {
+            info_with_peers!("loading validators from disk");
+
+            let Some(validators) = self.get::<PersistentList<PublicKeyBytes, P::ValidatorRegistryLimit>>(FinalizedValidators)? else {
+                bail!(
+                    "Unable to restore validators into state - no saved validators on disk found."
+                );
+            };
+
+            Ok(Either::Right(validators))
+        })?;
+
+        for (index, validator) in state.validators_mut().into_iter().enumerate() {
+            if validator.pubkey.is_zero() {
+                // restore validator pubkey, by taking pubkey from the finalized validators list
+                let finalized_validator_pubkey = finalized_validators
+                    .as_ref()
+                    .either(
+                        |v| v.get(index as u64).map(|v| v.pubkey),
+                        |v| v.get(index as u64).copied(),
+                    )
+                    .context("Invalid finalized validators list")?;
+                validator.pubkey = finalized_validator_pubkey;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn append_finalized_validator_pubkeys_to_batch(
+        &self,
+        batch: &mut Vec<(String, Vec<u8>)>,
+        validators: &Validators<P>,
+    ) -> Result<()> {
+        let current_validator_count = self.get::<u64>(FinalizedValidatorCount)?.unwrap_or(0);
+
+        if validators.len_u64() <= current_validator_count {
+            return Ok(());
+        }
+
+        let validator_pubkeys = PersistentList::<_, P::ValidatorRegistryLimit>::try_from_iter(
+            validators.into_iter().map(|v| v.pubkey),
+        )?;
+
+        batch.extend_from_slice(&[
+            serialize(FinalizedValidatorCount, validators.len_u64())?,
+            serialize(FinalizedValidators, validator_pubkeys)?,
+        ]);
+
+        Ok(())
     }
 }
 
@@ -1015,8 +1141,12 @@ impl<P: Preset> fork_choice_store::Storage<P> for Storage<P> {
         self.storage_mode
     }
 
-    fn stored_state_by_block_root(&self, block_root: H256) -> Result<Option<Arc<BeaconState<P>>>> {
-        self.state_by_block_root(block_root)
+    fn stored_state_by_block_root(
+        &self,
+        block_root: H256,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<Option<Arc<BeaconState<P>>>> {
+        self.state_by_block_root(block_root, finalized_validators)
     }
 }
 
@@ -1147,6 +1277,30 @@ impl PrefixableKey for SlotByStateRoot {
 }
 
 #[derive(Display)]
+#[display("{}", Self::PREFIX)]
+pub struct FinalizedValidators;
+
+impl FinalizedValidators {
+    const KEY: &'static str = "finalized_validators";
+}
+
+impl PrefixableKey for FinalizedValidators {
+    const PREFIX: &'static str = Self::KEY;
+}
+
+#[derive(Display)]
+#[display("{}", Self::PREFIX)]
+pub struct FinalizedValidatorCount;
+
+impl FinalizedValidatorCount {
+    const KEY: &'static str = "finalized_validator_count";
+}
+
+impl PrefixableKey for FinalizedValidatorCount {
+    const PREFIX: &'static str = Self::KEY;
+}
+
+#[derive(Display)]
 #[display("{}{_0:x}{_1}", Self::PREFIX)]
 pub struct BlobSidecarByBlobId(pub H256, pub BlobIndex);
 
@@ -1257,6 +1411,15 @@ pub fn print_beacon_database_info(database: &Database) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn prepare_state<P: Preset>(mut state: Arc<BeaconState<P>>) -> Arc<BeaconState<P>> {
+    for validator in &mut *state.make_mut().validators_mut() {
+        // pubkey never changes, so we can restore it later from finalized validator list
+        validator.pubkey = PublicKeyBytes::zero();
+    }
+
+    state
 }
 
 #[cfg(test)]

--- a/fork_choice_control/src/storage_back_sync.rs
+++ b/fork_choice_control/src/storage_back_sync.rs
@@ -10,6 +10,7 @@ use ssz::SszHash as _;
 use std_ext::ArcExt as _;
 use transition_functions::combined;
 use types::{
+    Validators,
     combined::{DataColumnSidecar, SignedBeaconBlock},
     deneb::containers::BlobSidecar,
     nonstandard::{FinalizedCheckpoint, WithOrigin},
@@ -41,6 +42,7 @@ impl<P: Preset> Storage<P> {
         end_slot: Slot,
         anchor_checkpoint_provider: &AnchorCheckpointProvider<P>,
         is_exiting: &Arc<AtomicBool>,
+        finalized_validators: &Validators<P>,
     ) -> Result<()> {
         let WithOrigin { value, origin } = anchor_checkpoint_provider.checkpoint();
 
@@ -54,7 +56,9 @@ impl<P: Preset> Storage<P> {
 
         // check whether archiving was interrupted
         if let Some(slot) = get_latest_archived_slot(&self.database)?
-            && self.stored_state(slot)?.is_some()
+            && self
+                .stored_state(slot, Some(finalized_validators))?
+                .is_some()
             && slot > start_slot
             && slot <= end_slot
         {
@@ -69,9 +73,10 @@ impl<P: Preset> Storage<P> {
 
             anchor_state
         } else {
-            self.stored_state(start_slot)?.ok_or(Error::StateNotFound {
-                state_slot: start_slot,
-            })?
+            self.stored_state(start_slot, Some(finalized_validators))?
+                .ok_or(Error::StateNotFound {
+                    state_slot: start_slot,
+                })?
         };
 
         let mut previous_block = None;
@@ -185,6 +190,7 @@ mod tests {
     use eth2_cache_utils::mainnet;
     use itertools::{EitherOrBoth, Itertools as _};
     use pubkey_cache::PubkeyCache;
+    use types::traits::BeaconState as _;
     use types::{nonstandard::StorageMode, phase0::consts::GENESIS_SLOT};
 
     use super::*;
@@ -244,11 +250,14 @@ mod tests {
             );
         }
 
+        let finalized_validators = genesis_state.validators().clone();
+
         storage.archive_back_sync_states(
             0,
             128,
             &AnchorCheckpointProvider::custom_from_genesis(genesis_state),
             &Arc::new(AtomicBool::new(false)),
+            &finalized_validators,
         )?;
 
         // Assert that the mappings from state root to slot are stored.
@@ -261,7 +270,7 @@ mod tests {
         for state_root in [state_1_root, state_22_root, state_96_root, state_128_root] {
             assert_eq!(
                 storage
-                    .stored_state_by_state_root(state_root)?
+                    .stored_state_by_state_root(state_root, &finalized_validators)?
                     .map(|state| state.hash_tree_root()),
                 Some(state_root),
             );

--- a/fork_choice_control/src/storage_tool.rs
+++ b/fork_choice_control/src/storage_tool.rs
@@ -30,7 +30,7 @@ pub fn export_state_and_blocks<P: Preset>(
     anchor_checkpoint_provider: &AnchorCheckpointProvider<P>,
 ) -> Result<()> {
     let export_state = |state_slot| -> Result<()> {
-        let state = match storage.stored_state(state_slot)? {
+        let state = match storage.stored_state(state_slot, None)? {
             Some(found_state) => found_state,
             None => {
                 let mut temporary_state =

--- a/fork_choice_store/src/misc.rs
+++ b/fork_choice_store/src/misc.rs
@@ -18,6 +18,7 @@ use strum::AsRefStr;
 use thiserror::Error;
 use transition_functions::unphased::StateRootPolicy;
 use types::{
+    Validators,
     combined::{
         Attestation, AttestingIndices, BeaconState, DataColumnSidecar, SignedAggregateAndProof,
         SignedBeaconBlock,
@@ -1076,7 +1077,12 @@ impl DataAvailabilityPolicy {
     }
 }
 
-pub trait Storage<P: Preset>: Sync {
+pub trait Storage<P: Preset>: Sync + Sized {
     fn storage_mode(&self) -> StorageMode;
-    fn stored_state_by_block_root(&self, block_root: H256) -> Result<Option<Arc<BeaconState<P>>>>;
+
+    fn stored_state_by_block_root(
+        &self,
+        block_root: H256,
+        finalized_validators: Option<&Validators<P>>,
+    ) -> Result<Option<Arc<BeaconState<P>>>>;
 }

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -43,6 +43,7 @@ use transition_functions::{
 };
 use typenum::Unsigned as _;
 use types::{
+    Validators,
     combined::{
         Attestation, AttesterSlashing, AttestingIndices, BeaconState, DataColumnSidecar,
         SignedAggregateAndProof, SignedBeaconBlock,
@@ -1032,6 +1033,11 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         self.last_finalized()
             .execution_block_hash()
             .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn finalized_validators(&self) -> Validators<P> {
+        self.last_finalized().state(self).validators().clone()
     }
 
     pub fn validate_block(
@@ -3430,7 +3436,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
     // `Vector` has no `resize` method as of `im` version 15.1.0.
     fn extend_latest_messages_after_finalization(&mut self) {
         let old_length = self.latest_messages.len();
-        let new_length = self.last_finalized().state(self).validators().len_usize();
+        let new_length = self.finalized_validators().len_usize();
         let added_vacancies = core::iter::repeat_n(None, new_length - old_length);
 
         self.latest_messages.extend(added_vacancies);
@@ -3973,7 +3979,23 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         &self,
         block_root: H256,
     ) -> Result<Option<Arc<BeaconState<P>>>> {
-        self.storage.stored_state_by_block_root(block_root)
+        // Do not call `self.finalized_validators()` here.
+        //
+        // `finalized_validators()` tries to load the finalized state when it is
+        // not already in memory. That load path eventually calls this function
+        // again, which would cause infinite recursion.
+        //
+        // Instead, use a best-effort approach: read finalized validators only
+        // when the finalized state is already present, and fall back to loading
+        // validators from disk otherwise.
+        let finalized_validators = self
+            .last_finalized()
+            .state
+            .as_ref()
+            .map(types::traits::BeaconState::validators);
+
+        self.storage
+            .stored_state_by_block_root(block_root, finalized_validators)
     }
 
     #[must_use]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -100,7 +100,7 @@ pub mod gloas {
     mod spec_tests;
 }
 
-pub use collections::ProposerLookahead;
+pub use collections::{ProposerLookahead, Validators};
 
 mod collections;
 


### PR DESCRIPTION
This change optimizes disk usage, by excluding validator pubkeys from state before persisting it to disk, and restoring them by taking pubkeys from finalized validator list. Pubkeys are removed by zeroizing them, so that snappy compresses them, effectively removing them from state.

This change reduces mainnet state size by ~72% - from ~151.6 to ~41.3 MB compressed size.