### PR TITLE
Fix nethermind integration memory leak

### DIFF
--- a/bindings/c/src/generic.rs
+++ b/bindings/c/src/generic.rs
@@ -225,6 +225,13 @@ impl<T> Drop for CVec<T> {
             return;
         }
 
+        unsafe {
+            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(
+                self.data,
+                self.data_len as usize,
+            ));
+        }
+
         let layout = Layout::new::<T>()
             .repeat_packed(self.data_len as usize)
             .expect("layout must be checked before, while allocating vec.");

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -42,19 +42,19 @@ mod layout;
 #[repr(C)]
 pub struct CEmbedAdapter {
     engine_new_payload_v1:
-        unsafe extern "C" fn(payload: CExecutionPayloadV1) -> CResult<CPayloadStatusV1>,
+        unsafe extern "C" fn(payload: *const CExecutionPayloadV1) -> CResult<CPayloadStatusV1>,
     engine_new_payload_v2:
-        unsafe extern "C" fn(payload: CExecutionPayloadV2) -> CResult<CPayloadStatusV1>,
+        unsafe extern "C" fn(payload: *const CExecutionPayloadV2) -> CResult<CPayloadStatusV1>,
     engine_new_payload_v3: unsafe extern "C" fn(
-        payload: CExecutionPayloadV3,
-        versioned_hashes: CVec<CH256>,
+        payload: *const CExecutionPayloadV3,
+        versioned_hashes: *const CVec<CH256>,
         parent_beacon_block_root: CH256,
     ) -> CResult<CPayloadStatusV1>,
     engine_new_payload_v4: unsafe extern "C" fn(
-        payload: CExecutionPayloadV3,
-        versioned_hashes: CVec<CH256>,
+        payload: *const CExecutionPayloadV3,
+        versioned_hashes: *const CVec<CH256>,
         parent_beacon_block_root: CH256,
-        execution_requests: CExecutionRequests,
+        execution_requests: *const CExecutionRequests,
     ) -> CResult<CPayloadStatusV1>,
     engine_forkchoice_updated_v1: unsafe extern "C" fn(
         state: CForkChoiceStateV1,
@@ -62,11 +62,11 @@ pub struct CEmbedAdapter {
     ) -> CResult<CForkChoiceUpdatedResponse>,
     engine_forkchoice_updated_v2: unsafe extern "C" fn(
         state: CForkChoiceStateV1,
-        payload: COption<CPayloadAttributesV2>,
+        payload: *const COption<CPayloadAttributesV2>,
     ) -> CResult<CForkChoiceUpdatedResponse>,
     engine_forkchoice_updated_v3: unsafe extern "C" fn(
         state: CForkChoiceStateV1,
-        payload: COption<CPayloadAttributesV3>,
+        payload: *const COption<CPayloadAttributesV3>,
     ) -> CResult<CForkChoiceUpdatedResponse>,
     engine_get_payload_v1: unsafe extern "C" fn(payload_id: CH64) -> CResult<CExecutionPayloadV1>,
     engine_get_payload_v2:
@@ -78,15 +78,16 @@ pub struct CEmbedAdapter {
     engine_get_payload_v5:
         unsafe extern "C" fn(payload_id: CH64) -> CResult<CEngineGetPayloadV5Response>,
     engine_get_blobs_v1: unsafe extern "C" fn(
-        versioned_hashes: CVec<CH256>,
+        versioned_hashes: *const CVec<CH256>,
     ) -> CResult<CVec<COption<CBlobAndProofV1>>>,
     engine_get_blobs_v2: unsafe extern "C" fn(
-        versioned_hashes: CVec<CH256>,
+        versioned_hashes: *const CVec<CH256>,
     ) -> CResult<COption<CVec<CBlobAndProofV2>>>,
-    engine_exchange_capabilities:
-        unsafe extern "C" fn(capabilities: CVec<CGrandineString>) -> CResult<CVec<CGrandineString>>,
+    engine_exchange_capabilities: unsafe extern "C" fn(
+        capabilities: *const CVec<CGrandineString>,
+    ) -> CResult<CVec<CGrandineString>>,
     engine_get_client_version_v1:
-        unsafe extern "C" fn(version: CClientVersionV1) -> CResult<CVec<CClientVersionV1>>,
+        unsafe extern "C" fn(version: *const CClientVersionV1) -> CResult<CVec<CClientVersionV1>>,
 }
 
 impl eth1_api::EmbedAdapter for CEmbedAdapter {
@@ -112,7 +113,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
     ) -> Result<PayloadStatusV1> {
         let payload = payload.into();
 
-        let result = unsafe { (self.engine_new_payload_v1)(payload) };
+        let result = unsafe { (self.engine_new_payload_v1)(&payload) };
 
         Result::<_>::from(result).map(Into::into)
     }
@@ -123,7 +124,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
     ) -> Result<PayloadStatusV1> {
         let payload = payload.into();
 
-        let result = unsafe { (self.engine_new_payload_v2)(payload) };
+        let result = unsafe { (self.engine_new_payload_v2)(&payload) };
 
         Result::<_>::from(result).map(Into::into)
     }
@@ -142,7 +143,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
         let parent_beacon_block_root = parent_beacon_block_root.into();
 
         let result = unsafe {
-            (self.engine_new_payload_v3)(payload, versioned_hashes, parent_beacon_block_root)
+            (self.engine_new_payload_v3)(&payload, &versioned_hashes, parent_beacon_block_root)
         };
 
         Result::<_>::from(result).map(Into::into)
@@ -165,10 +166,10 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
 
         let result = unsafe {
             (self.engine_new_payload_v4)(
-                payload,
-                versioned_hashes,
+                &payload,
+                &versioned_hashes,
                 parent_beacon_block_root,
-                execution_requests,
+                &execution_requests,
             )
         };
 
@@ -196,7 +197,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
         let state: CForkChoiceStateV1 = state.into();
         let payload: Option<CPayloadAttributesV2> = payload.map(Into::into);
         let payload = payload.into();
-        let result = unsafe { (self.engine_forkchoice_updated_v2)(state, payload) };
+        let result = unsafe { (self.engine_forkchoice_updated_v2)(state, &payload) };
 
         Result::from(result).map(Into::into)
     }
