### PR TITLE
Add `#![no_main]` to suppress duplicate entry point error

### DIFF
--- a/zkvm/guest/risc0/guest/src/main.rs
+++ b/zkvm/guest/risc0/guest/src/main.rs
@@ -1,3 +1,10 @@
+// These two lines are necessary for the program to properly compile.
+//
+// Under the hood, we wrap your main function with some extra code so that it behaves properly
+// inside the zkVM.
+#![no_main]
+risc0_zkvm::guest::entry!(main);
+
 use anyhow::Result;
 use pubkey_cache::PubkeyCache;
 use risc0_zkvm::guest::env;
@@ -9,8 +16,6 @@ use types::{
     nonstandard::Phase,
     preset::{Mainnet, Preset},
 };
-
-risc0_zkvm::guest::entry!(main);
 
 fn read_block_and_state<P: Preset>()
 -> Result<(Config, SignedBeaconBlock<P>, BeaconState<P>, PubkeyCache)> {


### PR DESCRIPTION
`risc0_zkvm::guest::entry!(main)` defines its own entry point, so a recent risc0 version update stopped auto-suppressing the standard one, causing a duplicate main function error at compile time