### PR TITLE
Use `should_build_on_full` instead of `should_extend_payload` in `prepare_execution_payload`

### DIFF
--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -1814,7 +1814,7 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                 let parent_root = state.latest_block_header().hash_tree_root();
                 let snapshot = self.producer_context.controller.snapshot();
 
-                let withdrawals = if snapshot.should_extend_payload(parent_root)
+                let withdrawals = if snapshot.should_build_on_full(parent_root)
                     && let Some(envelope) =
                         snapshot.cached_execution_payload_envelope_by_root(parent_root)
                 {
@@ -1828,8 +1828,20 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                     )?;
 
                     gloas::get_expected_withdrawals(&state_copy)?.0
-                } else {
+                } else if state.latest_execution_payload_bid().block_hash
+                    == state.latest_block_hash()
+                {
+                    // Fork-boundary case: the parent is a pre-Gloas block, so there is no
+                    // Gloas envelope to apply, but `upgrade_to_gloas` initialized the state
+                    // with `latest_execution_payload_bid.block_hash == latest_block_hash`,
+                    // so the block's `process_withdrawals` will run normally. Mirror it.
                     gloas::get_expected_withdrawals(state)?.0
+                } else {
+                    state
+                        .payload_expected_withdrawals()
+                        .into_iter()
+                        .copied()
+                        .collect()
                 };
 
                 let withdrawals = withdrawals

--- a/fork_choice_control/src/queries.rs
+++ b/fork_choice_control/src/queries.rs
@@ -1201,6 +1201,11 @@ impl<P: Preset> Snapshot<'_, P> {
     }
 
     #[must_use]
+    pub fn should_build_on_full(&self, head_root: H256) -> bool {
+        self.store_snapshot.should_build_on_full(head_root)
+    }
+
+    #[must_use]
     pub fn cached_execution_payload_envelope_by_root(
         &self,
         block_root: H256,

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -875,6 +875,17 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         }
     }
 
+    #[must_use]
+    pub fn should_build_on_full(&self, block_root: H256) -> bool {
+        let (head, payload_status) = self.head_with_payload_status();
+
+        if head.block_root == block_root {
+            return payload_status != PAYLOAD_STATUS_EMPTY;
+        }
+
+        self.is_payload_verified(block_root)
+    }
+
     pub fn should_extend_payload(&self, block_root: H256) -> bool {
         if !self.is_payload_verified(block_root) {
             return false;


### PR DESCRIPTION
This PR also handle Gloas fork boundary case where parent block is pre-Gloas fork