@@ -209,7 +210,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
         let state: CForkChoiceStateV1 = state.into();
         let payload: Option<CPayloadAttributesV3> = payload.map(Into::into);
         let payload = payload.into();
-        let result = unsafe { (self.engine_forkchoice_updated_v3)(state, payload) };
+        let result = unsafe { (self.engine_forkchoice_updated_v3)(state, &payload) };
 
         Result::<_>::from(result).map(Into::into)
     }
@@ -263,7 +264,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
             .map(|hash| hash.into())
             .collect::<CVec<_>>();
 
-        let result = unsafe { (self.engine_get_blobs_v1)(versioned_hashes) };
+        let result = unsafe { (self.engine_get_blobs_v1)(&versioned_hashes) };
 
         let result: Result<_> = result.into();
 
@@ -290,7 +291,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
             .map(|hash| hash.into())
             .collect::<CVec<_>>();
 
-        let result = unsafe { (self.engine_get_blobs_v2)(versioned_hashes) };
+        let result = unsafe { (self.engine_get_blobs_v2)(&versioned_hashes) };
 
         let result: Result<_> = result.into();
 
@@ -317,7 +318,7 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
             .collect::<Result<_, _>>()
             .context("invalid capabilities")?;
 
-        let result = unsafe { (self.engine_exchange_capabilities)(capabilities) };
+        let result = unsafe { (self.engine_exchange_capabilities)(&capabilities) };
         let result: Result<_> = result.into();
 
         result.and_then(|v| {
@@ -341,7 +342,8 @@ impl eth1_api::EmbedAdapter for CEmbedAdapter {
         &self,
         own_version: ClientVersionV1,
     ) -> Result<Vec<ClientVersionV1>> {
-        let result = unsafe { (self.engine_get_client_version_v1)(own_version.try_into()?) };
+        let own_version = own_version.try_into()?;
+        let result = unsafe { (self.engine_get_client_version_v1)(&own_version) };
 
         let result: Result<_> = result.into();
 

--- a/bindings/csharp/.editorconfig
+++ b/bindings/csharp/.editorconfig
@@ -384,6 +384,7 @@ dotnet_diagnostic.CS1591.severity = silent
 dotnet_diagnostic.SA1009.severity = silent
 dotnet_diagnostic.SA1010.severity = silent
 dotnet_diagnostic.SA1011.severity = silent
+dotnet_diagnostic.SA1023.severity = silent
 dotnet_diagnostic.SA1600.severity = silent
 dotnet_diagnostic.SA1601.severity = silent
 dotnet_diagnostic.SA1633.severity = silent

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineClient.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineClient.cs
@@ -7,25 +7,25 @@ using System.Threading.Tasks;
 using Grandine.Native;
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CPayloadStatusV1 EngineNewPayloadV1Delegate(CExecutionPayloadV1 payload);
+internal unsafe delegate CResult_CPayloadStatusV1 EngineNewPayloadV1Delegate(CExecutionPayloadV1* payload);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CPayloadStatusV1 EngineNewPayloadV2Delegate(CExecutionPayloadV2 payload);
+internal unsafe delegate CResult_CPayloadStatusV1 EngineNewPayloadV2Delegate(CExecutionPayloadV2* payload);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CPayloadStatusV1 EngineNewPayloadV3Delegate(CExecutionPayloadV3 payload, CVec_CH256 versionedHashes, CH256 parentBeaconBlockRoot);
+internal unsafe delegate CResult_CPayloadStatusV1 EngineNewPayloadV3Delegate(CExecutionPayloadV3* payload, CVec_CH256* versionedHashes, CH256 parentBeaconBlockRoot);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CPayloadStatusV1 EngineNewPayloadV4Delegate(CExecutionPayloadV3 payload, CVec_CH256 versionedHashes, CH256 parentBeaconBlockRoot, CExecutionRequests executionRequests);
+internal unsafe delegate CResult_CPayloadStatusV1 EngineNewPayloadV4Delegate(CExecutionPayloadV3* payload, CVec_CH256* versionedHashes, CH256 parentBeaconBlockRoot, CExecutionRequests* executionRequests);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV1Delegate(CForkChoiceStateV1 state, COption_CPayloadAttributesV1 attributes);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV2Delegate(CForkChoiceStateV1 state, COption_CPayloadAttributesV2 attributes);
+internal unsafe delegate CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV2Delegate(CForkChoiceStateV1 state, COption_CPayloadAttributesV2* attributes);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV3Delegate(CForkChoiceStateV1 state, COption_CPayloadAttributesV3 attributes);
+internal unsafe delegate CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV3Delegate(CForkChoiceStateV1 state, COption_CPayloadAttributesV3* attributes);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate CResult_CExecutionPayloadV1 EngineGetPayloadV1Delegate(CH64 payloadId);
@@ -43,16 +43,16 @@ internal delegate CResult_CEngineGetPayloadV4Response EngineGetPayloadV4Delegate
 internal delegate CResult_CEngineGetPayloadV5Response EngineGetPayloadV5Delegate(CH64 payloadId);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1Delegate(CVec_CH256 versionedHashes);
+internal unsafe delegate CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1Delegate(CVec_CH256* versionedHashes);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2Delegate(CVec_CH256 versionedHashes);
+internal unsafe delegate CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2Delegate(CVec_CH256* versionedHashes);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CVec_CGrandineString EngineExchangeCapabilitiesDelegate(CVec_CGrandineString clCapabilities);
+internal unsafe delegate CResult_CVec_CGrandineString EngineExchangeCapabilitiesDelegate(CVec_CGrandineString* clCapabilities);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate CResult_CVec_CClientVersionV1 EngineGetClientVersionV1Delegate(CClientVersionV1 clVersion);
+internal unsafe delegate CResult_CVec_CClientVersionV1 EngineGetClientVersionV1Delegate(CClientVersionV1* clVersion);
 
 public class GrandineClient : IAsyncDisposable
 {
@@ -124,22 +124,22 @@ public class GrandineClient : IAsyncDisposable
             IntPtr engine_getClientVersionV1 = Marshal.GetFunctionPointerForDelegate(this.engineGetClientVersionV1);
             res = NativeMethods.grandine_set_execution_layer_adapter(new CEmbedAdapter
             {
-                engine_new_payload_v1 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV1, CResult_CPayloadStatusV1>)engine_newPayloadV1Ptr,
-                engine_new_payload_v2 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV2, CResult_CPayloadStatusV1>)engine_newPayloadV2Ptr,
-                engine_new_payload_v3 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV3, CVec_CH256, CH256, CResult_CPayloadStatusV1>)engine_newPayloadV3Ptr,
-                engine_new_payload_v4 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV3, CVec_CH256, CH256, CExecutionRequests, CResult_CPayloadStatusV1>)engine_newPayloadV4Ptr,
+                engine_new_payload_v1 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV1*, CResult_CPayloadStatusV1>)engine_newPayloadV1Ptr,
+                engine_new_payload_v2 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV2*, CResult_CPayloadStatusV1>)engine_newPayloadV2Ptr,
+                engine_new_payload_v3 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV3*, CVec_CH256*, CH256, CResult_CPayloadStatusV1>)engine_newPayloadV3Ptr,
+                engine_new_payload_v4 = (delegate* unmanaged[Cdecl]<CExecutionPayloadV3*, CVec_CH256*, CH256, CExecutionRequests*, CResult_CPayloadStatusV1>)engine_newPayloadV4Ptr,
                 engine_forkchoice_updated_v1 = (delegate* unmanaged[Cdecl]<CForkChoiceStateV1, COption_CPayloadAttributesV1, CResult_CForkChoiceUpdatedResponse>)engine_forkchoiceUpdatedV1Ptr,
