### PR TITLE
Fixed nethermind reference assemblies installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
           path: artifacts
 
       - name: Download csharp bindings
-        if: needs.version.outputs.label == 'unstable'
+        if: needs.version.outputs.label == 'unstable' && needs.build_csharp_bindings.result == 'success'
         uses: actions/download-artifact@v5
         with:
           name: plugin
@@ -244,7 +244,7 @@ jobs:
           mv ./artifacts/lib-linux-arm64/libgrandine.so ./target/aarch64-unknown-linux-gnu/compact/libgrandine.so
       
       - name: Move C# artifacts
-        if: needs.version.outputs.label == 'unstable'
+        if: needs.version.outputs.label == 'unstable' && needs.build_csharp_bindings.result == 'success'
         run: |
           mkdir -p ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/
           mv ./artifacts/Grandine.NethermindPlugin.dll ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/
@@ -262,7 +262,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build & push docker images (with nethermind integration)
-        if: needs.version.outputs.label == 'unstable'
+        if: needs.version.outputs.label == 'unstable' && needs.build_csharp_bindings.result == 'success'
         env:
           DOCKER_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && env.GRANDINE_COMMIT || '' }}
         run: |
@@ -273,7 +273,7 @@ jobs:
             NETHERMIND_VERSION=${{ env.NETHERMIND_VERSION }}
 
       - name: Build & push docker images
-        if: needs.version.outputs.label == 'stable'
+        if: needs.version.outputs.label == 'stable' || needs.build_csharp_bindings.result != 'success'
         env: 
           DOCKER_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && env.GRANDINE_COMMIT || '' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ aarch64-apple-darwin: ./target/aarch64-apple-darwin/compact/grandine ./target/aa
 
 # ------ GRANDINE-NETHERMIND INTEGRATION ------
 
-NETHERMIND_VERSION ?= 1.36.1
+NETHERMIND_VERSION ?= 1.36.2
 # If empty, public authentication will happen. Public auth rate limits by ip address, so may fail unexpectedly.
 GITHUB_TOKEN ?=
 
@@ -121,14 +121,8 @@ endif
 .PHONY: nethermind-plugin
 nethermind-plugin: ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/Grandine.NethermindPlugin.dll
 ./bindings/csharp/Grandine.NethermindPlugin/bin/Release/net10.0/Grandine.NethermindPlugin.dll:
-	@mkdir -p build
-	curl $(NETHERMIND_DOWNLOAD_EXTRA_ARGS) -s "https://api.github.com/repos/NethermindEth/nethermind/releases/tags/$(NETHERMIND_VERSION)" | \
-	jq -r '.assets[] | select(.name | endswith("ref-assemblies.zip")) | .browser_download_url' | \
-	xargs -r -n1 curl $(NETHERMIND_DOWNLOAD_EXTRA_ARGS) -L -o "build/nethermind-$(NETHERMIND_VERSION)-ref-assemblies.zip"
-	mkdir -p ./bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)
-	rm -f ./bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)/*.dll
-	unzip -o ./build/nethermind-$(NETHERMIND_VERSION)-ref-assemblies.zip -d ./bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)
 	cd ./bindings/csharp && \
+	dotnet add ./Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj package Nethermind.ReferenceAssemblies --version $(NETHERMIND_VERSION) && \
 	dotnet publish -c Release \
 		/p:NethermindReferenceAssembliesVersion=$(NETHERMIND_VERSION) \
 		/p:NethermindReferenceAssembliesDir="$(CURDIR)/bindings/csharp/.nethermind-ref-assemblies/$(NETHERMIND_VERSION)"
@@ -138,7 +132,6 @@ clean-nethermind-plugin:
 	rm -rf bindings/csharp/Grandine.NethermindPlugin/bin
 	rm -rf bindings/csharp/Grandine.NethermindPlugin/obj
 	rm -rf bindings/csharp/generated
-	rm -rf bindings/csharp/.nethermind-ref-assemblies
 
 .PHONY: download-nethermind
 download-nethermind:

--- a/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
+++ b/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
@@ -26,11 +26,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NethermindReferenceAssembliesVersion Condition="'$(NethermindReferenceAssembliesVersion)' == ''">1.36.1</NethermindReferenceAssembliesVersion>
-    <NethermindReferenceAssembliesDir Condition="'$(NethermindReferenceAssembliesDir)' == ''">$(MSBuildThisFileDirectory)..\.nethermind-ref-assemblies\$(NethermindReferenceAssembliesVersion)</NethermindReferenceAssembliesDir>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="runtimes\**" Pack="true">
       <PackagePath>runtimes\%(RecursiveDir)native\%(Filename)%(Extension)</PackagePath>
@@ -40,20 +35,11 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="9.0.0" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.4.0" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="Exists('$(NethermindReferenceAssembliesDir)')">
-    <Reference Include="$(NethermindReferenceAssembliesDir)\*.dll">
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup Condition="!Exists('$(NethermindReferenceAssembliesDir)')">
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="$(NethermindReferenceAssembliesVersion)" />
   </ItemGroup>
 
   <Target Name="GenerateBindings" BeforeTargets="BeforeBuild;BeforeRebuild">


### PR DESCRIPTION
In latest release, nethermind bringed back the reference assemblies publish process to nuget. Reference assemblies were removed from github release.

This pull request reverts changed made in [#635], and adds fallback to release pipeline, so that when C# plugin build fails, the grandine docker images are still built.

[#635]: https://github.com/grandinetech/grandine/pull/635