### PR TITLE
Log EL SYNCING status at debug instead of warn

### DIFF
--- a/eth1_api/src/execution_service.rs
+++ b/eth1_api/src/execution_service.rs
@@ -12,7 +12,7 @@ use futures::{
     StreamExt as _,
     channel::mpsc::{UnboundedReceiver, UnboundedSender},
 };
-use logging::warn_with_peers;
+use logging::{debug_with_peers, warn_with_peers};
 use std_ext::ArcExt as _;
 use types::{
     combined::{ExecutionPayload, ExecutionPayloadParams},
@@ -177,7 +177,7 @@ impl<P: Preset, W: Wait> ExecutionService<P, W> {
                 }
 
                 if response.payload_status.status.is_syncing() {
-                    warn_with_peers!(
+                    debug_with_peers!(
                         "engine_forkchoiceUpdated returned SYNCING status \
                          (head_eth1_block_hash: {head_eth1_block_hash:?}, \
                           safe_eth1_block_hash: {safe_eth1_block_hash:?}, \
@@ -216,7 +216,7 @@ impl<P: Preset, W: Wait> ExecutionService<P, W> {
         }
 
         if response.status.is_syncing() {
-            warn_with_peers!(
+            debug_with_peers!(
                 "engine_newPayload returned SYNCING status \
                  (beacon_block_root: {beacon_block_root:?}, \
                   block_number: {block_number}, \


### PR DESCRIPTION
While the execution layer is syncing, `engine_forkchoiceUpdated` and `engine_newPayload` return SYNCING, which is a normal and expected status. Grandine continues optimistically and control flow is unchanged, so logging it at `warn` is just noise during EL sync (the subject of #217).

This downgrades both SYNCING branches in `execution_service.rs` from `warn_with_peers!` to `debug_with_peers!`. The INVALID and call-failure branches stay at `warn`. The detail is still available via `GRANDINE_LOG=eth1_api=debug` (the default filter is `eth1_api=info`).

Re #217.

**Scope note:** #217 also mentions a `request_with_fallback` warning in `eth1_api/http_api.rs` that fires on a JSON-RPC `-32001` "Receipt not available" error during EL sync. I left that path unchanged on purpose: it is a generic RPC-error handler that also marks the endpoint offline and increments error metrics, and there is no EL-sync-state signal at that layer — downgrading it via error-code/string matching would hide genuine endpoint failures. A proper fix would plumb EL-sync state into that layer; happy to follow up separately, so I've left #217 open.

(Saw @DarkLord017 expressed interest earlier, but the issue was unassigned with no follow-up — happy to coordinate, and the deferred `request_with_fallback` case is up for grabs.)