-                engine_forkchoice_updated_v2 = (delegate* unmanaged[Cdecl]<CForkChoiceStateV1, COption_CPayloadAttributesV2, CResult_CForkChoiceUpdatedResponse>)engine_forkchoiceUpdatedV2Ptr,
-                engine_forkchoice_updated_v3 = (delegate* unmanaged[Cdecl]<CForkChoiceStateV1, COption_CPayloadAttributesV3, CResult_CForkChoiceUpdatedResponse>)engine_forkchoiceUpdatedV3Ptr,
+                engine_forkchoice_updated_v2 = (delegate* unmanaged[Cdecl]<CForkChoiceStateV1, COption_CPayloadAttributesV2*, CResult_CForkChoiceUpdatedResponse>)engine_forkchoiceUpdatedV2Ptr,
+                engine_forkchoice_updated_v3 = (delegate* unmanaged[Cdecl]<CForkChoiceStateV1, COption_CPayloadAttributesV3*, CResult_CForkChoiceUpdatedResponse>)engine_forkchoiceUpdatedV3Ptr,
                 engine_get_payload_v1 = (delegate* unmanaged[Cdecl]<CH64, CResult_CExecutionPayloadV1>)engine_getPayloadV1Ptr,
                 engine_get_payload_v2 = (delegate* unmanaged[Cdecl]<CH64, CResult_CEngineGetPayloadV2Response>)engine_getPayloadV2Ptr,
                 engine_get_payload_v3 = (delegate* unmanaged[Cdecl]<CH64, CResult_CEngineGetPayloadV3Response>)engine_getPayloadV3Ptr,
                 engine_get_payload_v4 = (delegate* unmanaged[Cdecl]<CH64, CResult_CEngineGetPayloadV4Response>)engine_getPayloadV4Ptr,
                 engine_get_payload_v5 = (delegate* unmanaged[Cdecl]<CH64, CResult_CEngineGetPayloadV5Response>)engine_getPayloadV5Ptr,
