### PR TITLE
Use nethermind reference assemblies from github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,26 +110,35 @@ aarch64-apple-darwin: ./target/aarch64-apple-darwin/compact/grandine ./target/aa
 
 # ------ GRANDINE-NETHERMIND INTEGRATION ------
 
-NETHERMIND_VERSION ?= 1.36.0
+NETHERMIND_VERSION ?= 1.36.1
 # If empty, public authentication will happen. Public auth rate limits by ip address, so may fail unexpectedly.
 GITHUB_TOKEN ?=
+
+ifneq ($(GITHUB_TOKEN),)
+NETHERMIND_DOWNLOAD_EXTRA_ARGS = --header "Authorization: Bearer $(GITHUB_TOKEN)"
+endif
 
 .PHONY: nethermind-plugin
 nethermind-plugin: ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/Grandine.NethermindPlugin.dll
 ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/Grandine.NethermindPlugin.dll:
+	@mkdir -p build
+	curl $(NETHERMIND_DOWNLOAD_EXTRA_ARGS) -s "https://api.github.com/repos/NethermindEth/nethermind/releases/tags/$(NETHERMIND_VERSION)" | \
+	jq -r '.assets[] | select(.name | endswith("ref-assemblies.zip")) | .browser_download_url' | \
+	xargs -r -n1 curl $(NETHERMIND_DOWNLOAD_EXTRA_ARGS) -L -o "build/nethermind-$(NETHERMIND_VERSION)-ref-assemblies.zip"
+	mkdir -p ./bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)
+	rm -f ./bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)/*.dll
+	unzip -o ./build/nethermind-$(NETHERMIND_VERSION)-ref-assemblies.zip -d ./bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)
 	cd ./bindings/csharp && \
-	dotnet add ./Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj package Nethermind.ReferenceAssemblies --version $(NETHERMIND_VERSION) && \
-	dotnet publish -c Release
+	dotnet publish -c Release \
+		/p:NethermindReferenceAssembliesVersion=$(NETHERMIND_VERSION) \
+		/p:NethermindReferenceAssembliesDir="$(CURDIR)/bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)"
 
 .PHONY: clean-nethermind-plugin
 clean-nethermind-plugin:
 	rm -rf bindings/csharp/Grandine.NethermindPlugin/bin
 	rm -rf bindings/csharp/Grandine.NethermindPlugin/obj
 	rm -rf bindings/csharp/generated
-
-ifneq ($(GITHUB_TOKEN),)
-NETHERMIND_DOWNLOAD_EXTRA_ARGS = --header "Authorization: Bearer $(GITHUB_TOKEN)"
-endif
+	rm -rf bindings/csharp/.nethermind-ref-assemblies
 
 .PHONY: download-nethermind
 download-nethermind:

--- a/bindings/csharp/.gitignore
+++ b/bindings/csharp/.gitignore
@@ -4,3 +4,4 @@ nupkgs
 **/runtimes
 src/generated.rs
 generated/*
+.nethermind-ref-assemblies/

--- a/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
+++ b/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
@@ -26,6 +26,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NethermindReferenceAssembliesVersion Condition="'$(NethermindReferenceAssembliesVersion)' == ''">1.36.1</NethermindReferenceAssembliesVersion>
+    <NethermindReferenceAssembliesDir Condition="'$(NethermindReferenceAssembliesDir)' == ''">$(MSBuildThisFileDirectory)..\.nethermind-ref-assemblies\$(NethermindReferenceAssembliesVersion)</NethermindReferenceAssembliesDir>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="runtimes\**" Pack="true">
       <PackagePath>runtimes\%(RecursiveDir)native\%(Filename)%(Extension)</PackagePath>
@@ -35,11 +40,20 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="9.0.0" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.4.0" />
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(NethermindReferenceAssembliesDir)')">
+    <Reference Include="$(NethermindReferenceAssembliesDir)\*.dll">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="!Exists('$(NethermindReferenceAssembliesDir)')">
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="$(NethermindReferenceAssembliesVersion)" />
   </ItemGroup>
 
   <Target Name="GenerateBindings" BeforeTargets="BeforeBuild;BeforeRebuild">


### PR DESCRIPTION
Recently, nethermind changed reference assemblies publish process from using nuget to publishing them solely into github releases ([#10049]). This commit changes release pipeline to reflect these changes.

[#10049]: https://github.com/NethermindEth/nethermind/pull/10049