### PR TITLE
Fix `payload_attributes` SSE event values

### DIFF
--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -568,8 +568,8 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
                 self.event_channels.send_payload_attributes_event(
                     slot_head.beacon_state.phase(),
-                    proposer_index,
                     slot,
+                    proposer_index,
                     slot_head.beacon_block_root,
                     &payload_attributes,
                     payload.block_number(),


### PR DESCRIPTION
Fixes the `payload_attributes` SSE event fields by passing `slot` and `proposer_index` to `send_payload_attributes_event` in the correct order.

Previously, these two `u64`-backed values were swapped, causing emitted events to report the proposer index as `proposal_slot` and the slot as `proposer_index`.