-                engine_get_blobs_v1 = (delegate* unmanaged[Cdecl]<CVec_CH256, CResult_CVec_COption_CBlobAndProofV1>)engine_getBlobsV1Ptr,
-                engine_get_blobs_v2 = (delegate* unmanaged[Cdecl]<CVec_CH256, CResult_COption_CVec_CBlobAndProofV2>)engine_getBlobsV2Ptr,
-                engine_exchange_capabilities = (delegate* unmanaged[Cdecl]<CVec_CGrandineString, CResult_CVec_CGrandineString>)engine_exchangeCapabilitiesPtr,
-                engine_get_client_version_v1 = (delegate* unmanaged[Cdecl]<CClientVersionV1, CResult_CVec_CClientVersionV1>)engine_getClientVersionV1,
+                engine_get_blobs_v1 = (delegate* unmanaged[Cdecl]<CVec_CH256*, CResult_CVec_COption_CBlobAndProofV1>)engine_getBlobsV1Ptr,
+                engine_get_blobs_v2 = (delegate* unmanaged[Cdecl]<CVec_CH256*, CResult_COption_CVec_CBlobAndProofV2>)engine_getBlobsV2Ptr,
+                engine_exchange_capabilities = (delegate* unmanaged[Cdecl]<CVec_CGrandineString*, CResult_CVec_CGrandineString>)engine_exchangeCapabilitiesPtr,
+                engine_get_client_version_v1 = (delegate* unmanaged[Cdecl]<CClientVersionV1*, CResult_CVec_CClientVersionV1>)engine_getClientVersionV1,
             });
         }
 

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
@@ -18,12 +18,14 @@ public class GrandineEngineApi : IGrandineEngineApi
         this.engineRpc = engineRpc;
     }
 
