### PR TITLE
Update nethermind build to 1.37.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,16 @@ jobs:
           # zkVM test - ZiskOS implementation
           - backend: zisk
             install: |
+              export ZISK_VERSION=0.13.0
+              export ZISK_DIR="$HOME/.config/.zisk"
               sudo DEBIAN_FRONTEND='noninteractive' apt-get update
               sudo DEBIAN_FRONTEND='noninteractive' apt-get install -y xz-utils jq curl build-essential qemu-system libomp-dev libgmp-dev nlohmann-json3-dev protobuf-compiler uuid-dev libgrpc++-dev libsecp256k1-dev libsodium-dev libpqxx-dev nasm libopenmpi-dev openmpi-bin openmpi-common libclang-dev clang gcc-riscv64-unknown-elf
-              curl https://raw.githubusercontent.com/0xPolygonHermez/zisk/main/ziskup/install.sh | GH_RUNNER=true ZISK_VERSION=0.13.0 bash
-              echo "/home/runner/.config/.zisk/bin" >> $GITHUB_PATH
-              export PATH="/home/runner/.config/.zisk/bin:$PATH"
+              mkdir -p "$ZISK_DIR/bin"
+              curl -fsSL "https://raw.githubusercontent.com/0xPolygonHermez/zisk/v$ZISK_VERSION/ziskup/ziskup" -o "$ZISK_DIR/bin/ziskup"
+              chmod +x "$ZISK_DIR/bin/ziskup"
+              GH_RUNNER=true "$ZISK_DIR/bin/ziskup" --version "$ZISK_VERSION"
+              echo "$ZISK_DIR/bin" >> "$GITHUB_PATH"
+              export PATH="$ZISK_DIR/bin:$PATH"
               cargo-zisk -V
             execute: RUST_LOG=info cargo run -p zkvm_host --features zisk --release -- --test "$TEST" execute
 

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ aarch64-apple-darwin: ./target/aarch64-apple-darwin/compact/grandine ./target/aa
 
 # ------ GRANDINE-NETHERMIND INTEGRATION ------
 
-NETHERMIND_VERSION ?= 1.36.2
+NETHERMIND_VERSION ?= 1.37.1
 # If empty, public authentication will happen. Public auth rate limits by ip address, so may fail unexpectedly.
 GITHUB_TOKEN ?=
 

--- a/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
+++ b/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
@@ -33,9 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.0.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.4.0" />
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/bindings/csharp/build.rs
+++ b/bindings/csharp/build.rs
@@ -161,7 +161,7 @@ fn generate_csharp_config_interface(mut buffer: impl Write) -> Result<(), io::Er
         writeln!(buffer, "")?;
         writeln!(
             buffer,
-            r#"    [ConfigItem(Description = {description:?}{default})]"#,
+            r#"    [ConfigItem(CliOptionAlias = {arg_name:?}, Description = {description:?}{default})]"#,
             default = default_value
                 .map(|v| format!(", DefaultValue = {v:?}"))
                 .unwrap_or("".to_owned())


### PR DESCRIPTION
This PR:
* fixes nethermind 1.37.1 build, that uses newer Autofac version;
* fixes zisk installation in CI;
* sets proper argument names in our nethermind plugin.