### PR TITLE
Remove custom repeat_layout in favor of stable Layout::repeat

### DIFF
--- a/bindings/c/src/generic.rs
+++ b/bindings/c/src/generic.rs
@@ -12,8 +12,6 @@ use anyhow::Result;
 use generic_array::ArrayLength;
 use ssz::ByteList;
 
-use crate::layout::repeat_layout;
-
 pub const GRANDINE_SUCCESS: u32 = 0;
 pub const GRANDINE_ERROR_GENERIC: u32 = 1;
 pub const GRANDINE_ERROR_ENGINE_API: u32 = 2;
@@ -227,8 +225,10 @@ impl<T> Drop for CVec<T> {
             return;
         }
 
-        let layout = repeat_layout(Layout::new::<T>(), self.data_len as usize)
-            .expect("layout must be checked before, while allocating vec.");
+        let layout = Layout::new::<T>()
+                .repeat(self.data_len as usize)
+                .map(|(layout, _)| layout)
+                .expect("layout must be checked before, while allocating vec.");
 
         unsafe { alloc::dealloc(self.data as *mut u8, layout) };
     }
@@ -243,7 +243,9 @@ impl<T: Clone> Clone for CVec<T> {
             }
         } else {
             let data = unsafe { &*ptr::slice_from_raw_parts(self.data, self.data_len as usize) };
-            let layout = repeat_layout(Layout::new::<T>(), self.data_len as usize)
+            let layout = Layout::new::<T>()
+                .repeat(self.data_len as usize)
+                .map(|(layout, _)| layout)
                 .expect("layout must be checked before, while allocating vec.");
             let dest = unsafe { alloc::alloc(layout) };
             let dest = unsafe {

--- a/bindings/c/src/layout.rs
+++ b/bindings/c/src/layout.rs
@@ -1,6 +1,4 @@
-use std::alloc::{Layout, LayoutError};
-
-use anyhow::Result;
+use std::alloc::Layout;
 
 use crate::{
     arrays::{CH256, CH384},
@@ -24,7 +22,7 @@ impl CLayout {
 }
 
 impl TryInto<Layout> for CLayout {
-    type Error = LayoutError;
+    type Error = std::alloc::LayoutError;
 
     fn try_into(self) -> Result<Layout, Self::Error> {
         Layout::from_size_align(self.size, self.align)
@@ -83,17 +81,4 @@ pub extern "C" fn grandine_layout_string() -> CLayout {
 #[unsafe(no_mangle)]
 pub extern "C" fn grandine_layout_client_version() -> CLayout {
     CLayout::new(Layout::new::<CClientVersionV1>())
-}
-
-// this is just straight copy-paste from rust std library
-// TODO: once Layout.repeat(n) stabilizes, remove this function.
-pub fn repeat_layout(item_layout: Layout, n: usize) -> Result<Layout> {
-    let padded = item_layout.pad_to_align();
-
-    if let Some(size) = padded.size().checked_mul(n) {
-        // The safe constructor is called here to enforce the isize size limit.
-        Ok(Layout::from_size_align(size, padded.align())?)
-    } else {
-        anyhow::bail!("Invalid layout");
-    }
 }

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -31,7 +31,7 @@ use crate::{
         CPayloadAttributesV3, CPayloadStatusV1,
     },
     generic::{CGrandineString, COption, CResult, CVec, GRANDINE_ERROR_GENERIC},
-    layout::{CLayout, repeat_layout},
+    layout::CLayout,
 };
 
 mod arrays;
@@ -370,7 +370,7 @@ pub extern "C" fn grandine_vec_alloc(item_layout: CLayout, size: usize) -> *mut 
         return core::ptr::null_mut();
     };
 
-    let Ok(layout) = repeat_layout(item_layout, size) else {
+    let Ok(layout) = item_layout.repeat(size).map(|(layout, _)| layout) else {
         return core::ptr::null_mut();
     };
 


### PR DESCRIPTION


`Layout::repeat` has been stable since Rust 1.44, making the hand-rolled `repeat_layout` helper in `bindings/c/src/layout.rs` unnecessary. 


This removes the function and replaces all three call sites in `lib.rs` and `generic.rs` with `layout.repeat(n).map(|(layout, _)| layout)`.

