### PR TITLE
Deduplicate CI build runs for internal PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI Build
 
 on: [push, pull_request]
 
+# Cancel in-progress runs for the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+
 env:
   TEST_CASES: |
     consensus spec tests mainnet fulu empty block transition
@@ -9,6 +14,8 @@ env:
 
 jobs:
   build:
+    # Skip pull_request events for same-repo branches (push already covers them)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -95,6 +102,8 @@ jobs:
         run: scripts/ci/consensus-spec-tests-coverage.rb
 
   zkvm-test:
+    # Skip pull_request events for same-repo branches (push already covers them)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         backend: [risc0, sp1, pico, ziren, zisk]
@@ -182,7 +191,7 @@ jobs:
       - name: Setup nim for constantine backend
         uses: jiro4989/setup-nim-action@v2
         with:
-          nim-version: '2.0.2'
+          nim-version: "2.0.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           parent-nim-install-directory: ${{ runner.temp }}
       - name: Install dependencies for constantine backend


### PR DESCRIPTION
This PR is to de-duplicate CI Build runs on internal PR so the `pull_request` event is skipped while the `push` event already handled it

**DISCLOSE**: AI-assisted coding