### PR TITLE
Process Electra and Single attestations in the slasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14305,6 +14305,7 @@ dependencies = [
  "ssz",
  "thiserror 2.0.18",
  "tracing",
+ "try_from_iterator",
  "types",
  "unwrap_none",
  "wincode",

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -1319,6 +1319,9 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             .is_ok()
         });
 
+        // Slasher-originated slashings are emitted as `AttesterSlashing::Electra` (see #655), which
+        // `pre_electra` filters out here. That is acceptable: a post-Electra node does not build
+        // pre-Electra blocks, and the Electra proposal path includes them via `post_electra`.
         let slashings = ContiguousList::try_from_iter(
             slashings
                 .drain(0..split_index.min(P::MaxAttesterSlashings::USIZE))

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -21,6 +21,7 @@ p2p = { workspace = true }
 ssz = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+try_from_iterator = { workspace = true }
 types = { workspace = true }
 wincode = { workspace = true }
 

--- a/slasher/src/attestations.rs
+++ b/slasher/src/attestations.rs
@@ -2,10 +2,8 @@ use anyhow::Result;
 use database::Database;
 use ssz::SszHash as _;
 use types::{
-    phase0::{
-        containers::{AttesterSlashing, IndexedAttestation},
-        primitives::{Epoch, ValidatorIndex},
-    },
+    electra::containers::{AttesterSlashing, IndexedAttestation},
+    phase0::primitives::{Epoch, ValidatorIndex},
     preset::Preset,
 };
 
@@ -161,6 +159,8 @@ impl<P: Preset> Attestations<P> {
 
 #[cfg(test)]
 mod tests {
+    use ssz::ContiguousList;
+    use try_from_iterator::TryFromIterator as _;
     use types::preset::Mainnet;
     use unwrap_none::UnwrapNone as _;
 
@@ -173,6 +173,56 @@ mod tests {
         indexed_attestation.data.source.epoch = source;
         indexed_attestation.data.target.epoch = target;
         indexed_attestation
+    }
+
+    fn build_attestation_with_indices<P: Preset>(
+        source: Epoch,
+        target: Epoch,
+        attesting_indices: impl IntoIterator<Item = ValidatorIndex>,
+    ) -> IndexedAttestation<P> {
+        let mut indexed_attestation = build_attestation::<P>(source, target);
+        indexed_attestation.attesting_indices =
+            ContiguousList::try_from_iter(attesting_indices).expect("indices fit within the bound");
+        indexed_attestation
+    }
+
+    // An Electra aggregate carries many attesters in a single attestation; the slasher must detect a
+    // violation for each of them and reconstruct it with the full multi-index attestations. This is
+    // the case that Phase 0's smaller `attesting_indices` bound could not represent.
+    #[test]
+    fn detects_double_vote_for_each_attester_in_multi_index_attestation() -> Result<()> {
+        let attestations = build_attestations::<Mainnet>();
+        let current_epoch = 14;
+        let attesters = [3, 7, 11];
+
+        let first = build_attestation_with_indices::<Mainnet>(2, 5, attesters);
+        let second = build_attestation_with_indices::<Mainnet>(3, 5, attesters);
+
+        for index in attesters {
+            attestations.find_slashing(index, &first)?.unwrap_none();
+            attestations.update(index, &first, current_epoch)?;
+        }
+
+        for index in attesters {
+            let explained = attestations
+                .find_slashing(index, &second)?
+                .expect("a double vote must be detected for every attester");
+
+            assert_eq!(explained.reason, AttesterSlashingReason::DoubleVote);
+            assert_eq!(explained.slashing.attestation_1, first);
+            assert_eq!(explained.slashing.attestation_2, second);
+            assert_eq!(
+                explained
+                    .slashing
+                    .attestation_1
+                    .attesting_indices
+                    .into_iter()
+                    .collect::<Vec<ValidatorIndex>>(),
+                attesters.to_vec(),
+            );
+        }
+
+        Ok(())
     }
 
     fn build_attestations<P: Preset>() -> Attestations<P> {

--- a/slasher/src/indexed_attestations.rs
+++ b/slasher/src/indexed_attestations.rs
@@ -4,10 +4,8 @@ use anyhow::Result;
 use database::Database;
 use ssz::{SszHash as _, SszReadDefault as _, SszWrite as _};
 use types::{
-    phase0::{
-        containers::IndexedAttestation,
-        primitives::{Epoch, H256},
-    },
+    electra::containers::IndexedAttestation,
+    phase0::primitives::{Epoch, H256},
     preset::Preset,
 };
 

--- a/slasher/src/messages.rs
+++ b/slasher/src/messages.rs
@@ -1,10 +1,8 @@
 use futures::channel::mpsc::UnboundedSender;
 use logging::warn_with_peers;
 use types::{
-    phase0::{
-        containers::{AttesterSlashing, ProposerSlashing},
-        primitives::Epoch,
-    },
+    electra::containers::AttesterSlashing,
+    phase0::{containers::ProposerSlashing, primitives::Epoch},
     preset::Preset,
 };
 

--- a/slasher/src/slasher.rs
+++ b/slasher/src/slasher.rs
@@ -10,14 +10,17 @@ use futures::{
     select,
     stream::StreamExt,
 };
-use helper_functions::{misc, phase0};
+use helper_functions::{electra, misc, phase0};
 use logging::{debug_with_peers, info_with_peers, warn_with_peers};
 use p2p::P2pToSlasher;
+use ssz::ContiguousList;
 use thiserror::Error;
+use try_from_iterator::TryFromIterator as _;
 use types::{
     combined::{Attestation, AttesterSlashing as CombinedAttesterSlashing, SignedBeaconBlock},
+    electra::containers::{AttesterSlashing, IndexedAttestation, SingleAttestation},
     phase0::{
-        containers::{AttesterSlashing, IndexedAttestation, ProposerSlashing},
+        containers::{IndexedAttestation as Phase0IndexedAttestation, ProposerSlashing},
         primitives::{Epoch, Version},
     },
     preset::Preset,
@@ -148,47 +151,74 @@ impl<P: Preset> Slasher<P> {
     }
 
     fn process_attestation(&self, attestation: &Attestation<P>) -> Result<()> {
-        let attestation = match attestation {
-            Attestation::Phase0(attestation) => attestation,
-            // TODO:
-            Attestation::Electra(_) | Attestation::Single(_) => return Ok(()),
+        let Some(indexed_attestation) = self.indexed_attestation(attestation)? else {
+            return Ok(());
         };
 
-        let target = attestation.data.target;
+        let current_epoch = self.controller.finalized_epoch();
+
+        debug_with_peers!(
+            "processing attestation record \
+             (attesters: {:?}, slot: {}, source: {}, target: {}, fork_version: {:?})",
+            indexed_attestation.attesting_indices,
+            indexed_attestation.data.slot,
+            indexed_attestation.data.source.epoch,
+            indexed_attestation.data.target.epoch,
+            self.fork_version,
+        );
+
+        for explained_attester_slashing in
+            self.check_attestation(&indexed_attestation, current_epoch)?
+        {
+            info_with_peers!("attester slashing constructed: {explained_attester_slashing:?}");
+
+            self.process_attester_slashing(explained_attester_slashing.slashing);
+        }
+
+        Ok(())
+    }
+
+    // Convert an attestation of any variant into an Electra `IndexedAttestation`, which the slasher
+    // uses uniformly for slashing detection and reporting. Electra's `attesting_indices` bound is a
+    // superset of Phase 0's, so Phase 0 attestations widen losslessly. A `SingleAttestation` carries
+    // its attester index explicitly, so it needs no committee lookup and no target state.
+    //
+    // Returns `None` when the target state needed to resolve aggregated attesting indices is
+    // unavailable.
+    fn indexed_attestation(
+        &self,
+        attestation: &Attestation<P>,
+    ) -> Result<Option<IndexedAttestation<P>>> {
+        // `SingleAttestation` carries its attester index explicitly, so no target state is needed.
+        if let Attestation::Single(attestation) = attestation {
+            return Ok(Some(single_attestation_to_indexed(attestation)));
+        }
+
+        let target = attestation.data().target;
         let slot = misc::compute_start_slot_at_epoch::<P>(target.epoch);
 
         let target_state = if Feature::CacheTargetStates.is_enabled() {
-            self.controller
-                .checkpoint_state_blocking(attestation.data.target)?
+            self.controller.checkpoint_state_blocking(target)?
         } else {
             self.controller.state_before_or_at_slot(target.root, slot)
         };
 
-        if let Some(target_state) = target_state {
-            let current_epoch = self.controller.finalized_epoch();
-            // TODO(feature/electra): use electra::get_indexed_attestation for electra attestations
-            let indexed_attestation = phase0::get_indexed_attestation(&target_state, attestation)?;
+        let Some(target_state) = target_state else {
+            return Ok(None);
+        };
 
-            debug_with_peers!(
-                "processing attestation record \
-                 (attesters: {:?}, slot: {}, source: {}, target: {}, fork_version: {:?})",
-                indexed_attestation.attesting_indices,
-                indexed_attestation.data.slot,
-                indexed_attestation.data.source.epoch,
-                indexed_attestation.data.target.epoch,
-                self.fork_version,
-            );
-
-            for explained_attester_slashing in
-                self.check_attestation(&indexed_attestation, current_epoch)?
-            {
-                info_with_peers!("attester slashing constructed: {explained_attester_slashing:?}");
-
-                self.process_attester_slashing(explained_attester_slashing.slashing);
+        let indexed_attestation = match attestation {
+            Attestation::Phase0(attestation) => {
+                let attestation = phase0::get_indexed_attestation(&target_state, attestation)?;
+                widen_indexed_attestation(attestation)
             }
-        }
+            Attestation::Electra(attestation) => {
+                electra::get_indexed_attestation(&target_state, attestation)?
+            }
+            Attestation::Single(_) => unreachable!("Single attestations are handled above"),
+        };
 
-        Ok(())
+        Ok(Some(indexed_attestation))
     }
 
     fn check_block(
@@ -240,10 +270,101 @@ impl<P: Preset> Slasher<P> {
 
     fn process_attester_slashing(&self, attester_slashing: AttesterSlashing<P>) {
         self.controller
-            .on_own_attester_slashing(Box::new(CombinedAttesterSlashing::Phase0(
+            .on_own_attester_slashing(Box::new(CombinedAttesterSlashing::Electra(
                 attester_slashing.clone(),
             )));
 
         SlasherToValidator::AttesterSlashing(attester_slashing).send(&self.slasher_to_validator_tx);
+    }
+}
+
+// `SingleAttestation` already identifies its single attester, so its `IndexedAttestation` can be
+// built directly without resolving a committee against the target state.
+fn single_attestation_to_indexed<P: Preset>(
+    attestation: &SingleAttestation,
+) -> IndexedAttestation<P> {
+    let attesting_indices =
+        ContiguousList::try_from_iter(core::iter::once(attestation.attester_index))
+            .expect("a single index always fits in IndexedAttestation.attesting_indices");
+
+    IndexedAttestation {
+        attesting_indices,
+        data: attestation.data,
+        signature: attestation.signature,
+    }
+}
+
+// Phase 0 `IndexedAttestation`s have a smaller `attesting_indices` bound than Electra ones, so they
+// always widen losslessly into the Electra representation the slasher uses internally.
+fn widen_indexed_attestation<P: Preset>(
+    attestation: Phase0IndexedAttestation<P>,
+) -> IndexedAttestation<P> {
+    IndexedAttestation {
+        attesting_indices: ContiguousList::try_from_iter(attestation.attesting_indices).expect(
+            "Phase 0 attesting indices always fit in Electra IndexedAttestation.attesting_indices",
+        ),
+        data: attestation.data,
+        signature: attestation.signature,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bls::SignatureBytes;
+    use types::{
+        phase0::{containers::AttestationData, primitives::ValidatorIndex},
+        preset::Mainnet,
+    };
+
+    use super::*;
+
+    #[test]
+    fn single_attestation_converts_to_single_index_indexed_attestation() {
+        let attester_index: ValidatorIndex = 42;
+        let data = AttestationData::default();
+        let signature = SignatureBytes::default();
+
+        let single = SingleAttestation {
+            committee_index: 3,
+            attester_index,
+            data,
+            signature,
+        };
+
+        let indexed = single_attestation_to_indexed::<Mainnet>(&single);
+
+        assert_eq!(
+            indexed
+                .attesting_indices
+                .into_iter()
+                .collect::<Vec<ValidatorIndex>>(),
+            vec![attester_index],
+        );
+        assert_eq!(indexed.data, data);
+        assert_eq!(indexed.signature, signature);
+    }
+
+    #[test]
+    fn phase0_indexed_attestation_widens_preserving_indices_data_and_signature() {
+        let attesting_indices = ContiguousList::try_from_iter([7, 9, 11])
+            .expect("three indices fit within the Phase 0 bound");
+
+        let phase0_attestation = Phase0IndexedAttestation::<Mainnet> {
+            attesting_indices,
+            data: AttestationData::default(),
+            signature: SignatureBytes::default(),
+        };
+
+        let widened = widen_indexed_attestation(phase0_attestation.clone());
+
+        assert_eq!(
+            widened
+                .attesting_indices
+                .into_iter()
+                .collect::<Vec<ValidatorIndex>>(),
+            vec![7, 9, 11],
+        );
+        assert_eq!(widened.data, phase0_attestation.data);
+        assert_eq!(widened.signature, phase0_attestation.signature);
     }
 }

--- a/slasher/src/status.rs
+++ b/slasher/src/status.rs
@@ -12,8 +12,7 @@
     reason = "Explained*Slashing.reason is used for logging through the `Debug` impl."
 )]
 use types::{
-    phase0::containers::{AttesterSlashing, ProposerSlashing},
-    preset::Preset,
+    electra::containers::AttesterSlashing, phase0::containers::ProposerSlashing, preset::Preset,
 };
 
 #[derive(Debug)]

--- a/slasher/src/targets.rs
+++ b/slasher/src/targets.rs
@@ -3,8 +3,9 @@ use core::marker::PhantomData;
 use anyhow::Result;
 use database::Database;
 use types::{
+    electra::containers::IndexedAttestation,
     phase0::{
-        containers::{AttestationData, IndexedAttestation},
+        containers::AttestationData,
         primitives::{Epoch, ValidatorIndex},
     },
     preset::Preset,

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -319,7 +319,7 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
 
                 slashing = slasher_to_validator_rx.select_next_some() => match slashing {
                     SlasherToValidator::AttesterSlashing(attester_slashing) => {
-                        self.block_producer.add_new_attester_slashing(AttesterSlashing::Phase0(attester_slashing)).await;
+                        self.block_producer.add_new_attester_slashing(AttesterSlashing::Electra(attester_slashing)).await;
                     }
                     SlasherToValidator::ProposerSlashing(proposer_slashing) => {
                         self.block_producer.add_new_proposer_slashing(proposer_slashing).await;


### PR DESCRIPTION
## Summary

The slasher was silently dropping `Attestation::Electra` and `Attestation::Single` from its detection path, so attester-slashing detection has been effectively dead on mainnet since the Electra fork.

This change unifies the slasher's internal `IndexedAttestation` and `AttesterSlashing` types on the Electra form (Electra's bound supersets Phase 0's, and the live network is post-Electra). The three attestation kinds are handled as follows:

- `Attestation::Single`: built directly from `attester_index` into an Electra `IndexedAttestation` via `ContiguousList::try_from_iter`.
- `Attestation::Electra`: passed through `electra::get_indexed_attestation`.
- `Attestation::Phase0`: widened to Electra via `ContiguousList::try_from_iter` (Phase 0's `MaxValidatorsPerCommittee` bound is a subset of Electra's `MaxAttestersPerSlot`).

`process_attester_slashing` now emits `CombinedAttesterSlashing::Electra`. The change ripples through `slasher/src/{attestations,indexed_attestations,messages,status,targets}.rs`, `validator/src/validator.rs`, and a 3-line comment in `block_producer/src/block_producer.rs` documenting the intentional pre-Electra filter drop.

## Tests

Three new tests:

- `single_attestation_converts_to_single_index_indexed_attestation` (slasher.rs): Single → Electra `IndexedAttestation` round-trip.
- `phase0_indexed_attestation_widens_preserving_indices_data_and_signature` (slasher.rs): Phase 0 → Electra widening preserves all fields.
- `detects_double_vote_for_each_attester_in_multi_index_attestation` (attestations.rs): multi-attester double-vote detection path.

`cargo test -p slasher`: 9/9 pass. `cargo check -p validator`: clean.

## Compat notes

- Fork choice and block production re-validate independently, so the always-Electra-output choice does not affect their correctness.
- `AttestationData` is fork-independent, so existing slasher DB entries remain byte-compatible.
- SSZ encoding of an Electra `IndexedAttestation` containing a single index has the same on-wire shape as a Phase 0 `IndexedAttestation` with the same index, modulo the `attesting_indices` type bound.

Fixes #655.
