### PR TITLE
Fix system dependency installation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Install system dependencies (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
+          sudo DEBIAN_FRONTEND='noninteractive' apt-get update && \
+            sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
             --no-install-recommends -yq \
             ca-certificates \
             libssl-dev \
@@ -168,7 +169,8 @@ jobs:
       - name: Install system dependencies (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
+          sudo DEBIAN_FRONTEND='noninteractive' apt-get update && \
+            sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
             --no-install-recommends -yq \
             ca-certificates \
             libssl-dev \


### PR DESCRIPTION
Recently system dependency installation step started [failing]. This PR fixes this, by first updating apt lists, and only then installing needed dependencies.

[failing]: https://github.com/grandinetech/grandine/actions/runs/22483378864/job/65129133543