-    public CResult_CPayloadStatusV1 EngineNewPayloadV1(CExecutionPayloadV1 payload)
+    public unsafe CResult_CPayloadStatusV1 EngineNewPayloadV1(CExecutionPayloadV1* payloadPtr)
     {
         this.logger.Debug("Received engine_newPayloadV1 request from grandine");
 
         try
         {
+            var payload = *payloadPtr;
+
             var payloadStatus = this.engineRpc.engine_newPayloadV1(new ExecutionPayload
             {
                 ParentHash = payload.parent_hash.ToHash256(),
@@ -53,12 +55,13 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CPayloadStatusV1 EngineNewPayloadV2(CExecutionPayloadV2 payload)
+    public unsafe CResult_CPayloadStatusV1 EngineNewPayloadV2(CExecutionPayloadV2* payloadPtr)
     {
         this.logger.Debug("Received engine_newPayloadV2 request from grandine");
 
         try
         {
+            var payload = *payloadPtr;
             var withdrawals = GrandineUtils.WithdrawalsFromNative(payload.withdrawals);
 
             var payloadStatus = this.engineRpc.engine_newPayloadV2(new ExecutionPayload
@@ -93,12 +96,13 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CPayloadStatusV1 EngineNewPayloadV3(CExecutionPayloadV3 payload, CVec_CH256 versionedHashes, CH256 parentBeaconBlockRoot)
+    public unsafe CResult_CPayloadStatusV1 EngineNewPayloadV3(CExecutionPayloadV3* payloadPtr, CVec_CH256* versionedHashesPtr, CH256 parentBeaconBlockRoot)
     {
         this.logger.Debug("Received engine_newPayloadV3 request from grandine");
 
         try
         {
+            var payload = *payloadPtr;
             var withdrawals = GrandineUtils.WithdrawalsFromNative(payload.withdrawals);
             var parentBeaconBlockRootConverted = parentBeaconBlockRoot.ToHash256();
 
@@ -124,7 +128,7 @@ public class GrandineEngineApi : IGrandineEngineApi
                     ExcessBlobGas = payload.excess_blob_gas,
                     ParentBeaconBlockRoot = parentBeaconBlockRootConverted,
                 },
-                GrandineUtils.ConvertVersionedHashes(versionedHashes),
+                GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr),
                 parentBeaconBlockRootConverted)
             .Result;
 
@@ -141,14 +145,15 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CPayloadStatusV1 EngineNewPayloadV4(CExecutionPayloadV3 payload, CVec_CH256 versionedHashes, CH256 parentBeaconBlockRoot, CExecutionRequests executionRequests)
+    public unsafe CResult_CPayloadStatusV1 EngineNewPayloadV4(CExecutionPayloadV3* payloadPtr, CVec_CH256* versionedHashesPtr, CH256 parentBeaconBlockRoot, CExecutionRequests* executionRequestsPtr)
     {
         this.logger.Debug("Received engine_newPayloadV4 request from grandine");
 
         try
         {
+            var payload = *payloadPtr;
             var withdrawals = GrandineUtils.WithdrawalsFromNative(payload.withdrawals);
-            var executionRequestsConverted = GrandineUtils.ConvertExecutionRequests(executionRequests);
+            var executionRequestsConverted = GrandineUtils.ConvertExecutionRequests(*executionRequestsPtr);
             var parentBeaconBlockRootConverted = parentBeaconBlockRoot.ToHash256();
 
             var payloadStatus = this.engineRpc.engine_newPayloadV4(
@@ -174,7 +179,7 @@ public class GrandineEngineApi : IGrandineEngineApi
                     ParentBeaconBlockRoot = parentBeaconBlockRootConverted,
                     ExecutionRequests = executionRequestsConverted,
                 },
-                GrandineUtils.ConvertVersionedHashes(versionedHashes),
+                GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr),
                 parentBeaconBlockRootConverted,
                 executionRequestsConverted)
             .Result;
@@ -213,7 +218,7 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV2(CForkChoiceStateV1 state, COption_CPayloadAttributesV2 payload)
+    public unsafe CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV2(CForkChoiceStateV1 state, COption_CPayloadAttributesV2* payloadPtr)
     {
         this.logger.Debug("Received engine_forkchoiceUpdatedV2 request from grandine");
 
@@ -221,7 +226,7 @@ public class GrandineEngineApi : IGrandineEngineApi
         {
             var forkchoiceUpdatedResult = this.engineRpc.engine_forkchoiceUpdatedV2(
                 state.ToForkchoiceStateV1(),
-                GrandineUtils.ConvertPayloadAttributes(payload)).Result;
+                GrandineUtils.ConvertPayloadAttributes(*payloadPtr)).Result;
 
             return forkchoiceUpdatedResult.Result != Result.Success
                 ? CResult_CForkChoiceUpdatedResponse.Fail(NativeMethods.GRANDINE_ERROR_ENGINE_API, forkchoiceUpdatedResult.Result.Error)
@@ -234,7 +239,7 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV3(CForkChoiceStateV1 state, COption_CPayloadAttributesV3 payload)
+    public unsafe CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV3(CForkChoiceStateV1 state, COption_CPayloadAttributesV3* payloadPtr)
     {
         this.logger.Debug("Received engine_forkchoiceUpdatedV3 request from grandine");
 
@@ -242,7 +247,7 @@ public class GrandineEngineApi : IGrandineEngineApi
         {
             var forkchoiceUpdatedResult = this.engineRpc.engine_forkchoiceUpdatedV3(
                 state.ToForkchoiceStateV1(),
-                GrandineUtils.ConvertPayloadAttributes(payload)).Result;
+                GrandineUtils.ConvertPayloadAttributes(*payloadPtr)).Result;
 
             return forkchoiceUpdatedResult.Result != Result.Success
                 ? CResult_CForkChoiceUpdatedResponse.Fail(NativeMethods.GRANDINE_ERROR_ENGINE_API, forkchoiceUpdatedResult.Result.Error)
@@ -390,13 +395,13 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1(CVec_CH256 versionedHashes)
+    public unsafe CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1(CVec_CH256* versionedHashesPtr)
     {
         this.logger.Debug("Received engine_getBlobsV1 request from grandine");
 
         try
         {
-            var blobs = this.engineRpc.engine_getBlobsV1(GrandineUtils.ConvertVersionedHashes(versionedHashes)).Result;
+            var blobs = this.engineRpc.engine_getBlobsV1(GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr)).Result;
 
             if (blobs.Result != Result.Success)
             {
@@ -422,13 +427,13 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2(CVec_CH256 versionedHashes)
+    public unsafe CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2(CVec_CH256* versionedHashesPtr)
     {
         this.logger.Debug("Received engine_getBlobsV2 request from grandine");
 
         try
         {
-            var blobs = this.engineRpc.engine_getBlobsV2(GrandineUtils.ConvertVersionedHashes(versionedHashes)).Result;
+            var blobs = this.engineRpc.engine_getBlobsV2(GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr)).Result;
 
             if (blobs.Result != Result.Success)
             {
@@ -454,13 +459,13 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CVec_CGrandineString EngineExchangeCapabilities(CVec_CGrandineString capabilities)
+    public unsafe CResult_CVec_CGrandineString EngineExchangeCapabilities(CVec_CGrandineString* capabilitiesPtr)
     {
         this.logger.Debug("Received engine_exchangeCapabilities request from grandine");
 
         try
         {
-            var outputCapabilities = this.engineRpc.engine_exchangeCapabilities(GrandineUtils.ConvertCapabilities(capabilities));
+            var outputCapabilities = this.engineRpc.engine_exchangeCapabilities(GrandineUtils.ConvertCapabilities(*capabilitiesPtr));
 
             if (outputCapabilities.Result != Result.Success)
             {
@@ -481,13 +486,13 @@ public class GrandineEngineApi : IGrandineEngineApi
         }
     }
 
-    public CResult_CVec_CClientVersionV1 EngineGetClientVersionV1(CClientVersionV1 version)
+    public unsafe CResult_CVec_CClientVersionV1 EngineGetClientVersionV1(CClientVersionV1* versionPtr)
     {
         this.logger.Debug("Received engine_getClientVersionV1 request from grandine");
 
         try
         {
-            var clClientVersion = GrandineUtils.ConvertClientVersion(version);
+            var clClientVersion = GrandineUtils.ConvertClientVersion(*versionPtr);
 
             var response = this.engineRpc.engine_getClientVersionV1(clClientVersion);
 

--- a/bindings/csharp/Grandine.NethermindPlugin/IGrandineEngineApi.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/IGrandineEngineApi.cs
@@ -4,19 +4,19 @@ using Grandine.Native;
 
 public interface IGrandineEngineApi
 {
-    CResult_CPayloadStatusV1 EngineNewPayloadV1(CExecutionPayloadV1 payload);
+    unsafe CResult_CPayloadStatusV1 EngineNewPayloadV1(CExecutionPayloadV1* payload);
 
-    CResult_CPayloadStatusV1 EngineNewPayloadV2(CExecutionPayloadV2 payload);
+    unsafe CResult_CPayloadStatusV1 EngineNewPayloadV2(CExecutionPayloadV2* payload);
 
-    CResult_CPayloadStatusV1 EngineNewPayloadV3(CExecutionPayloadV3 payload, CVec_CH256 versionedHashes, CH256 parentBeaconBlockRoot);
+    unsafe CResult_CPayloadStatusV1 EngineNewPayloadV3(CExecutionPayloadV3* payload, CVec_CH256* versionedHashes, CH256 parentBeaconBlockRoot);
 
-    CResult_CPayloadStatusV1 EngineNewPayloadV4(CExecutionPayloadV3 payload, CVec_CH256 versionedHashes, CH256 parentBeaconBlockRoot, CExecutionRequests executionRequests);
+    unsafe CResult_CPayloadStatusV1 EngineNewPayloadV4(CExecutionPayloadV3* payload, CVec_CH256* versionedHashes, CH256 parentBeaconBlockRoot, CExecutionRequests* executionRequests);
 
-    CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV1(CForkChoiceStateV1 state, COption_CPayloadAttributesV1 payload);
+    unsafe CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV1(CForkChoiceStateV1 state, COption_CPayloadAttributesV1 payload);
 
-    CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV2(CForkChoiceStateV1 state, COption_CPayloadAttributesV2 payload);
+    unsafe CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV2(CForkChoiceStateV1 state, COption_CPayloadAttributesV2* payload);
 
-    CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV3(CForkChoiceStateV1 state, COption_CPayloadAttributesV3 payload);
+    unsafe CResult_CForkChoiceUpdatedResponse EngineForkchoiceUpdatedV3(CForkChoiceStateV1 state, COption_CPayloadAttributesV3* payload);
 
     CResult_CExecutionPayloadV1 EngineGetPayloadV1(CH64 payloadId);
 
@@ -28,11 +28,11 @@ public interface IGrandineEngineApi
 
     CResult_CEngineGetPayloadV5Response EngineGetPayloadV5(CH64 payloadId);
 
-    CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1(CVec_CH256 versionedHashes);
+    unsafe CResult_CVec_COption_CBlobAndProofV1 EngineGetBlobsV1(CVec_CH256* versionedHashes);
 
-    CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2(CVec_CH256 versionedHashes);
+    unsafe CResult_COption_CVec_CBlobAndProofV2 EngineGetBlobsV2(CVec_CH256* versionedHashes);
 
-    CResult_CVec_CGrandineString EngineExchangeCapabilities(CVec_CGrandineString capabilities);
+    unsafe CResult_CVec_CGrandineString EngineExchangeCapabilities(CVec_CGrandineString* capabilities);
 
-    CResult_CVec_CClientVersionV1 EngineGetClientVersionV1(CClientVersionV1 version);
+    unsafe CResult_CVec_CClientVersionV1 EngineGetClientVersionV1(CClientVersionV1* version);
 }


### PR DESCRIPTION
Fixed two memory leak issues in C bindings:
* implemented proper cleanup for method arguments - they are no longer moved through FFI boundary, but passed by reference;
* implemented proper cleanup for CVec<T> items.