### PR TITLE
fix: use deposit_requests_start_index in Gloas process_operations

### DIFF
--- a/transition_functions/src/gloas/block_processing.rs
+++ b/transition_functions/src/gloas/block_processing.rs
@@ -689,6 +689,7 @@ pub fn process_execution_payload_bid<P: Preset>(
     Ok(())
 }
 
+#[expect(clippy::too_many_lines)]
 pub fn process_operations<P: Preset, V: Verifier, B>(
     config: &Config,
     pubkey_cache: &PubkeyCache,
@@ -702,17 +703,32 @@ where
         + BlockBodyWithBlsToExecutionChanges<P>
         + BlockBodyWithPayloadAttestations<P>,
 {
-    // > Verify that outstanding deposits are processed up to the maximum number of deposits
-    let in_block = body.deposits().len().try_into()?;
-    let computed = state
+    // > [Modified in Electra:EIP6110]
+    // > Disable former deposit mechanism once all prior deposits are processed
+    let eth1_deposit_index_limit = state
         .eth1_data()
         .deposit_count
-        .saturating_sub(state.eth1_deposit_index())
-        .min(P::MaxDeposits::U64);
-    ensure!(
-        in_block == computed,
-        Error::<P>::DepositCountMismatch { computed, in_block }
-    );
+        .min(state.deposit_requests_start_index());
+
+    let in_block = body.deposits().len().try_into()?;
+
+    if state.eth1_deposit_index() < eth1_deposit_index_limit {
+        let computed =
+            P::MaxDeposits::U64.min(eth1_deposit_index_limit - state.eth1_deposit_index());
+
+        ensure!(
+            computed == in_block,
+            Error::<P>::DepositCountMismatch { computed, in_block },
+        );
+    } else {
+        ensure!(
+            in_block == 0,
+            Error::<P>::DepositCountMismatch {
+                computed: 0,
+                in_block
+            },
+        );
+    }
 
     for proposer_slashing in body.proposer_slashings().iter().copied() {
         process_proposer_slashing(


### PR DESCRIPTION
The Gloas deposit count validation at `gloas/block_processing.rs:705-715`
  uses the pre-Electra formula (`deposit_count - eth1_deposit_index`) which
  ignores `deposit_requests_start_index`.

  The Electra implementation (`electra/block_processing.rs:499-524`) correctly
  uses `deposit_requests_start_index` to disable the former deposit mechanism
  once all prior deposits are processed, per the consensus spec
  (gloas/beacon-chain.md line 1157-1158). The Gloas version should use the
  same formula.

  Without this fix, Grandine would compute a wrong expected deposit count
  for Gloas blocks, causing a consensus split.

  AI Assistance Disclosure: This bug was identified with the assistance
  of Claude Code during a cross-client security audit. The fix was
  reviewed and tested manually .