### PR TITLE
Implement structurally shared validator list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,7 +5939,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "bls",
  "bytesize",
  "cached",
  "clock",
@@ -5987,7 +5986,6 @@ dependencies = [
  "tokio",
  "tracing",
  "transition_functions",
- "try_from_iterator",
  "tynm",
  "typenum",
  "types",
@@ -6734,7 +6732,6 @@ dependencies = [
  "enumset",
  "hashing",
  "hex-literal 1.1.0",
- "im",
  "itertools 0.14.0",
  "nonzero_ext",
  "num-integer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17103,6 +17103,7 @@ dependencies = [
  "test-case",
  "test-generator",
  "thiserror 2.0.18",
+ "try_from_iterator",
  "typenum",
  "url",
  "variant_count",

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -213,7 +213,10 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
             .retain(|slashing| {
                 let proposer_index = slashing.signed_header_1.message.proposer_index;
 
-                let proposer = match finalized_state.validators().get(proposer_index) {
+                let proposer = match finalized_state
+                    .validators()
+                    .partial_validator(proposer_index)
+                {
                     Ok(proposer) => proposer,
                     Err(error) => {
                         log_with_feature(format_args!(
@@ -233,7 +236,10 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
             .retain(|slashing| match slashing {
                 AttesterSlashing::Phase0(attester_slashing) => {
                     accessors::slashable_indices(attester_slashing).any(|attester_index| {
-                        let attester = match finalized_state.validators().get(attester_index) {
+                        let attester = match finalized_state
+                            .validators()
+                            .partial_validator(attester_index)
+                        {
                             Ok(attester) => attester,
                             Err(error) => {
                                 log_with_feature(format_args!(
@@ -248,7 +254,10 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
                 }
                 AttesterSlashing::Electra(attester_slashing) => {
                     accessors::slashable_indices(attester_slashing).any(|attester_index| {
-                        let attester = match finalized_state.validators().get(attester_index) {
+                        let attester = match finalized_state
+                            .validators()
+                            .partial_validator(attester_index)
+                        {
                             Ok(attester) => attester,
                             Err(error) => {
                                 log_with_feature(format_args!(
@@ -270,7 +279,10 @@ impl<P: Preset, W: Wait> BlockProducer<P, W> {
             .retain(|voluntary_exit| {
                 let validator_index = voluntary_exit.message.validator_index;
 
-                let validator = match finalized_state.validators().get(validator_index) {
+                let validator = match finalized_state
+                    .validators()
+                    .partial_validator(validator_index)
+                {
                     Ok(validator) => validator,
                     Err(error) => {
                         log_with_feature(format_args!(

--- a/eip_7594/src/lib.rs
+++ b/eip_7594/src/lib.rs
@@ -518,12 +518,7 @@ pub fn get_validator_custody_requirement<P: Preset>(
 ) -> u64 {
     let total_node_balance = validator_indices
         .iter()
-        .map(|index| {
-            last_finalized_state
-                .validators()
-                .get(*index)
-                .map(|validator| validator.effective_balance)
-        })
+        .map(|index| last_finalized_state.validators().effective_balance(*index))
         .process_results(|iter| iter.sum::<Gwei>())
         .unwrap_or(0);
 

--- a/fork_choice_control/Cargo.toml
+++ b/fork_choice_control/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
-bls = { workspace = true }
 cached = { workspace = true }
 clock = { workspace = true }
 crossbeam-utils = { workspace = true }
@@ -49,7 +48,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 transition_functions = { workspace = true }
-try_from_iterator = { workspace = true }
 tynm = { workspace = true }
 typenum = { workspace = true }
 types = { workspace = true }

--- a/fork_choice_control/src/storage.rs
+++ b/fork_choice_control/src/storage.rs
@@ -13,7 +13,7 @@ use logging::{debug_with_peers, info_with_peers, warn_with_peers};
 use nonzero_ext::nonzero;
 use pubkey_cache::PubkeyCache;
 use reqwest::Client;
-use ssz::{PersistentList, Ssz, SszRead, SszReadDefault, SszWrite};
+use ssz::{ContiguousList, Ssz, SszRead, SszReadDefault, SszWrite};
 use std_ext::ArcExt as _;
 use thiserror::Error;
 use tracing::info;
@@ -1020,34 +1020,32 @@ impl<P: Preset> Storage<P> {
         state: &mut BeaconState<P>,
         finalized_validators: Option<&Validators<P>>,
     ) -> Result<()> {
-        let mut disk_validators = None;
+        match finalized_validators {
+            Some(validators) => {
+                state
+                    .validators_mut()
+                    .set_pubkeys(validators.pubkeys())
+                    .context("invalid finalized validators list")?;
+            }
+            None => {
+                info_with_peers!("loading validators from disk");
 
-        for (index, validator) in state.validators_mut().into_iter().enumerate() {
-            if validator.pubkey.is_zero() {
-                // restore validator pubkey, by taking pubkey from the finalized validators list
-                let finalized_validator_pubkey = match finalized_validators {
-                    Some(v) => v.get(index as u64).map(|v| v.pubkey),
-                    None => {
-                        if disk_validators.is_none() {
-                            info_with_peers!("loading validators from disk");
+                let Some(pubkeys) = self
+                    .get::<ContiguousList<PublicKeyBytes, P::ValidatorRegistryLimit>>(
+                        FinalizedValidators,
+                    )?
+                else {
+                    bail!(
+                        "unable to restore validators into state - no saved validators on disk found."
+                    );
+                };
 
-                            let Some(validators) = self.get::<PersistentList<PublicKeyBytes, P::ValidatorRegistryLimit>>(FinalizedValidators)?
-                            else {
-                                bail!("unable to restore validators into state - no saved validators on disk found.");
-                            };
-
-                            disk_validators = Some(validators);
-                        }
-
-                        disk_validators
-                            .as_ref()
-                            .expect("disk_validators are loaded before access above")
-                            .get(index as u64)
-                            .copied()
-                    }
-                }.context("invalid finalized validators list")?;
-
-                validator.pubkey = finalized_validator_pubkey;
+                // TODO: this part can be optimized, by deserializing im::Vector<PublicKeyBytes> directly from stroage,
+                // instead of deserializing ContiguousList and setting keys one-by-one. However, that would require
+                // implementing SszRead/SszWrite for im::Vector, just for this single usecase.
+                for (index, pubkey) in (0..state.validators().len_u64()).zip(pubkeys) {
+                    *state.validators_mut().pubkey_mut(index)? = pubkey;
+                }
             }
         }
 
@@ -1065,8 +1063,10 @@ impl<P: Preset> Storage<P> {
             return Ok(());
         }
 
-        let validator_pubkeys = PersistentList::<_, P::ValidatorRegistryLimit>::try_from_iter(
-            validators.into_iter().map(|v| v.pubkey),
+        // TODO: the same as with deserialization, this part can be optimizing, by serializing im::Vector<_> directly,
+        // instead of first converting it to ContiguousList.
+        let validator_pubkeys = ContiguousList::<_, P::ValidatorRegistryLimit>::try_from_iter(
+            validators.pubkeys().iter().copied(),
         )?;
 
         batch.extend_from_slice(&[
@@ -1447,15 +1447,14 @@ fn prepare_state<P: Preset>(
     mut state: Arc<BeaconState<P>>,
     finalized_validator_list_len: usize,
 ) -> Arc<BeaconState<P>> {
-    for validator in state
-        .make_mut()
+    let state_mut = state.make_mut();
+
+    // pubkeys never change, so they can be restored later from the finalized
+    // validator list; zero out the leading (finalized) prefix to shrink the
+    // serialized state.
+    state_mut
         .validators_mut()
-        .into_iter()
-        .take(finalized_validator_list_len)
-    {
-        // pubkey never changes, so we can restore it later from finalized validator list
-        validator.pubkey = PublicKeyBytes::zero();
-    }
+        .clear_pubkeys(finalized_validator_list_len);
 
     state
 }

--- a/fork_choice_control/src/storage.rs
+++ b/fork_choice_control/src/storage.rs
@@ -2,7 +2,6 @@ use core::{cell::OnceCell, marker::PhantomData, num::NonZeroU64};
 use std::{borrow::Cow, sync::Arc};
 
 use anyhow::{Context as _, Error as AnyhowError, Result, bail, ensure};
-use bls::PublicKeyBytes;
 use database::{Database, PrefixableKey};
 use derive_more::Display;
 use fork_choice_store::{ChainLink, Store};
@@ -13,12 +12,11 @@ use logging::{debug_with_peers, info_with_peers, warn_with_peers};
 use nonzero_ext::nonzero;
 use pubkey_cache::PubkeyCache;
 use reqwest::Client;
-use ssz::{ContiguousList, Ssz, SszRead, SszReadDefault, SszWrite};
+use ssz::{Ssz, SszRead, SszReadDefault, SszWrite};
 use std_ext::ArcExt as _;
 use thiserror::Error;
 use tracing::info;
 use transition_functions::combined;
-use try_from_iterator::TryFromIterator;
 use typenum::Unsigned as _;
 use types::{
     Validators,
@@ -33,6 +31,7 @@ use types::{
     phase0::{
         consts::GENESIS_SLOT,
         primitives::{Epoch, H256, Slot},
+        validator_list::PubkeyList,
     },
     preset::Preset,
     redacting_url::RedactingUrl,
@@ -1030,22 +1029,18 @@ impl<P: Preset> Storage<P> {
             None => {
                 info_with_peers!("loading validators from disk");
 
-                let Some(pubkeys) = self
-                    .get::<ContiguousList<PublicKeyBytes, P::ValidatorRegistryLimit>>(
-                        FinalizedValidators,
-                    )?
+                let Some(pubkeys) =
+                    self.get::<PubkeyList<P::ValidatorRegistryLimit>>(FinalizedValidators)?
                 else {
                     bail!(
                         "unable to restore validators into state - no saved validators on disk found."
                     );
                 };
 
-                // TODO: this part can be optimized, by deserializing im::Vector<PublicKeyBytes> directly from stroage,
-                // instead of deserializing ContiguousList and setting keys one-by-one. However, that would require
-                // implementing SszRead/SszWrite for im::Vector, just for this single usecase.
-                for (index, pubkey) in (0..state.validators().len_u64()).zip(pubkeys) {
-                    *state.validators_mut().pubkey_mut(index)? = pubkey;
-                }
+                state
+                    .validators_mut()
+                    .set_pubkeys(&pubkeys)
+                    .context("invalid finalized validators list loaded from disk")?;
             }
         }
 
@@ -1063,15 +1058,9 @@ impl<P: Preset> Storage<P> {
             return Ok(());
         }
 
-        // TODO: the same as with deserialization, this part can be optimizing, by serializing im::Vector<_> directly,
-        // instead of first converting it to ContiguousList.
-        let validator_pubkeys = ContiguousList::<_, P::ValidatorRegistryLimit>::try_from_iter(
-            validators.pubkeys().iter().copied(),
-        )?;
-
         batch.extend_from_slice(&[
             serialize(FinalizedValidatorCount, validators.len_u64())?,
-            serialize(FinalizedValidators, validator_pubkeys)?,
+            serialize(FinalizedValidators, validators.pubkeys())?,
         ]);
 
         Ok(())

--- a/fork_choice_control/src/tasks.rs
+++ b/fork_choice_control/src/tasks.rs
@@ -772,7 +772,6 @@ fn initialize_preprocessed_state_cache<P: Preset>(
     accessors::get_or_init_active_validator_indices_shuffled(state, RelativeEpoch::Current, false)?;
     accessors::get_or_init_active_validator_indices_shuffled(state, RelativeEpoch::Next, false)?;
     accessors::get_or_init_total_active_balance(state, false);
-    accessors::get_or_init_validator_indices(state, false);
 
     Ok(())
 }

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -1656,7 +1656,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             },
         );
 
-        let public_key = &target_state.validators().get(aggregator_index)?.pubkey;
+        let public_key = target_state.validators().pubkey(aggregator_index)?;
 
         if !signature_validated && origin.verify_signatures() {
             let chain_config = &self.chain_config;
@@ -3970,11 +3970,12 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         state
             .validators()
-            .into_iter()
-            .map(|validator| {
+            .partial_validators()
+            .zip(state.validators().effective_balances())
+            .map(|(validator, &effective_balance)| {
                 // The `Validator.slashed` check was added in `consensus-specs` version 1.3.0-rc.4.
                 if predicates::is_active_validator(validator, epoch) && !validator.slashed {
-                    validator.effective_balance
+                    effective_balance
                 } else {
                     0
                 }

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -213,26 +213,46 @@ impl<'config, P: Preset> Incremental<'config, P> {
 
             let balance = *self.beacon_state.balances().get(validator_index)?;
 
-            let validator = self
-                .beacon_state
-                .validators_mut()
-                .get_mut(validator_index)?;
-
             if is_post_electra {
-                validator.effective_balance = balance
+                let validator = self
+                    .beacon_state
+                    .validators()
+                    .partial_validator(validator_index)?;
+
+                let effective_balance = balance
                     .prev_multiple_of(P::EFFECTIVE_BALANCE_INCREMENT)
                     .min(misc::get_max_effective_balance::<P>(validator));
 
-                if validator.effective_balance >= P::MIN_ACTIVATION_BALANCE {
+                *self
+                    .beacon_state
+                    .validators_mut()
+                    .effective_balance_mut(validator_index)? = effective_balance;
+
+                if effective_balance >= P::MIN_ACTIVATION_BALANCE {
+                    let validator = self
+                        .beacon_state
+                        .validators_mut()
+                        .partial_validator_mut(validator_index)?;
+
                     validator.activation_eligibility_epoch = GENESIS_EPOCH;
                     validator.activation_epoch = GENESIS_EPOCH;
                 }
             } else {
-                validator.effective_balance = balance
+                let effective_balance = balance
                     .prev_multiple_of(P::EFFECTIVE_BALANCE_INCREMENT)
                     .min(P::MAX_EFFECTIVE_BALANCE);
 
-                if validator.effective_balance == P::MAX_EFFECTIVE_BALANCE {
+                *self
+                    .beacon_state
+                    .validators_mut()
+                    .effective_balance_mut(validator_index)? = effective_balance;
+
+                if effective_balance == P::MAX_EFFECTIVE_BALANCE {
+                    let validator = self
+                        .beacon_state
+                        .validators_mut()
+                        .partial_validator_mut(validator_index)?;
+
                     validator.activation_eligibility_epoch = GENESIS_EPOCH;
                     validator.activation_epoch = GENESIS_EPOCH;
                 }

--- a/helper_functions/Cargo.toml
+++ b/helper_functions/Cargo.toml
@@ -37,7 +37,6 @@ types = { workspace = true }
 unwrap_none = { workspace = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-im = { workspace = true }
 rayon = { workspace = true }
 
 [dev-dependencies]

--- a/helper_functions/src/accessors.rs
+++ b/helper_functions/src/accessors.rs
@@ -5,16 +5,12 @@ use anyhow::{Result, anyhow, bail, ensure};
 use arithmetic::{NonZeroExt as _, U64Ext as _, UsizeExt as _};
 use bit_field::BitField as _;
 use bls::{AggregatePublicKey, PublicKeyBytes, traits::PublicKey as _};
-#[cfg(not(target_os = "zkvm"))]
-use im::HashMap;
 use itertools::{EitherOrBoth, Itertools as _};
 use nonzero_ext::nonzero;
 use num_integer::Roots as _;
 use pubkey_cache::PubkeyCache;
 use rc_box::ArcBox;
 use ssz::{ContiguousList, ContiguousVector, FitsInU64, Hc, SszHash as _};
-#[cfg(target_os = "zkvm")]
-use std::collections::HashMap;
 use std_ext::CopyExt as _;
 use tap::{Pipe as _, TryConv as _};
 use try_from_iterator::TryFromIterator as _;
@@ -196,30 +192,7 @@ pub fn index_of_public_key<P: Preset>(
     state: &(impl BeaconState<P> + ?Sized),
     public_key: &PublicKeyBytes,
 ) -> Option<ValidatorIndex> {
-    get_or_init_validator_indices(state, true)
-        .get(public_key)
-        .copied()
-}
-
-pub fn get_or_init_validator_indices<P: Preset>(
-    state: &(impl BeaconState<P> + ?Sized),
-    report_cache_miss: bool,
-) -> &HashMap<PublicKeyBytes, ValidatorIndex> {
-    state.cache().validator_indices.get_or_init(|| {
-        if report_cache_miss {
-            #[cfg(feature = "metrics")]
-            if let Some(metrics) = METRICS.get() {
-                metrics.validator_indices_init_count.inc();
-            }
-        }
-
-        state
-            .validators()
-            .into_iter()
-            .map(|validator| validator.pubkey)
-            .zip(0..)
-            .collect()
-    })
+    state.validators().pubkeys().index_of(public_key)
 }
 
 pub fn get_active_validator_indices<P: Preset>(

--- a/helper_functions/src/accessors.rs
+++ b/helper_functions/src/accessors.rs
@@ -188,7 +188,7 @@ pub fn public_key<P: Preset>(
     state: &(impl BeaconState<P> + ?Sized),
     validator_index: ValidatorIndex,
 ) -> Result<&PublicKeyBytes> {
-    Ok(&state.validators().get(validator_index)?.pubkey)
+    Ok(state.validators().pubkey(validator_index)?)
 }
 
 #[must_use]
@@ -235,8 +235,8 @@ fn get_active_validator_indices_by_epoch<P: Preset>(
     epoch: Epoch,
 ) -> impl Iterator<Item = ValidatorIndex> + '_ {
     (0..)
-        .zip(state.validators())
-        .filter(move |(_, validator)| predicates::is_active_validator(validator, epoch))
+        .zip(state.validators().partial_validators())
+        .filter(move |&(_, validator)| predicates::is_active_validator(validator, epoch))
         .map(|(index, _)| index)
 }
 
@@ -609,9 +609,10 @@ pub fn get_or_init_total_active_balance<P: Preset>(
             let current_epoch = get_current_epoch(state);
             state
                 .validators()
-                .into_iter()
-                .filter(|validator| predicates::is_active_validator(validator, current_epoch))
-                .map(|validator| validator.effective_balance)
+                .partial_validators()
+                .zip(state.validators().effective_balances())
+                .filter(|&(validator, _)| predicates::is_active_validator(validator, current_epoch))
+                .map(|(_, effective_balance)| *effective_balance)
                 .sum::<Gwei>()
                 .max(P::EFFECTIVE_BALANCE_INCREMENT.get())
                 .try_into()
@@ -669,9 +670,8 @@ fn get_next_sync_committee_indices_pre_electra<P: Preset>(
 
         let effective_balance = state
             .validators()
-            .get(candidate_index)
-            .expect("candidate_index was produced by enumerating active validators")
-            .effective_balance;
+            .effective_balance(candidate_index)
+            .expect("candidate_index was produced by enumerating active validators");
 
         if effective_balance.try_mul(max_random_byte)?
             >= P::MAX_EFFECTIVE_BALANCE.try_mul(random_byte)?
@@ -725,9 +725,8 @@ fn get_next_sync_committee_indices_post_electra<P: Preset>(
 
         let effective_balance = state
             .validators()
-            .get(candidate_index)
-            .expect("candidate_index was produced by enumerating active validators")
-            .effective_balance;
+            .effective_balance(candidate_index)
+            .expect("candidate_index was produced by enumerating active validators");
 
         if effective_balance.try_mul(max_random_value)?
             >= P::MAX_EFFECTIVE_BALANCE_ELECTRA.try_mul(random_value)?
@@ -776,8 +775,7 @@ pub fn get_next_sync_committee<P: Preset>(
     let mut pubkeys = Box::<ContiguousVector<PublicKeyBytes, _>>::default();
 
     for (pubkey, validator_index) in pubkeys.iter_mut().zip(indices) {
-        let validator = state.validators().get(validator_index)?;
-        pubkey.clone_from(&validator.pubkey);
+        pubkey.clone_from(state.validators().pubkey(validator_index)?);
     }
 
     let aggregate_pubkey = itertools::process_results(
@@ -799,7 +797,7 @@ pub fn get_base_reward<P: Preset>(
     validator_index: ValidatorIndex,
     base_reward_per_increment: Gwei,
 ) -> Result<Gwei> {
-    let effective_balance = state.validators().get(validator_index)?.effective_balance;
+    let effective_balance = state.validators().effective_balance(validator_index)?;
     compute_base_reward::<P>(effective_balance, base_reward_per_increment)
 }
 

--- a/helper_functions/src/altair.rs
+++ b/helper_functions/src/altair.rs
@@ -29,10 +29,10 @@ pub fn slash_validator<P: Preset>(
     initiate_validator_exit(config, state, slashed_index)?;
 
     let epoch = get_current_epoch(state);
-    let validator = state.validators.get_mut(slashed_index)?;
-    let effective_balance = validator.effective_balance;
+    let effective_balance = state.validators.effective_balance(slashed_index)?;
     let slashing_penalty = effective_balance / P::MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR;
 
+    let validator = state.validators.partial_validator_mut(slashed_index)?;
     validator.slashed = true;
     validator.withdrawable_epoch = validator
         .withdrawable_epoch
@@ -104,7 +104,7 @@ mod tests {
             &mut slot_report,
         )?;
 
-        let validator = state.validators.get(0)?;
+        let validator = state.validators.partial_validator(0)?;
 
         assert_eq!(validator.exit_epoch, 3 + 1 + 4);
         assert_eq!(validator.withdrawable_epoch, 3 + 8192);

--- a/helper_functions/src/bellatrix.rs
+++ b/helper_functions/src/bellatrix.rs
@@ -27,10 +27,12 @@ pub fn slash_validator<P: Preset>(
     initiate_validator_exit(config, state, slashed_index)?;
 
     let epoch = get_current_epoch(state);
-    let validator = state.validators_mut().get_mut(slashed_index)?;
-    let effective_balance = validator.effective_balance;
+    let effective_balance = state.validators().effective_balance(slashed_index)?;
     let slashing_penalty = effective_balance / P::MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX;
 
+    let validator = state
+        .validators_mut()
+        .partial_validator_mut(slashed_index)?;
     validator.slashed = true;
     validator.withdrawable_epoch = validator
         .withdrawable_epoch
@@ -103,7 +105,7 @@ mod tests {
             &mut slot_report,
         )?;
 
-        let validator = state.validators.get(0)?;
+        let validator = state.validators.partial_validator(0)?;
 
         assert_eq!(validator.exit_epoch, 3 + 1 + 4);
         assert_eq!(validator.withdrawable_epoch, 3 + 8192);

--- a/helper_functions/src/capella.rs
+++ b/helper_functions/src/capella.rs
@@ -1,7 +1,7 @@
 use types::{
     phase0::{
-        containers::Validator,
         primitives::{Epoch, Gwei},
+        validator_list::PartialValidator,
     },
     preset::Preset,
 };
@@ -12,7 +12,11 @@ use crate::predicates;
 ///
 /// > Check if ``validator`` is fully withdrawable.
 #[must_use]
-pub fn is_fully_withdrawable_validator(validator: &Validator, balance: Gwei, epoch: Epoch) -> bool {
+pub fn is_fully_withdrawable_validator(
+    validator: &PartialValidator,
+    balance: Gwei,
+    epoch: Epoch,
+) -> bool {
     predicates::has_eth1_withdrawal_credential(validator)
         && validator.withdrawable_epoch <= epoch
         && balance > 0
@@ -23,10 +27,11 @@ pub fn is_fully_withdrawable_validator(validator: &Validator, balance: Gwei, epo
 /// > Check if ``validator`` is partially withdrawable.
 #[must_use]
 pub fn is_partially_withdrawable_validator<P: Preset>(
-    validator: &Validator,
+    validator: &PartialValidator,
+    effective_balance: Gwei,
     balance: Gwei,
 ) -> bool {
-    let has_max_effective_balance = validator.effective_balance == P::MAX_EFFECTIVE_BALANCE;
+    let has_max_effective_balance = effective_balance == P::MAX_EFFECTIVE_BALANCE;
     let has_excess_balance = balance > P::MAX_EFFECTIVE_BALANCE;
 
     predicates::has_eth1_withdrawal_credential(validator)

--- a/helper_functions/src/electra.rs
+++ b/helper_functions/src/electra.rs
@@ -12,8 +12,8 @@ use types::{
     nonstandard::SlashingKind,
     phase0::{
         consts::FAR_FUTURE_EPOCH,
-        containers::Validator,
         primitives::{Epoch, Gwei, ValidatorIndex},
+        validator_list::PartialValidator,
     },
     preset::Preset,
     traits::{BeaconState, PostElectraBeaconState},
@@ -30,14 +30,21 @@ use crate::{
 
 // > Check if ``validator`` is eligible to be placed into the activation queue.
 #[must_use]
-pub const fn is_eligible_for_activation_queue<P: Preset>(validator: &Validator) -> bool {
+pub const fn is_eligible_for_activation_queue<P: Preset>(
+    validator: &PartialValidator,
+    effective_balance: Gwei,
+) -> bool {
     validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
-        && validator.effective_balance >= P::MIN_ACTIVATION_BALANCE
+        && effective_balance >= P::MIN_ACTIVATION_BALANCE
 }
 
 // > Check if ``validator`` is fully withdrawable.
 #[must_use]
-pub fn is_fully_withdrawable_validator(validator: &Validator, balance: Gwei, epoch: Epoch) -> bool {
+pub fn is_fully_withdrawable_validator(
+    validator: &PartialValidator,
+    balance: Gwei,
+    epoch: Epoch,
+) -> bool {
     has_execution_withdrawal_credential(validator)
         && validator.withdrawable_epoch <= epoch
         && balance > 0
@@ -46,11 +53,12 @@ pub fn is_fully_withdrawable_validator(validator: &Validator, balance: Gwei, epo
 // > Check if ``validator`` is partially withdrawable.
 #[must_use]
 pub fn is_partially_withdrawable_validator<P: Preset>(
-    validator: &Validator,
+    validator: &PartialValidator,
+    effective_balance: Gwei,
     balance: Gwei,
 ) -> bool {
     let max_effective_balance = get_max_effective_balance::<P>(validator);
-    let has_max_effective_balance = validator.effective_balance == max_effective_balance;
+    let has_max_effective_balance = effective_balance == max_effective_balance;
     let has_excess_balance = balance > max_effective_balance;
 
     has_execution_withdrawal_credential(validator)
@@ -132,7 +140,7 @@ pub fn initiate_validator_exit<P: Preset>(
     state: &mut impl PostElectraBeaconState<P>,
     validator_index: ValidatorIndex,
 ) -> Result<()> {
-    let validator = state.validators().get(validator_index)?;
+    let validator = state.validators().partial_validator(validator_index)?;
 
     // > Return if validator already initiated exit
     if validator.exit_epoch != FAR_FUTURE_EPOCH {
@@ -140,11 +148,13 @@ pub fn initiate_validator_exit<P: Preset>(
     }
 
     // > Compute exit queue epoch
-    let exit_queue_epoch =
-        compute_exit_epoch_and_update_churn(config, state, validator.effective_balance)?;
+    let effective_balance = state.validators().effective_balance(validator_index)?;
+    let exit_queue_epoch = compute_exit_epoch_and_update_churn(config, state, effective_balance)?;
 
     // > Set validator exit epoch and withdrawable epoch
-    let validator = state.validators_mut().get_mut(validator_index)?;
+    let validator = state
+        .validators_mut()
+        .partial_validator_mut(validator_index)?;
 
     validator.exit_epoch = exit_queue_epoch;
 
@@ -167,10 +177,12 @@ pub fn slash_validator<P: Preset>(
     initiate_validator_exit(config, state, slashed_index)?;
 
     let epoch = get_current_epoch(state);
-    let validator = state.validators_mut().get_mut(slashed_index)?;
-    let effective_balance = validator.effective_balance;
+    let effective_balance = state.validators().effective_balance(slashed_index)?;
     let slashing_penalty = effective_balance / P::MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA;
 
+    let validator = state
+        .validators_mut()
+        .partial_validator_mut(slashed_index)?;
     validator.slashed = true;
     validator.withdrawable_epoch = validator
         .withdrawable_epoch

--- a/helper_functions/src/fork.rs
+++ b/helper_functions/src/fork.rs
@@ -11,7 +11,7 @@ use bls::{SignatureBytes, traits::SignatureBytes as _};
 use itertools::Itertools as _;
 use pubkey_cache::PubkeyCache;
 use ssz::{BitVector, PersistentList, PersistentVector};
-use std_ext::ArcExt as _;
+use std_ext::{ArcExt as _, CopyExt as _};
 use try_from_iterator::TryFromIterator as _;
 use typenum::Unsigned as _;
 use types::{
@@ -84,8 +84,8 @@ pub fn upgrade_to_altair<P: Preset>(
         epoch,
     };
 
-    let zero_participation = PersistentList::repeat_zero_with_length_of(&validators);
-    let inactivity_scores = PersistentList::repeat_zero_with_length_of(&validators);
+    let zero_participation = PersistentList::repeat_zero(validators.len_usize())?;
+    let inactivity_scores = PersistentList::repeat_zero(validators.len_usize())?;
 
     let mut post = AltairBeaconState {
         // > Versioning
@@ -644,13 +644,16 @@ pub fn upgrade_to_electra<P: Preset>(
 
         *balance = 0;
 
-        let validator = post.validators_mut().get_mut(index)?;
+        *post.validators_mut().effective_balance_mut(index)? = 0;
+        post.validators_mut()
+            .partial_validator_mut(index)?
+            .activation_eligibility_epoch = FAR_FUTURE_EPOCH;
 
-        validator.effective_balance = 0;
-        validator.activation_eligibility_epoch = FAR_FUTURE_EPOCH;
-
-        let withdrawal_credentials = validator.withdrawal_credentials;
-        let pubkey = validator.pubkey;
+        let withdrawal_credentials = post
+            .validators()
+            .partial_validator(index)?
+            .withdrawal_credentials;
+        let pubkey = post.validators().pubkey(index)?.copy();
 
         post.pending_deposits_mut().push(PendingDeposit {
             pubkey,
@@ -663,7 +666,7 @@ pub fn upgrade_to_electra<P: Preset>(
 
     for index in post
         .validators
-        .into_iter()
+        .partial_validators()
         .zip(0..)
         .filter(|(validator, _)| predicates::has_compounding_withdrawal_credential(validator))
         .map(|(_, index)| index)

--- a/helper_functions/src/fork.rs
+++ b/helper_functions/src/fork.rs
@@ -965,10 +965,7 @@ fn onboard_builders<P: Preset>(
     pubkey_cache: &PubkeyCache,
     state: &mut GloasBeaconState<P>,
 ) -> Result<()> {
-    let mut validator_pubkeys = accessors::get_or_init_validator_indices(state, true)
-        .keys()
-        .copied()
-        .collect_vec();
+    let mut validator_pubkeys = state.validators.pubkeys().clone();
     let mut builder_pubkeys = vec![];
     let mut pending_deposits = vec![];
 

--- a/helper_functions/src/misc.rs
+++ b/helper_functions/src/misc.rs
@@ -37,11 +37,12 @@ use types::{
             AttestationSubnetCount, BLS_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX,
             GENESIS_EPOCH, GENESIS_SLOT,
         },
-        containers::{ForkData, SignedBeaconBlockHeader, SigningData, Validator},
+        containers::{ForkData, SignedBeaconBlockHeader, SigningData},
         primitives::{
             CommitteeIndex, Domain, DomainType, Epoch, ExecutionAddress, ForkDigest, Gwei, H128,
             H256, NodeId, Slot, SubnetId, Uint256, UnixSeconds, ValidatorIndex, Version,
         },
+        validator_list::PartialValidator,
     },
     preset::{Preset, SyncSubcommitteeSize},
     traits::{
@@ -258,9 +259,8 @@ fn compute_proposer_index_pre_electra<P: Preset>(
 
         let effective_balance = state
             .validators()
-            .get(candidate_index)
-            .expect("candidate_index was produced by enumerating active validators")
-            .effective_balance;
+            .effective_balance(candidate_index)
+            .expect("candidate_index was produced by enumerating active validators");
 
         if effective_balance.try_mul(max_random_byte)?
             >= P::MAX_EFFECTIVE_BALANCE.try_mul(random_byte)?
@@ -305,9 +305,8 @@ fn compute_proposer_index_post_electra<P: Preset>(
 
         let effective_balance = state
             .validators()
-            .get(candidate_index)
-            .expect("candidate_index was produced by enumerating active validators")
-            .effective_balance;
+            .effective_balance(candidate_index)
+            .expect("candidate_index was produced by enumerating active validators");
 
         if effective_balance.try_mul(max_random_value)?
             >= P::MAX_EFFECTIVE_BALANCE_ELECTRA.try_mul(random_value)?
@@ -388,7 +387,7 @@ pub fn compute_subnets_for_sync_committee<P: Preset>(
         state.next_sync_committee()
     };
 
-    let target_pubkey = &state.validators().get(validator_index)?.pubkey;
+    let target_pubkey = state.validators().pubkey(validator_index)?;
 
     let mut subnets = BitVector::default();
 
@@ -832,7 +831,7 @@ pub fn get_committee_indices<P: Preset>(
 
 // > Get max effective balance for ``validator``.
 #[must_use]
-pub fn get_max_effective_balance<P: Preset>(validator: &Validator) -> Gwei {
+pub fn get_max_effective_balance<P: Preset>(validator: &PartialValidator) -> Gwei {
     if predicates::has_compounding_withdrawal_credential(validator) {
         P::MAX_EFFECTIVE_BALANCE_ELECTRA
     } else {
@@ -960,10 +959,7 @@ fn compute_balance_weighted_acceptance<P: Preset>(
         random_bytes[offset.try_add(1)?],
     ]));
 
-    let effective_balance = state
-        .validators()
-        .get(index)
-        .map(|validator| validator.effective_balance)?;
+    let effective_balance = state.validators().effective_balance(index)?;
 
     Ok(effective_balance.try_mul(max_random_value)?
         >= P::MAX_EFFECTIVE_BALANCE_ELECTRA.try_mul(random_value)?)

--- a/helper_functions/src/mutators.rs
+++ b/helper_functions/src/mutators.rs
@@ -67,7 +67,12 @@ pub fn initiate_validator_exit<P: Preset>(
     validator_index: ValidatorIndex,
 ) -> Result<()> {
     // > Return if validator already initiated exit
-    if state.validators().get(validator_index)?.exit_epoch != FAR_FUTURE_EPOCH {
+    if state
+        .validators()
+        .partial_validator(validator_index)?
+        .exit_epoch
+        != FAR_FUTURE_EPOCH
+    {
         return Ok(());
     }
 
@@ -103,7 +108,9 @@ pub fn initiate_validator_exit<P: Preset>(
     }
 
     // > Set validator exit epoch and withdrawable epoch
-    let validator = state.validators_mut().get_mut(validator_index)?;
+    let validator = state
+        .validators_mut()
+        .partial_validator_mut(validator_index)?;
 
     validator.exit_epoch = exit_queue_epoch;
 
@@ -139,7 +146,7 @@ pub fn switch_to_compounding_validator<P: Preset>(
     state: &mut impl PostElectraBeaconState<P>,
     index: ValidatorIndex,
 ) -> Result<()> {
-    let validator = state.validators_mut().get_mut(index)?;
+    let validator = state.validators_mut().partial_validator_mut(index)?;
 
     validator.withdrawal_credentials[..COMPOUNDING_WITHDRAWAL_PREFIX.len()]
         .copy_from_slice(COMPOUNDING_WITHDRAWAL_PREFIX);
@@ -160,10 +167,11 @@ pub fn queue_excess_active_balance<P: Preset>(
 
         *state.balances_mut().get_mut(index)? = P::MIN_ACTIVATION_BALANCE;
 
-        let validator = state.validators().get(index)?;
-
-        let pubkey = validator.pubkey;
-        let withdrawal_credentials = validator.withdrawal_credentials;
+        let pubkey = state.validators().pubkey(index)?.to_owned();
+        let withdrawal_credentials = state
+            .validators()
+            .partial_validator(index)?
+            .withdrawal_credentials;
 
         state.pending_deposits_mut().push(PendingDeposit {
             pubkey,
@@ -304,8 +312,8 @@ mod tests {
         // `exit_epoch` is `FAR_FUTURE_EPOCH` and should be set to the lowest possible value.
         initiate_validator_exit(&config, &mut state, 1)?;
 
-        assert_eq!(state.validators.get(0)?.exit_epoch, 4);
-        assert_eq!(state.validators.get(1)?.exit_epoch, 5);
+        assert_eq!(state.validators.partial_validator(0)?.exit_epoch, 4);
+        assert_eq!(state.validators.partial_validator(1)?.exit_epoch, 5);
 
         Ok(())
     }

--- a/helper_functions/src/phase0.rs
+++ b/helper_functions/src/phase0.rs
@@ -10,8 +10,9 @@ use types::{
     phase0::{
         beacon_state::BeaconState as Phase0BeaconState,
         consts::FAR_FUTURE_EPOCH,
-        containers::{Attestation, AttestationData, IndexedAttestation, Validator},
-        primitives::ValidatorIndex,
+        containers::{Attestation, AttestationData, IndexedAttestation},
+        primitives::{Gwei, ValidatorIndex},
+        validator_list::PartialValidator,
     },
     preset::Preset,
     traits::BeaconState,
@@ -74,9 +75,12 @@ pub fn get_attesting_indices<'all, P: Preset>(
 
 // > Check if ``validator`` is eligible to be placed into the activation queue.
 #[must_use]
-pub const fn is_eligible_for_activation_queue<P: Preset>(validator: &Validator) -> bool {
+pub const fn is_eligible_for_activation_queue<P: Preset>(
+    validator: &PartialValidator,
+    effective_balance: Gwei,
+) -> bool {
     validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
-        && validator.effective_balance == P::MAX_EFFECTIVE_BALANCE
+        && effective_balance == P::MAX_EFFECTIVE_BALANCE
 }
 
 pub fn slash_validator<P: Preset>(
@@ -90,10 +94,10 @@ pub fn slash_validator<P: Preset>(
     initiate_validator_exit(config, state, slashed_index)?;
 
     let epoch = get_current_epoch(state);
-    let validator = state.validators.get_mut(slashed_index)?;
-    let effective_balance = validator.effective_balance;
+    let effective_balance = state.validators.effective_balance(slashed_index)?;
     let slashing_penalty = effective_balance / P::MIN_SLASHING_PENALTY_QUOTIENT;
 
+    let validator = state.validators.partial_validator_mut(slashed_index)?;
     validator.slashed = true;
     validator.withdrawable_epoch = validator
         .withdrawable_epoch
@@ -164,7 +168,7 @@ mod tests {
             &mut slot_report,
         )?;
 
-        let validator = state.validators.get(0)?;
+        let validator = state.validators.partial_validator(0)?;
 
         assert_eq!(validator.exit_epoch, 3 + 1 + 4);
         assert_eq!(validator.withdrawable_epoch, 3 + 8192);

--- a/helper_functions/src/predicates.rs
+++ b/helper_functions/src/predicates.rs
@@ -28,6 +28,7 @@ use types::{
         consts::{ETH1_ADDRESS_WITHDRAWAL_PREFIX, FAR_FUTURE_EPOCH, TargetAggregatorsPerCommittee},
         containers::{AttestationData, Validator},
         primitives::{CommitteeIndex, Epoch, Gwei, H256, Slot},
+        validator_list::PartialValidator,
     },
     preset::Preset,
     traits::{
@@ -46,7 +47,7 @@ use crate::{
 // > Check if ``validator`` is active.
 #[inline]
 #[must_use]
-pub const fn is_active_validator(validator: &Validator, epoch: Epoch) -> bool {
+pub const fn is_active_validator(validator: &PartialValidator, epoch: Epoch) -> bool {
     validator.activation_epoch <= epoch && epoch < validator.exit_epoch
 }
 
@@ -54,7 +55,7 @@ pub const fn is_active_validator(validator: &Validator, epoch: Epoch) -> bool {
 #[must_use]
 pub fn is_eligible_for_activation<P: Preset>(
     state: &impl BeaconState<P>,
-    validator: &Validator,
+    validator: &PartialValidator,
 ) -> bool {
     // > Placement in queue is finalized
     validator.activation_eligibility_epoch <= state.finalized_checkpoint().epoch
@@ -63,7 +64,10 @@ pub fn is_eligible_for_activation<P: Preset>(
 }
 
 #[inline]
-pub fn is_eligible_for_penalties(validator: &Validator, previous_epoch: Epoch) -> Result<bool> {
+pub fn is_eligible_for_penalties(
+    validator: &PartialValidator,
+    previous_epoch: Epoch,
+) -> Result<bool> {
     Ok(is_active_validator(validator, previous_epoch)
         || (validator.slashed && previous_epoch.try_add(1)? < validator.withdrawable_epoch))
 }
@@ -71,7 +75,7 @@ pub fn is_eligible_for_penalties(validator: &Validator, previous_epoch: Epoch) -
 // > Check if ``validator`` is slashable.
 #[inline]
 #[must_use]
-pub const fn is_slashable_validator(validator: &Validator, epoch: Epoch) -> bool {
+pub const fn is_slashable_validator(validator: &PartialValidator, epoch: Epoch) -> bool {
     !validator.slashed
         && epoch < validator.withdrawable_epoch
         && validator.activation_epoch <= epoch
@@ -303,7 +307,7 @@ pub fn is_execution_enabled<P: Preset>(
 ///
 /// > Check if ``validator`` has an 0x01 prefixed "eth1" withdrawal credential.
 #[must_use]
-pub fn has_eth1_withdrawal_credential(validator: &Validator) -> bool {
+pub fn has_eth1_withdrawal_credential(validator: &PartialValidator) -> bool {
     validator
         .withdrawal_credentials
         .as_bytes()
@@ -389,13 +393,13 @@ pub fn is_compounding_withdrawal_credential(withdrawal_credentials: H256) -> boo
 
 // > Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal credential.
 #[must_use]
-pub fn has_compounding_withdrawal_credential(validator: &Validator) -> bool {
+pub fn has_compounding_withdrawal_credential(validator: &PartialValidator) -> bool {
     is_compounding_withdrawal_credential(validator.withdrawal_credentials)
 }
 
 // > Check if ``validator`` has a 0x01 or 0x02 prefixed withdrawal credential.
 #[must_use]
-pub fn has_execution_withdrawal_credential(validator: &Validator) -> bool {
+pub fn has_execution_withdrawal_credential(validator: &PartialValidator) -> bool {
     has_compounding_withdrawal_credential(validator) || has_eth1_withdrawal_credential(validator)
 }
 
@@ -856,7 +860,10 @@ mod extra_tests {
         let validator = inactive_validator();
         let epoch = 10;
 
-        assert!(!is_active_validator(&validator, epoch));
+        assert!(!is_active_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]
@@ -867,7 +874,10 @@ mod extra_tests {
         };
         let epoch = 10;
 
-        assert!(is_active_validator(&validator, epoch));
+        assert!(is_active_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]
@@ -878,7 +888,10 @@ mod extra_tests {
         };
         let epoch = 10;
 
-        assert!(!is_active_validator(&validator, epoch));
+        assert!(!is_active_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]
@@ -889,7 +902,10 @@ mod extra_tests {
         };
         let epoch = 10;
 
-        assert!(!is_slashable_validator(&validator, epoch));
+        assert!(!is_slashable_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]
@@ -897,7 +913,10 @@ mod extra_tests {
         let validator = inactive_validator();
         let epoch = 10;
 
-        assert!(!is_slashable_validator(&validator, epoch));
+        assert!(!is_slashable_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]
@@ -905,7 +924,10 @@ mod extra_tests {
         let validator = exiting_validator();
         let epoch = 11;
 
-        assert!(!is_slashable_validator(&validator, epoch));
+        assert!(!is_slashable_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]
@@ -913,7 +935,10 @@ mod extra_tests {
         let validator = exiting_validator();
         let epoch = 10;
 
-        assert!(is_slashable_validator(&validator, epoch));
+        assert!(is_slashable_validator(
+            &PartialValidator::from(&validator),
+            epoch
+        ));
     }
 
     #[test]

--- a/http_api/src/gui.rs
+++ b/http_api/src/gui.rs
@@ -38,6 +38,7 @@ use types::{
         consts::{GENESIS_EPOCH, GENESIS_SLOT},
         containers::Validator,
         primitives::{Epoch, Gwei, H256, Slot, ValidatorIndex},
+        validator_list::PartialValidator,
     },
     preset::Preset,
     traits::{BeaconState as _, SignedBeaconBlock as _},
@@ -134,7 +135,7 @@ impl ValidatorEpochRangeReport {
 
     fn accumulate(
         &mut self,
-        validator: &Validator,
+        validator: &PartialValidator,
         current_epoch: Epoch,
         report: ValidatorEpochReport,
     ) -> Result<()> {
@@ -525,7 +526,7 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     epoch_deltas,
                     post_balances,
                 ) {
-                    if skip_validator(validator) {
+                    if skip_validator(&validator) {
                         continue;
                     }
 
@@ -566,7 +567,11 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     validator_reports
                         .entry(validator.pubkey)
                         .or_insert_with(|| ValidatorEpochRangeReport::new(validator_index))
-                        .accumulate(validator, current_epoch, validator_report)?;
+                        .accumulate(
+                            state.validators().partial_validator(validator_index)?,
+                            current_epoch,
+                            validator_report,
+                        )?;
                 }
             }
             EpochReport::PostAltair(AltairEpochReport {
@@ -593,7 +598,7 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     epoch_deltas,
                     post_balances,
                 ) {
-                    if skip_validator(validator) {
+                    if skip_validator(&validator) {
                         continue;
                     }
 
@@ -654,7 +659,11 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     validator_reports
                         .entry(validator.pubkey)
                         .or_insert_with(|| ValidatorEpochRangeReport::new(validator_index))
-                        .accumulate(validator, current_epoch, validator_report)?;
+                        .accumulate(
+                            state.validators().partial_validator(validator_index)?,
+                            current_epoch,
+                            validator_report,
+                        )?;
                 }
             }
         }
@@ -733,7 +742,7 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     epoch_deltas,
                     post_balances,
                 ) {
-                    if skip_validator(validator) {
+                    if skip_validator(&validator) {
                         continue;
                     }
 
@@ -774,7 +783,11 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     validator_reports
                         .entry(validator.pubkey)
                         .or_insert_with(|| ValidatorEpochRangeReport::new(validator_index))
-                        .accumulate(validator, current_epoch, validator_report)?;
+                        .accumulate(
+                            state.validators().partial_validator(validator_index)?,
+                            current_epoch,
+                            validator_report,
+                        )?;
                 }
             }
             EpochReport::PostAltair(AltairEpochReport {
@@ -801,7 +814,7 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     epoch_deltas,
                     post_balances,
                 ) {
-                    if skip_validator(validator) {
+                    if skip_validator(&validator) {
                         continue;
                     }
 
@@ -862,7 +875,11 @@ pub async fn get_validator_statistics<P: Preset, W: Wait>(
                     validator_reports
                         .entry(validator.pubkey)
                         .or_insert_with(|| ValidatorEpochRangeReport::new(validator_index))
-                        .accumulate(validator, current_epoch, validator_report)?;
+                        .accumulate(
+                            state.validators().partial_validator(validator_index)?,
+                            current_epoch,
+                            validator_report,
+                        )?;
                 }
             }
         }
@@ -1103,7 +1120,10 @@ mod tests {
 
         mutators::initiate_validator_exit(&config, &mut state, exiting_validator_index)?;
 
-        let exit_epoch = state.validators().get(exiting_validator_index)?.exit_epoch;
+        let exit_epoch = state
+            .validators()
+            .partial_validator(exiting_validator_index)?
+            .exit_epoch;
         let start_slot = misc::compute_start_slot_at_epoch::<Minimal>(exit_epoch);
 
         combined::process_slots(&config, &pubkey_cache, state.make_mut(), start_slot - 1)?;

--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -725,7 +725,7 @@ pub async fn state_validator<P: Preset, W: Wait>(
     let response = StateValidatorResponse {
         balance,
         index: validator_index,
-        status: ValidatorStatus::new(validator, &state),
+        status: ValidatorStatus::new(&validator, &state),
         validator: validator.clone(),
     };
 
@@ -3888,7 +3888,7 @@ fn state_validators<P: Preset, W: Wait>(
     .map(|(index, validator, balance)| StateValidatorResponse {
         index,
         balance,
-        status: ValidatorStatus::new(validator, &state),
+        status: ValidatorStatus::new(&validator, &state),
         validator: validator.clone(),
     })
     .collect();

--- a/metrics/src/beaconchain.rs
+++ b/metrics/src/beaconchain.rs
@@ -207,7 +207,9 @@ impl ValidatorMetrics {
             .iter()
             .filter(|pubkey| {
                 accessors::index_of_public_key(&state, pubkey)
-                    .and_then(|validator_index| state.validators().get(validator_index).ok())
+                    .and_then(|validator_index| {
+                        state.validators().partial_validator(validator_index).ok()
+                    })
                     .is_some_and(|validator| {
                         predicates::is_active_validator(validator, current_epoch)
                     })

--- a/operation_pools/src/bls_to_execution_change_pool.rs
+++ b/operation_pools/src/bls_to_execution_change_pool.rs
@@ -254,7 +254,10 @@ impl<P: Preset, W: Wait> Service<P, W> {
         let finalized_state = self.controller.last_finalized_state().value;
 
         self.bls_to_execution_changes.retain(|validator_index, _| {
-            let validator = match finalized_state.validators().get(*validator_index) {
+            let validator = match finalized_state
+                .validators()
+                .partial_validator(*validator_index)
+            {
                 Ok(validator) => validator,
                 Err(error) => {
                     debug_with_peers!("BLS to execution change is too recent to discard: {error}");

--- a/operation_pools/src/sync_committee_agg_pool/pool.rs
+++ b/operation_pools/src/sync_committee_agg_pool/pool.rs
@@ -124,10 +124,7 @@ impl<P: Preset> Pool<P> {
         let messages = self.sync_committee_messages(contribution_data).await;
 
         for message in messages.read().await.iter() {
-            let validator_pubkey = &beacon_state
-                .validators()
-                .get(message.validator_index)?
-                .pubkey;
+            let validator_pubkey = beacon_state.validators().pubkey(message.validator_index)?;
 
             let positions_in_subcommittee = subcommittee_pubkeys
                 .iter()
@@ -201,10 +198,7 @@ impl<P: Preset> Pool<P> {
         }
 
         for message in messages {
-            let validator_pubkey = &beacon_state
-                .validators()
-                .get(message.validator_index)?
-                .pubkey;
+            let validator_pubkey = beacon_state.validators().pubkey(message.validator_index)?;
 
             let positions_in_subcommittee = subcommittee_pubkeys
                 .iter()

--- a/operation_pools/src/sync_committee_agg_pool/tasks.rs
+++ b/operation_pools/src/sync_committee_agg_pool/tasks.rs
@@ -14,7 +14,7 @@ use helper_functions::{
 use logging::{debug_with_peers, warn_with_peers};
 use prometheus_metrics::Metrics;
 use pubkey_cache::PubkeyCache;
-use std_ext::ArcExt as _;
+use std_ext::{ArcExt as _, CopyExt as _};
 use typenum::Unsigned as _;
 use types::{
     altair::{
@@ -406,18 +406,18 @@ fn validate_external_contribution_and_proof<P: Preset>(
     );
 
     let aggregator_index = contribution_and_proof.aggregator_index;
-    let aggregator = state.validators().get(aggregator_index)?;
+    let aggregator_pubkey = state.validators().pubkey(aggregator_index)?.copy();
     let subcommittee_pubkeys =
         accessors::get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index)?;
 
     ensure!(
-        subcommittee_pubkeys.contains(&aggregator.pubkey),
+        subcommittee_pubkeys.contains(&aggregator_pubkey),
         "aggregator is not in the declared subcommittee",
     );
 
     let mut verifier = MultiVerifier::default();
 
-    let pubkey = pubkey_cache.get_or_insert(aggregator.pubkey)?;
+    let pubkey = pubkey_cache.get_or_insert(aggregator_pubkey)?;
 
     verifier.verify_singular(
         SyncAggregatorSelectionData {
@@ -495,7 +495,7 @@ fn validate_external_message<P: Preset>(
     );
 
     let validator_pubkey =
-        pubkey_cache.get_or_insert(state.validators().get(validator_index)?.pubkey)?;
+        pubkey_cache.get_or_insert(state.validators().pubkey(validator_index)?.copy())?;
 
     message.beacon_block_root.verify(
         config,

--- a/prometheus_metrics/src/metrics.rs
+++ b/prometheus_metrics/src/metrics.rs
@@ -161,7 +161,6 @@ pub struct Metrics {
     pub beacon_proposer_index_init_count: IntCounter,
     pub ptc_cache_init_count: IntCounter,
     pub total_active_balance_init_count: IntCounter,
-    pub validator_indices_init_count: IntCounter,
 
     // Transition function metrics
     pub blinded_block_transition_times: Histogram,
@@ -720,11 +719,6 @@ impl Metrics {
                 "Total active balance cache init count",
             )?,
 
-            validator_indices_init_count: IntCounter::new(
-                "VALIDATOR_INDICES_INIT_COUNT",
-                "Validator indices cache init count",
-            )?,
-
             // Transition function metrics
             blinded_block_transition_times: Histogram::with_opts(histogram_opts!(
                 "BLINDED_BLOCK_TRANSITION_TIMES",
@@ -1019,7 +1013,6 @@ impl Metrics {
         default_registry.register(Box::new(self.beacon_proposer_index_init_count.clone()))?;
         default_registry.register(Box::new(self.ptc_cache_init_count.clone()))?;
         default_registry.register(Box::new(self.total_active_balance_init_count.clone()))?;
-        default_registry.register(Box::new(self.validator_indices_init_count.clone()))?;
         default_registry.register(Box::new(self.blinded_block_transition_times.clone()))?;
         default_registry.register(Box::new(self.block_transition_times.clone()))?;
         default_registry.register(Box::new(self.epoch_processing_times.clone()))?;

--- a/ssz/src/lib.rs
+++ b/ssz/src/lib.rs
@@ -21,7 +21,9 @@ pub use crate::{
     persistent_list::PersistentList,
     persistent_vector::PersistentVector,
     porcelain::{SszHash, SszRead, SszReadDefault, SszSize, SszWrite},
-    shared::{read_offset_unchecked, subslice, write_offset},
+    shared::{
+        read_list, read_offset_unchecked, saturating_usize, subslice, write_list, write_offset,
+    },
     size::Size,
     type_level::{
         BitVectorBits, ByteVectorBytes, BytesToDepth, ContiguousVectorElements, FitsInU64,

--- a/ssz/src/persistent_list.rs
+++ b/ssz/src/persistent_list.rs
@@ -279,17 +279,6 @@ where
 
 impl<T, N, B> PersistentList<T, N, B> {
     #[must_use]
-    pub fn repeat_zero_with_length_of<U, B2>(other: &PersistentList<U, N, B2>) -> Self
-    where
-        T: ZeroDefault + SszHash + SszWrite + Clone,
-        N: Unsigned,
-        B: BundleSize<T> + MerkleElements<T>,
-        B2: BundleSize<U>,
-    {
-        Self::repeat_zero(other.len_usize()).expect("lists have the same maximum length")
-    }
-
-    #[must_use]
     pub const fn len_usize(&self) -> usize {
         self.length
     }
@@ -439,7 +428,7 @@ impl<T, N, B> PersistentList<T, N, B> {
         Ok(())
     }
 
-    fn repeat_zero(length: usize) -> Result<Self, ReadError>
+    pub fn repeat_zero(length: usize) -> Result<Self, ReadError>
     where
         T: ZeroDefault + SszHash + SszWrite + Clone,
         N: Unsigned,

--- a/ssz/src/shared.rs
+++ b/ssz/src/shared.rs
@@ -23,6 +23,7 @@ use crate::{
 //                       Try to avoid referring to `Unsigned::U64` or `Unsigned::U128`.
 // The associated constants in `typenum::Unsigned` are computed using the `<<` operator,
 // which silently discards set bits that are shifted out of range.
+#[must_use]
 pub const fn saturating_usize<N: Unsigned>() -> usize {
     if N::U64 > usize::MAX as u64 {
         usize::MAX

--- a/transition_functions/src/altair/block_processing.rs
+++ b/transition_functions/src/altair/block_processing.rs
@@ -474,7 +474,6 @@ pub fn apply_deposits<P: Preset>(
                 amounts,
                 ..
             } => {
-                let public_key_bytes = pubkey;
                 let withdrawal_credentials = withdrawal_credentials[0];
                 let first_amount = amounts[0];
                 let total_amount = amounts.iter().sum();
@@ -501,16 +500,6 @@ pub fn apply_deposits<P: Preset>(
                 state.previous_epoch_participation_mut().push(0)?;
                 state.current_epoch_participation_mut().push(0)?;
                 state.inactivity_scores_mut().push(0)?;
-
-                state
-                    .cache_mut()
-                    .validator_indices
-                    .get_mut()
-                    .expect(
-                        "state.cache.validator_indices is initialized by \
-                         index_of_public_key, which is called before apply_deposits",
-                    )
-                    .insert(public_key_bytes, validator_index);
 
                 for amount in amounts {
                     slot_report.add_deposit(validator_index, amount);

--- a/transition_functions/src/altair/epoch_intermediates.rs
+++ b/transition_functions/src/altair/epoch_intermediates.rs
@@ -203,66 +203,63 @@ pub fn statistics_and_summaries<P: Preset, S: PostAltairBeaconState<P>>(
 
     let mut statistics = Statistics::default();
 
-    let summaries = state
-        .validators()
-        .into_iter()
-        .zip(participation.iter().copied())
-        .map(
-            |(validator, participation)| -> Result<AltairValidatorSummary> {
-                let Validator {
-                    effective_balance,
-                    slashed,
-                    withdrawable_epoch,
-                    ..
-                } = *validator;
+    let summaries = izip!(
+        state.validators().partial_validators(),
+        state.validators().effective_balances().copied(),
+        participation.iter().copied(),
+    )
+    .map(
+        |(validator, effective_balance, participation)| -> Result<AltairValidatorSummary> {
+            let slashed = validator.slashed;
+            let withdrawable_epoch = validator.withdrawable_epoch;
 
-                let active_in_previous_epoch = is_active_validator(validator, previous_epoch);
-                let active_in_current_epoch = is_active_validator(validator, current_epoch);
-                let eligible_for_penalties = is_eligible_for_penalties(validator, previous_epoch)?;
+            let active_in_previous_epoch = is_active_validator(validator, previous_epoch);
+            let active_in_current_epoch = is_active_validator(validator, current_epoch);
+            let eligible_for_penalties = is_eligible_for_penalties(validator, previous_epoch)?;
 
-                if !slashed {
-                    // Unlike `get_unslashed_attesting_indices` in Phase 0,
-                    // `get_unslashed_participating_indices` in Altair checks if validators were active.
-                    // There doesn't seem to be a way for a validator that's not active to attest in
-                    // normal operation, but some test cases in `consensus-spec-tests` cover the check.
+            if !slashed {
+                // Unlike `get_unslashed_attesting_indices` in Phase 0,
+                // `get_unslashed_participating_indices` in Altair checks if validators were active.
+                // There doesn't seem to be a way for a validator that's not active to attest in
+                // normal operation, but some test cases in `consensus-spec-tests` cover the check.
 
-                    if active_in_previous_epoch {
-                        if participation.previous_epoch_matching_source() {
-                            statistics.previous_epoch_source_participating_balance = statistics
-                                .previous_epoch_source_participating_balance
-                                .try_add(effective_balance)?;
-                        }
-
-                        if participation.previous_epoch_matching_target() {
-                            statistics.previous_epoch_target_participating_balance = statistics
-                                .previous_epoch_target_participating_balance
-                                .try_add(effective_balance)?;
-                        }
-
-                        if participation.previous_epoch_matching_head() {
-                            statistics.previous_epoch_head_participating_balance = statistics
-                                .previous_epoch_head_participating_balance
-                                .try_add(effective_balance)?;
-                        }
+                if active_in_previous_epoch {
+                    if participation.previous_epoch_matching_source() {
+                        statistics.previous_epoch_source_participating_balance = statistics
+                            .previous_epoch_source_participating_balance
+                            .try_add(effective_balance)?;
                     }
 
-                    if active_in_current_epoch && participation.current_epoch_matching_target() {
-                        statistics.current_epoch_target_participating_balance = statistics
-                            .current_epoch_target_participating_balance
+                    if participation.previous_epoch_matching_target() {
+                        statistics.previous_epoch_target_participating_balance = statistics
+                            .previous_epoch_target_participating_balance
+                            .try_add(effective_balance)?;
+                    }
+
+                    if participation.previous_epoch_matching_head() {
+                        statistics.previous_epoch_head_participating_balance = statistics
+                            .previous_epoch_head_participating_balance
                             .try_add(effective_balance)?;
                     }
                 }
 
-                Ok(AltairValidatorSummary {
-                    effective_balance,
-                    slashed,
-                    withdrawable_epoch,
-                    active_in_previous_epoch,
-                    eligible_for_penalties,
-                })
-            },
-        )
-        .collect::<Result<Vec<_>>>()?;
+                if active_in_current_epoch && participation.current_epoch_matching_target() {
+                    statistics.current_epoch_target_participating_balance = statistics
+                        .current_epoch_target_participating_balance
+                        .try_add(effective_balance)?;
+                }
+            }
+
+            Ok(AltairValidatorSummary {
+                effective_balance,
+                slashed,
+                withdrawable_epoch,
+                active_in_previous_epoch,
+                eligible_for_penalties,
+            })
+        },
+    )
+    .collect::<Result<Vec<_>>>()?;
 
     statistics.clamp_balances::<P>();
 
@@ -275,50 +272,54 @@ pub fn statistics<P: Preset, S: PostAltairBeaconState<P>>(state: &S) -> Result<S
 
     let mut statistics = Statistics::default();
 
-    state
-        .validators()
-        .into_iter()
-        .zip(state.previous_epoch_participation())
-        .zip(state.current_epoch_participation())
-        .filter(|((validator, _), _)| !validator.slashed)
-        .try_for_each(
-            |((validator, previous_epoch_participation), current_epoch_participation)| {
-                let active_in_previous_epoch = is_active_validator(validator, previous_epoch);
-                let active_in_current_epoch = is_active_validator(validator, current_epoch);
+    izip!(
+        state.validators().partial_validators(),
+        state.validators().effective_balances().copied(),
+        state.previous_epoch_participation(),
+        state.current_epoch_participation(),
+    )
+    .filter(|(validator, _, _, _)| !validator.slashed)
+    .try_for_each(
+        |(
+            validator,
+            effective_balance,
+            previous_epoch_participation,
+            current_epoch_participation,
+        )| {
+            let active_in_previous_epoch = is_active_validator(validator, previous_epoch);
+            let active_in_current_epoch = is_active_validator(validator, current_epoch);
 
-                let effective_balance = validator.effective_balance;
-
-                if active_in_previous_epoch {
-                    if previous_epoch_participation.get_bit(TIMELY_SOURCE_FLAG_INDEX) {
-                        statistics.previous_epoch_source_participating_balance = statistics
-                            .previous_epoch_source_participating_balance
-                            .try_add(effective_balance)?;
-                    }
-
-                    if previous_epoch_participation.get_bit(TIMELY_TARGET_FLAG_INDEX) {
-                        statistics.previous_epoch_target_participating_balance = statistics
-                            .previous_epoch_target_participating_balance
-                            .try_add(effective_balance)?;
-                    }
-
-                    if previous_epoch_participation.get_bit(TIMELY_HEAD_FLAG_INDEX) {
-                        statistics.previous_epoch_head_participating_balance = statistics
-                            .previous_epoch_head_participating_balance
-                            .try_add(effective_balance)?;
-                    }
-                }
-
-                if active_in_current_epoch
-                    && current_epoch_participation.get_bit(TIMELY_TARGET_FLAG_INDEX)
-                {
-                    statistics.current_epoch_target_participating_balance = statistics
-                        .current_epoch_target_participating_balance
+            if active_in_previous_epoch {
+                if previous_epoch_participation.get_bit(TIMELY_SOURCE_FLAG_INDEX) {
+                    statistics.previous_epoch_source_participating_balance = statistics
+                        .previous_epoch_source_participating_balance
                         .try_add(effective_balance)?;
                 }
 
-                Ok::<(), Error>(())
-            },
-        )?;
+                if previous_epoch_participation.get_bit(TIMELY_TARGET_FLAG_INDEX) {
+                    statistics.previous_epoch_target_participating_balance = statistics
+                        .previous_epoch_target_participating_balance
+                        .try_add(effective_balance)?;
+                }
+
+                if previous_epoch_participation.get_bit(TIMELY_HEAD_FLAG_INDEX) {
+                    statistics.previous_epoch_head_participating_balance = statistics
+                        .previous_epoch_head_participating_balance
+                        .try_add(effective_balance)?;
+                }
+            }
+
+            if active_in_current_epoch
+                && current_epoch_participation.get_bit(TIMELY_TARGET_FLAG_INDEX)
+            {
+                statistics.current_epoch_target_participating_balance = statistics
+                    .current_epoch_target_participating_balance
+                    .try_add(effective_balance)?;
+            }
+
+            Ok::<(), Error>(())
+        },
+    )?;
 
     statistics.clamp_balances::<P>();
 

--- a/transition_functions/src/altair/epoch_processing.rs
+++ b/transition_functions/src/altair/epoch_processing.rs
@@ -292,7 +292,8 @@ fn process_slashings<P: Preset, S: SlashingPenalties>(
 
 pub fn process_participation_flag_updates<P: Preset>(state: &mut impl PostAltairBeaconState<P>) {
     // > Rotate current/previous epoch participation
-    let zero_participation = PersistentList::repeat_zero_with_length_of(state.validators());
+    let zero_participation = PersistentList::repeat_zero(state.validators().len_usize())
+        .expect("validator list and participation lists have the same maximum length");
 
     *state.previous_epoch_participation_mut() =
         core::mem::replace(state.current_epoch_participation_mut(), zero_participation);

--- a/transition_functions/src/capella/block_processing.rs
+++ b/transition_functions/src/capella/block_processing.rs
@@ -369,7 +369,7 @@ pub fn process_bls_to_execution_change<P: Preset>(
 
     let validator = state
         .validators_mut()
-        .get_mut(address_change.validator_index)?;
+        .partial_validator_mut(address_change.validator_index)?;
 
     validator.withdrawal_credentials =
         misc::eth1_address_withdrawal_credentials(address_change.to_execution_address);
@@ -478,7 +478,8 @@ pub fn get_expected_withdrawals<P: Preset>(
 
     for _ in 0..bound {
         let balance = state.balances().get(validator_index).copied()?;
-        let validator = state.validators().get(validator_index)?;
+        let validator = state.validators().partial_validator(validator_index)?;
+        let validator_effective_balance = state.validators().effective_balance(validator_index)?;
 
         let address = validator
             .withdrawal_credentials
@@ -497,7 +498,11 @@ pub fn get_expected_withdrawals<P: Preset>(
             withdrawal_index = withdrawal_index
                 .checked_add(1)
                 .ok_or(Error::<P>::WithdrawalIndexOverflow)?;
-        } else if is_partially_withdrawable_validator::<P>(validator, balance) {
+        } else if is_partially_withdrawable_validator::<P>(
+            validator,
+            validator_effective_balance,
+            balance,
+        ) {
             withdrawals.push(Withdrawal {
                 index: withdrawal_index,
                 validator_index,

--- a/transition_functions/src/deneb/epoch_processing.rs
+++ b/transition_functions/src/deneb/epoch_processing.rs
@@ -154,13 +154,18 @@ fn process_registry_updates<P: Preset>(
     let mut ejections = vec![];
     let mut activation_queue = vec![];
 
-    for (validator, validator_index) in state.validators().into_iter().zip(0..) {
-        if is_eligible_for_activation_queue::<P>(validator) {
+    for ((validator, &effective_balance), validator_index) in state
+        .validators()
+        .partial_validators()
+        .zip(state.validators.effective_balances())
+        .zip(0..)
+    {
+        if is_eligible_for_activation_queue::<P>(validator, effective_balance) {
             eligible_for_activation_queue.push(validator_index);
         }
 
         if is_active_validator(validator, current_epoch)
-            && validator.effective_balance <= config.ejection_balance
+            && effective_balance <= config.ejection_balance
         {
             ejections.push(validator_index);
         }
@@ -174,7 +179,7 @@ fn process_registry_updates<P: Preset>(
     for validator_index in eligible_for_activation_queue {
         state
             .validators_mut()
-            .get_mut(validator_index)?
+            .partial_validator_mut(validator_index)?
             .activation_eligibility_epoch = next_epoch;
     }
 
@@ -186,7 +191,7 @@ fn process_registry_updates<P: Preset>(
         // `process_slashings` depends on `Validator.withdrawable_epoch`,
         // which may have been modified by `initiate_validator_exit`.
         // However, no test cases in `consensus-spec-tests` fail if this is absent.
-        summaries[index].update_from(state.validators().get(validator_index)?);
+        summaries[index].update_from(&state.validators().get(validator_index)?);
     }
 
     // > Queue validators eligible for activation and not yet dequeued for activation
@@ -206,7 +211,7 @@ fn process_registry_updates<P: Preset>(
     for validator_index in activation_queue.into_iter().take(churn_limit) {
         state
             .validators_mut()
-            .get_mut(validator_index)?
+            .partial_validator_mut(validator_index)?
             .activation_epoch = activation_exit_epoch;
     }
 

--- a/transition_functions/src/electra/block_processing.rs
+++ b/transition_functions/src/electra/block_processing.rs
@@ -65,6 +65,7 @@ use types::{
             Validator,
         },
         primitives::{DepositIndex, ExecutionAddress, Gwei, H256, ValidatorIndex},
+        validator_list::PartialValidator,
     },
     preset::Preset,
     traits::{
@@ -367,7 +368,8 @@ pub fn get_expected_withdrawals<P: Preset>(
 
     // > Sweep for remaining
     for _ in 0..bound {
-        let validator = state.validators().get(validator_index)?;
+        let validator = state.validators().partial_validator(validator_index)?;
+        let validator_effective_balance = state.validators().effective_balance(validator_index)?;
 
         let partially_withdrawn_balance = withdrawals
             .iter()
@@ -398,7 +400,11 @@ pub fn get_expected_withdrawals<P: Preset>(
             withdrawal_index = withdrawal_index
                 .checked_add(1)
                 .ok_or(Error::<P>::WithdrawalIndexOverflow)?;
-        } else if is_partially_withdrawable_validator::<P>(validator, balance) {
+        } else if is_partially_withdrawable_validator::<P>(
+            validator,
+            validator_effective_balance,
+            balance,
+        ) {
             withdrawals.push(Withdrawal {
                 index: withdrawal_index,
                 validator_index,
@@ -906,7 +912,7 @@ pub fn add_validator_to_registry<P: Preset>(
         withdrawable_epoch: FAR_FUTURE_EPOCH,
     };
 
-    let max_effective_balance = get_max_effective_balance::<P>(&validator);
+    let max_effective_balance = get_max_effective_balance::<P>(&(&validator).into());
 
     validator.effective_balance = amount
         .prev_multiple_of(P::EFFECTIVE_BALANCE_INCREMENT)
@@ -1091,7 +1097,8 @@ pub fn process_withdrawal_request<P: Preset>(
         return Ok(());
     };
     let validator_balance = *balance(state, validator_index)?;
-    let validator = state.validators().get(validator_index)?;
+    let validator = state.validators().partial_validator(validator_index)?;
+    let validator_effective_balance = state.validators().effective_balance(validator_index)?;
 
     // > Verify withdrawal credentials
     let has_correct_credential = has_execution_withdrawal_credential(validator);
@@ -1137,7 +1144,7 @@ pub fn process_withdrawal_request<P: Preset>(
         return Ok(());
     }
 
-    let has_sufficient_effective_balance = validator.effective_balance >= P::MIN_ACTIVATION_BALANCE;
+    let has_sufficient_effective_balance = validator_effective_balance >= P::MIN_ACTIVATION_BALANCE;
     let has_excess_balance =
         validator_balance > P::MIN_ACTIVATION_BALANCE.try_add(pending_balance_to_withdraw)?;
 
@@ -1242,8 +1249,8 @@ pub fn process_consolidation_request<P: Preset>(
         return Ok(());
     };
 
-    let source_validator = state.validators().get(source_index)?;
-    let target_validator = state.validators().get(target_index)?;
+    let source_validator = state.validators().partial_validator(source_index)?;
+    let target_validator = state.validators().partial_validator(target_index)?;
 
     // > Verify source withdrawal credentials
     let has_correct_credential = has_execution_withdrawal_credential(source_validator);
@@ -1275,8 +1282,6 @@ pub fn process_consolidation_request<P: Preset>(
         return Ok(());
     }
 
-    let source_validator = state.validators().get(source_index)?;
-
     // > Verify the source has been active long enough
     if current_epoch
         < source_validator
@@ -1292,13 +1297,11 @@ pub fn process_consolidation_request<P: Preset>(
     }
 
     // > Initiate source validator exit and append pending consolidation
-    let exit_epoch = compute_consolidation_epoch_and_update_churn(
-        config,
-        state,
-        source_validator.effective_balance,
-    )?;
+    let source_effective_balance = state.validators().effective_balance(source_index)?;
+    let exit_epoch =
+        compute_consolidation_epoch_and_update_churn(config, state, source_effective_balance)?;
 
-    let source_validator = state.validators_mut().get_mut(source_index)?;
+    let source_validator = state.validators_mut().partial_validator_mut(source_index)?;
 
     source_validator.exit_epoch = exit_epoch;
     source_validator.withdrawable_epoch = source_validator
@@ -1335,7 +1338,7 @@ fn is_valid_switch_to_compounding_request<P: Preset>(
         return Ok(false);
     };
 
-    let source_validator = state.validators().get(source_index)?;
+    let source_validator = state.validators().partial_validator(source_index)?;
 
     // > Verify request has been authorized
     if compute_source_address(source_validator) != source_address {
@@ -1362,7 +1365,7 @@ fn is_valid_switch_to_compounding_request<P: Preset>(
     Ok(true)
 }
 
-fn compute_source_address(validator: &Validator) -> ExecutionAddress {
+fn compute_source_address(validator: &PartialValidator) -> ExecutionAddress {
     ExecutionAddress::from_slice(&validator.withdrawal_credentials[PREFIX_LEN..])
 }
 

--- a/transition_functions/src/electra/block_processing.rs
+++ b/transition_functions/src/electra/block_processing.rs
@@ -899,8 +899,6 @@ pub fn add_validator_to_registry<P: Preset>(
     withdrawal_credentials: H256,
     amount: Gwei,
 ) -> Result<()> {
-    let validator_index = state.validators().len_u64();
-
     let mut validator = Validator {
         pubkey,
         withdrawal_credentials,
@@ -923,16 +921,6 @@ pub fn add_validator_to_registry<P: Preset>(
     state.previous_epoch_participation_mut().push(0)?;
     state.current_epoch_participation_mut().push(0)?;
     state.inactivity_scores_mut().push(0)?;
-
-    state
-        .cache_mut()
-        .validator_indices
-        .get_mut()
-        .expect(
-            "state.cache.validator_indices is initialized by \
-                index_of_public_key, which is called before apply_deposits",
-        )
-        .insert(pubkey, validator_index);
 
     Ok(())
 }

--- a/transition_functions/src/electra/epoch_processing.rs
+++ b/transition_functions/src/electra/epoch_processing.rs
@@ -26,7 +26,7 @@ use types::{
     electra::{beacon_state::BeaconState as ElectraBeaconState, containers::PendingDeposit},
     phase0::{
         consts::{FAR_FUTURE_EPOCH, GENESIS_SLOT},
-        containers::{DepositMessage, Validator},
+        containers::DepositMessage,
         primitives::Gwei,
     },
     preset::Preset,
@@ -177,13 +177,18 @@ pub fn process_registry_updates<P: Preset>(
     let mut ejections = vec![];
     let mut activation_queue = vec![];
 
-    for (validator, validator_index) in state.validators().into_iter().zip(0..) {
-        if is_eligible_for_activation_queue::<P>(validator) {
+    for ((validator, &effective_balance), validator_index) in state
+        .validators()
+        .partial_validators()
+        .zip(state.validators().effective_balances())
+        .zip(0..)
+    {
+        if is_eligible_for_activation_queue::<P>(validator, effective_balance) {
             eligible_for_activation_queue.push(validator_index);
         }
 
         if is_active_validator(validator, current_epoch)
-            && validator.effective_balance <= config.ejection_balance
+            && effective_balance <= config.ejection_balance
         {
             ejections.push(validator_index);
         }
@@ -197,7 +202,7 @@ pub fn process_registry_updates<P: Preset>(
     for validator_index in eligible_for_activation_queue {
         state
             .validators_mut()
-            .get_mut(validator_index)?
+            .partial_validator_mut(validator_index)?
             .activation_eligibility_epoch = next_epoch;
     }
 
@@ -209,7 +214,7 @@ pub fn process_registry_updates<P: Preset>(
         // `process_slashings` depends on `Validator.withdrawable_epoch`,
         // which may have been modified by `initiate_validator_exit`.
         // However, no test cases in `consensus-spec-tests` fail if this is absent.
-        summaries[index].update_from(state.validators().get(validator_index)?);
+        summaries[index].update_from(&state.validators().get(validator_index)?);
     }
 
     // > Activate all eligible validators
@@ -221,7 +226,7 @@ pub fn process_registry_updates<P: Preset>(
     {
         state
             .validators_mut()
-            .get_mut(validator_index)?
+            .partial_validator_mut(validator_index)?
             .activation_epoch = activation_exit_epoch;
     }
 
@@ -270,7 +275,7 @@ pub fn process_pending_deposits<P: Preset>(
         let mut is_validator_withdrawn = false;
 
         if let Some(validator_index) = accessors::index_of_public_key(state, &deposit.pubkey) {
-            let validator = state.validators().get(validator_index)?;
+            let validator = state.validators().partial_validator(validator_index)?;
 
             is_validator_exited = validator.exit_epoch < FAR_FUTURE_EPOCH;
             is_validator_withdrawn = validator.withdrawable_epoch < next_epoch;
@@ -437,39 +442,24 @@ pub fn process_effective_balance_updates<P: Preset>(
     // packed into bundles of 8.
     let mut balances = balances.into_iter().copied();
 
-    let mut update_result: Result<()> = Ok(());
-
-    let mut update_effective_balance = |validator: &mut Validator| -> Result<()> {
+    validators.update_effective_balances(|validator, effective_balance| -> Result<Gwei> {
         let max_effective_balance = get_max_effective_balance::<P>(validator);
 
         let balance = balances
             .next()
             .expect("list of validators and list of balances should have the same length");
 
-        let below = balance.try_add(downward_threshold)? < validator.effective_balance;
-        let above = validator.effective_balance.try_add(upward_threshold)? < balance;
+        let below = balance.try_add(downward_threshold)? < effective_balance;
+        let above = effective_balance.try_add(upward_threshold)? < balance;
 
         if below || above {
-            validator.effective_balance = balance
+            return Ok(balance
                 .prev_multiple_of(P::EFFECTIVE_BALANCE_INCREMENT)
-                .min(max_effective_balance);
+                .min(max_effective_balance));
         }
 
-        Ok(())
-    };
-
-    // > Update effective balances with hysteresis
-    validators.update(|validator| {
-        if update_result.is_err() {
-            return;
-        }
-
-        update_result = update_effective_balance(validator);
-    });
-
-    update_result?;
-
-    Ok(())
+        Ok(effective_balance)
+    })
 }
 
 fn process_historical_summaries_update<P: Preset>(state: &mut ElectraBeaconState<P>) -> Result<()> {

--- a/transition_functions/src/gloas/block_processing.rs
+++ b/transition_functions/src/gloas/block_processing.rs
@@ -391,7 +391,8 @@ fn process_validators_sweep_withdrawals<P: Preset>(
             break;
         }
 
-        let validator = state.validators().get(validator_index)?;
+        let validator = state.validators().partial_validator(validator_index)?;
+        let validator_effective_balance = state.validators().effective_balance(validator_index)?;
 
         let partially_withdrawn_balance = withdrawals
             .iter()
@@ -422,7 +423,11 @@ fn process_validators_sweep_withdrawals<P: Preset>(
             *withdrawal_index = withdrawal_index
                 .checked_add(1)
                 .ok_or(Error::<P>::WithdrawalIndexOverflow)?;
-        } else if is_partially_withdrawable_validator::<P>(validator, balance) {
+        } else if is_partially_withdrawable_validator::<P>(
+            validator,
+            validator_effective_balance,
+            balance,
+        ) {
             withdrawals.push(Withdrawal {
                 index: *withdrawal_index,
                 validator_index,
@@ -877,7 +882,7 @@ pub fn apply_attestation<P: Preset>(
         .into_iter()
         .map(|validator_index| {
             let base_reward = get_base_reward(state, validator_index, base_reward_per_increment)?;
-            let effective_balance = state.validators().get(validator_index)?.effective_balance;
+            let effective_balance = state.validators().effective_balance(validator_index)?;
             Ok((validator_index, base_reward, effective_balance))
         })
         .collect::<Result<Vec<_>>>()?;

--- a/transition_functions/src/gloas/execution_payload_processing.rs
+++ b/transition_functions/src/gloas/execution_payload_processing.rs
@@ -14,6 +14,7 @@ use helper_functions::{
 };
 use pubkey_cache::PubkeyCache;
 use ssz::SszHash as _;
+use std_ext::CopyExt as _;
 use types::{
     combined::ExecutionPayloadParams,
     config::Config,
@@ -43,7 +44,7 @@ pub fn verify_execution_payload_envelope_signature<P: Preset>(
     let builder_index = signed_envelope.message.builder_index;
     let pubkey = if builder_index == BUILDER_INDEX_SELF_BUILD {
         let validator_index = state.latest_block_header().proposer_index;
-        state.validators().get(validator_index)?.pubkey
+        state.validators().pubkey(validator_index)?.copy()
     } else {
         state.builders().get(builder_index)?.pubkey
     };

--- a/transition_functions/src/phase0/block_processing.rs
+++ b/transition_functions/src/phase0/block_processing.rs
@@ -432,16 +432,6 @@ fn apply_deposits<P: Preset>(
                 state.validators.push(validator)?;
                 state.balances.push(total_amount)?;
 
-                state
-                    .cache
-                    .validator_indices
-                    .get_mut()
-                    .expect(
-                        "state.cache.validator_indices is initialized by \
-                         index_of_public_key, which is called before apply_deposits",
-                    )
-                    .insert(pubkey, validator_index);
-
                 for amount in amounts {
                     slot_report.add_deposit(validator_index, amount);
                 }

--- a/transition_functions/src/phase0/epoch_intermediates.rs
+++ b/transition_functions/src/phase0/epoch_intermediates.rs
@@ -43,7 +43,7 @@ pub trait Statistics: Copy + Default {
     fn accumulate_validator(
         &mut self,
         active_in_current_epoch: bool,
-        validator: &Validator,
+        effective_balance: Gwei,
     ) -> Result<()>;
 
     fn accumulate_previous_epoch_attestation(
@@ -143,12 +143,12 @@ impl Statistics for StatisticsForTransition {
     fn accumulate_validator(
         &mut self,
         active_in_current_epoch: bool,
-        validator: &Validator,
+        effective_balance: Gwei,
     ) -> Result<()> {
         if active_in_current_epoch {
             self.current_epoch_active_balance = self
                 .current_epoch_active_balance
-                .try_add(validator.effective_balance)?;
+                .try_add(effective_balance)?;
         }
         Ok(())
     }
@@ -279,12 +279,12 @@ impl Statistics for StatisticsForReport {
     fn accumulate_validator(
         &mut self,
         active_in_current_epoch: bool,
-        validator: &Validator,
+        effective_balance: Gwei,
     ) -> Result<()> {
         if active_in_current_epoch {
             self.current_epoch_active_balance = self
                 .current_epoch_active_balance
-                .try_add(validator.effective_balance)?;
+                .try_add(effective_balance)?;
         }
         Ok(())
     }
@@ -628,19 +628,16 @@ pub fn statistics_and_summaries<P: Preset, S: Statistics>(
 
     let summaries = state
         .validators
-        .into_iter()
-        .map(|validator| {
-            let Validator {
-                effective_balance,
-                slashed,
-                withdrawable_epoch,
-                ..
-            } = *validator;
+        .partial_validators()
+        .zip(state.validators.effective_balances())
+        .map(|(validator, &effective_balance)| {
+            let slashed = validator.slashed;
+            let withdrawable_epoch = validator.withdrawable_epoch;
 
             let active_in_current_epoch = is_active_validator(validator, current_epoch);
             let eligible_for_penalties = is_eligible_for_penalties(validator, previous_epoch)?;
 
-            statistics.accumulate_validator(active_in_current_epoch, validator)?;
+            statistics.accumulate_validator(active_in_current_epoch, effective_balance)?;
 
             Ok(Phase0ValidatorSummary {
                 effective_balance,

--- a/transition_functions/src/unphased/block_processing.rs
+++ b/transition_functions/src/unphased/block_processing.rs
@@ -139,7 +139,7 @@ pub fn process_block_header<P: Preset>(
 
     // > Verify proposer is not slashed
     let index = block.proposer_index();
-    let proposer = state.validators().get(index)?;
+    let proposer = state.validators().partial_validator(index)?;
 
     ensure!(!proposer.slashed, Error::<P>::ProposerSlashed { index });
 
@@ -159,7 +159,7 @@ pub fn process_randao<P: Preset>(
 
     // > Verify RANDAO reveal
     let proposer_index = get_beacon_proposer_index(config, state)?;
-    let public_key = &state.validators().get(proposer_index)?.pubkey;
+    let public_key = state.validators().pubkey(proposer_index)?;
 
     if !verifier.has_option(VerifierOption::SkipRandaoVerification) {
         verifier.verify_singular(
@@ -260,13 +260,14 @@ pub fn validate_proposer_slashing_with_verifier<P: Preset>(
 
     // > Verify the proposer is slashable
     let index = header_1.proposer_index;
-    let proposer = state.validators().get(index)?;
+    let proposer = state.validators().partial_validator(index)?;
+    let proposer_pubkey = state.validators().pubkey(index)?;
 
     ensure!(
         is_slashable_validator(proposer, get_current_epoch(state)),
         Error::<P>::ProposerNotSlashable {
             index,
-            proposer: proposer.clone(),
+            proposer: state.validators().get(index)?,
         },
     );
 
@@ -278,7 +279,7 @@ pub fn validate_proposer_slashing_with_verifier<P: Preset>(
         verifier.verify_singular(
             signed_header.message.signing_root(config, state),
             signed_header.signature,
-            pubkey_cache.get_or_insert(proposer.pubkey)?,
+            pubkey_cache.get_or_insert(*proposer_pubkey)?,
             SignatureKind::Block,
         )?;
     }
@@ -335,7 +336,7 @@ pub fn validate_attester_slashing_with_verifier<P: Preset>(
         .filter(|attester_index| {
             let attester = state
                 .validators()
-                .get(*attester_index)
+                .partial_validator(*attester_index)
                 .expect("attester indices are validated in validate_received_indexed_attestation");
 
             is_slashable_validator(attester, current_epoch)
@@ -637,7 +638,8 @@ pub fn validate_voluntary_exit_with_verifier<P: Preset>(
 ) -> Result<()> {
     let voluntary_exit = signed_voluntary_exit.message;
     let index = voluntary_exit.validator_index;
-    let validator = state.validators().get(index)?;
+    let validator = state.validators().partial_validator(index)?;
+    let validator_pubkey = state.validators().pubkey(index)?;
     let current_epoch = get_current_epoch(state);
 
     // > Verify the validator is active
@@ -645,7 +647,7 @@ pub fn validate_voluntary_exit_with_verifier<P: Preset>(
         is_active_validator(validator, current_epoch),
         Error::<P>::ValidatorNotActive {
             index,
-            validator: validator.clone(),
+            validator: state.validators().get(index)?,
             current_epoch,
         },
     );
@@ -685,7 +687,7 @@ pub fn validate_voluntary_exit_with_verifier<P: Preset>(
     verifier.verify_singular(
         voluntary_exit.signing_root(config, state),
         signed_voluntary_exit.signature,
-        pubkey_cache.get_or_insert(validator.pubkey)?,
+        pubkey_cache.get_or_insert(*validator_pubkey)?,
         SignatureKind::VoluntaryExit,
     )?;
 

--- a/transition_functions/src/unphased/epoch_processing.rs
+++ b/transition_functions/src/unphased/epoch_processing.rs
@@ -19,7 +19,7 @@ use types::{
     nonstandard::AttestationEpoch,
     phase0::{
         consts::GENESIS_EPOCH,
-        containers::{Checkpoint, HistoricalBatch, Validator},
+        containers::{Checkpoint, HistoricalBatch},
         primitives::{Gwei, ValidatorIndex},
     },
     preset::Preset,
@@ -94,13 +94,18 @@ pub fn process_registry_updates<P: Preset>(
     let mut ejections = vec![];
     let mut activation_queue = vec![];
 
-    for (validator, validator_index) in state.validators().into_iter().zip(0..) {
-        if is_eligible_for_activation_queue::<P>(validator) {
+    for ((validator, &effective_balance), validator_index) in state
+        .validators()
+        .partial_validators()
+        .zip(state.validators().effective_balances())
+        .zip(0..)
+    {
+        if is_eligible_for_activation_queue::<P>(validator, effective_balance) {
             eligible_for_activation_queue.push(validator_index);
         }
 
         if is_active_validator(validator, current_epoch)
-            && validator.effective_balance <= config.ejection_balance
+            && effective_balance <= config.ejection_balance
         {
             ejections.push(validator_index);
         }
@@ -114,7 +119,7 @@ pub fn process_registry_updates<P: Preset>(
     for validator_index in eligible_for_activation_queue {
         state
             .validators_mut()
-            .get_mut(validator_index)?
+            .partial_validator_mut(validator_index)?
             .activation_eligibility_epoch = next_epoch;
     }
 
@@ -126,7 +131,7 @@ pub fn process_registry_updates<P: Preset>(
         // `process_slashings` depends on `Validator.withdrawable_epoch`,
         // which may have been modified by `initiate_validator_exit`.
         // However, no test cases in `consensus-spec-tests` fail if this is absent.
-        summaries[index].update_from(state.validators().get(validator_index)?);
+        summaries[index].update_from(&state.validators().get(validator_index)?);
     }
 
     // > Queue validators eligible for activation and not yet dequeued for activation
@@ -146,7 +151,7 @@ pub fn process_registry_updates<P: Preset>(
     for validator_index in activation_queue.into_iter().take(churn_limit) {
         state
             .validators_mut()
-            .get_mut(validator_index)?
+            .partial_validator_mut(validator_index)?
             .activation_epoch = activation_exit_epoch;
     }
 
@@ -176,35 +181,23 @@ pub fn process_effective_balance_updates<P: Preset>(state: &mut impl BeaconState
     // The reason why the speedup is so small is likely because values in the balance tree are
     // packed into bundles of 8.
     let mut balances = balances.into_iter().copied();
-    let mut update_result: Result<()> = Ok(());
 
-    let mut update_balances = |validator: &mut Validator| -> Result<()> {
+    validators.update_effective_balances(|_, effective_balance| -> Result<Gwei> {
         let balance = balances
             .next()
             .expect("list of validators and list of balances should have the same length");
 
-        let below = balance.try_add(downward_threshold)? < validator.effective_balance;
-        let above = validator.effective_balance.try_add(upward_threshold)? < balance;
+        let below = balance.try_add(downward_threshold)? < effective_balance;
+        let above = effective_balance.try_add(upward_threshold)? < balance;
 
         if below || above {
-            validator.effective_balance = balance
+            return Ok(balance
                 .prev_multiple_of(P::EFFECTIVE_BALANCE_INCREMENT)
-                .min(P::MAX_EFFECTIVE_BALANCE);
+                .min(P::MAX_EFFECTIVE_BALANCE));
         }
 
-        Ok(())
-    };
-
-    // > Update effective balances with hysteresis
-    validators.update(|validator| {
-        if update_result.is_err() {
-            return;
-        }
-
-        update_result = update_balances(validator);
-    });
-
-    update_result
+        Ok(effective_balance)
+    })
 }
 
 pub fn process_slashings_reset<P: Preset>(state: &mut impl BeaconState<P>) -> Result<()> {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -33,6 +33,7 @@ static_assertions = { workspace = true }
 std_ext = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
+try_from_iterator = { workspace = true }
 typenum = { workspace = true }
 url = { workspace = true }
 variant_count = { workspace = true }

--- a/types/src/cache.rs
+++ b/types/src/cache.rs
@@ -1,14 +1,9 @@
 use core::{iter::FusedIterator, ops::Range, slice::Iter};
 use std::sync::Arc;
 
-use bls::PublicKeyBytes;
 use duplicate::duplicate;
 use enum_map::EnumMap;
-#[cfg(not(target_os = "zkvm"))]
-use im::HashMap;
 use once_cell::sync::OnceCell;
-#[cfg(target_os = "zkvm")]
-use std::collections::HashMap;
 
 use crate::{
     altair::primitives::NonZeroGwei,
@@ -35,7 +30,6 @@ pub struct Cache {
     pub active_validator_indices_ordered: EnumMap<RelativeEpoch, OnceCell<PackedIndices>>,
     pub active_validator_indices_shuffled: EnumMap<RelativeEpoch, OnceCell<PackedIndices>>,
     pub total_active_balance: EnumMap<RelativeEpoch, OnceCell<NonZeroGwei>>,
-    pub validator_indices: OnceCell<HashMap<PublicKeyBytes, ValidatorIndex>>,
     /// PTC cache: previous, current, and next slot.
     /// Shifted in `advance_slot()`: Previous <- Current <- Next.
     pub ptc_cache: EnumMap<RelativeSlot, OnceCell<Vec<ValidatorIndex>>>,

--- a/types/src/collections.rs
+++ b/types/src/collections.rs
@@ -18,8 +18,9 @@ use crate::{
     electra::containers::{PendingConsolidation, PendingDeposit, PendingPartialWithdrawal},
     gloas::containers::{Builder, BuilderPendingPayment, BuilderPendingWithdrawal},
     phase0::{
-        containers::{Eth1Data, PendingAttestation, Validator},
+        containers::{Eth1Data, PendingAttestation},
         primitives::{Gwei, H256, ValidatorIndex},
+        validator_list::ValidatorList,
     },
     preset::{
         BuilderPendingPaymentsLength, MaxAttestationsPerEpoch, Preset, ProposerLookaheadLength,
@@ -35,7 +36,7 @@ pub type HistoricalRoots<P> =
 
 pub type Eth1DataVotes<P> = PersistentList<Eth1Data, SlotsPerEth1VotingPeriod<P>>;
 
-pub type Validators<P> = PersistentList<Validator, <P as Preset>::ValidatorRegistryLimit>;
+pub type Validators<P> = ValidatorList<<P as Preset>::ValidatorRegistryLimit>;
 
 pub type Balances<P> =
     PersistentList<Gwei, <P as Preset>::ValidatorRegistryLimit, UnhashedBundleSize<Gwei>>;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod phase0 {
     pub mod consts;
     pub mod containers;
     pub mod primitives;
+    pub mod validator_list;
 
     mod container_impls;
 

--- a/types/src/phase0/validator_list.rs
+++ b/types/src/phase0/validator_list.rs
@@ -6,7 +6,7 @@ use arithmetic::{NonZeroExt as _, U64Ext as _};
 use bls::PublicKeyBytes;
 use derivative::Derivative;
 #[cfg(not(target_os = "zkvm"))]
-use im::{Vector, vector::Iter as VectorIter};
+use im::{HashMap, Vector, vector::Iter as VectorIter};
 use once_cell::race::OnceBox;
 use serde::{
     Deserialize, Serialize,
@@ -17,14 +17,14 @@ use ssz::{
     SszSize, SszWrite, U1, hashing, mix_in_length, read_list, saturating_usize, write_list,
 };
 #[cfg(target_os = "zkvm")]
-use std::{slice::Iter as VectorIter, vec::Vec as Vector};
+use std::{collections::HashMap, slice::Iter as VectorIter, vec::Vec as Vector};
 use std_ext::CopyExt;
 use try_from_iterator::TryFromIterator;
 use typenum::Unsigned;
 
 use crate::phase0::{
     containers::Validator,
-    primitives::{Epoch, Gwei},
+    primitives::{Epoch, Gwei, ValidatorIndex},
 };
 
 #[cfg(target_os = "zkvm")]
@@ -69,12 +69,164 @@ impl From<&Validator> for PartialValidator {
     }
 }
 
+/// Validator public keys together with a public key -> index map.
+#[derive(Clone, Debug, Default, Derivative)]
+#[derivative(PartialEq(bound = ""), Eq(bound = ""))]
+pub struct PubkeyList<N: Unsigned> {
+    keys: Vector<PublicKeyBytes>,
+
+    #[derivative(PartialEq = "ignore")]
+    index_map: HashMap<PublicKeyBytes, ValidatorIndex>,
+
+    phantom: PhantomData<N>,
+}
+
+impl<N: Unsigned> PubkeyList<N> {
+    #[must_use]
+    pub fn index_of(&self, pubkey: &PublicKeyBytes) -> Option<ValidatorIndex> {
+        let index = self.index_map.get(pubkey).copied()?;
+        let in_bounds = usize::try_from(index).is_ok_and(|index| index < self.keys.len());
+        in_bounds.then_some(index)
+    }
+
+    #[must_use]
+    pub fn contains(&self, pubkey: &PublicKeyBytes) -> bool {
+        self.index_of(pubkey).is_some()
+    }
+
+    fn get(&self, index: usize) -> Option<&PublicKeyBytes> {
+        self.keys.get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    #[must_use]
+    pub fn iter(&self) -> VectorIter<'_, PublicKeyBytes> {
+        self.keys.iter()
+    }
+
+    pub fn push(&mut self, pubkey: PublicKeyBytes) {
+        let index = ValidatorIndex::try_from(self.keys.len())
+            .expect("validator count never exceeds ValidatorIndex range");
+
+        self.keys.push_back(pubkey);
+        self.index_map.insert(pubkey, index);
+    }
+
+    fn prefix(&self, length: usize) -> Self {
+        let mut keys = self.keys.clone();
+        let keys = keys.slice(0..length);
+
+        Self {
+            keys,
+            index_map: self.index_map.clone(),
+            phantom: PhantomData,
+        }
+    }
+
+    fn clear_prefix(&mut self, count: usize) {
+        let length = self.keys.len();
+
+        let mut keys: Vector<PublicKeyBytes> =
+            iter::repeat_n(PublicKeyBytes::zero(), count).collect();
+
+        let mut tail = self.keys.clone();
+
+        #[cfg(not(target_os = "zkvm"))]
+        keys.append(tail.slice(count..length));
+        #[cfg(target_os = "zkvm")]
+        keys.append(&mut tail.slice(count..length));
+
+        self.keys = keys;
+    }
+}
+
+impl<N: Unsigned> Extend<PublicKeyBytes> for PubkeyList<N> {
+    fn extend<T: IntoIterator<Item = PublicKeyBytes>>(&mut self, iter: T) {
+        let Self {
+            keys, index_map, ..
+        } = self;
+
+        let start = ValidatorIndex::try_from(keys.len())
+            .expect("validator count never exceeds ValidatorIndex range");
+
+        for (pubkey, index) in iter.into_iter().zip(start..) {
+            keys.push_back(pubkey);
+            index_map.insert(pubkey, index);
+        }
+
+        assert!(
+            keys.len() <= saturating_usize::<N>(),
+            "pubkey list length {} exceeds maximum {}",
+            keys.len(),
+            saturating_usize::<N>(),
+        );
+    }
+}
+
+impl<N: Unsigned> TryFromIterator<PublicKeyBytes> for PubkeyList<N> {
+    type Error = ssz::ReadError;
+
+    fn try_from_iter(items: impl IntoIterator<Item = PublicKeyBytes>) -> Result<Self, Self::Error> {
+        let maximum = saturating_usize::<N>();
+        let mut iter = items.into_iter().fuse();
+
+        let (keys, index_map): (Vector<_>, HashMap<_, _>) = iter
+            .by_ref()
+            .take(maximum)
+            .zip(0u64..)
+            .map(|(pubkey, index)| (pubkey, (pubkey, index)))
+            .unzip();
+
+        if iter.next().is_some() {
+            return Err(ssz::ReadError::ListTooLong {
+                maximum,
+                actual: maximum.saturating_add(1).saturating_add(iter.count()),
+            });
+        }
+
+        Ok(Self {
+            keys,
+            index_map,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<'list, N: Unsigned> IntoIterator for &'list PubkeyList<N> {
+    type Item = &'list PublicKeyBytes;
+    type IntoIter = VectorIter<'list, PublicKeyBytes>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.keys.iter()
+    }
+}
+
+impl<N: Unsigned> SszSize for PubkeyList<N> {
+    const SIZE: ssz::Size = ssz::Size::Variable { minimum_size: 0 };
+}
+
+impl<N: Unsigned> SszWrite for PubkeyList<N> {
+    fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), ssz::WriteError> {
+        write_list(bytes, self)
+    }
+}
+
+impl<C, N: Unsigned> SszRead<C> for PubkeyList<N> {
+    fn from_ssz_unchecked(context: &C, bytes: &[u8]) -> Result<Self, ssz::ReadError> {
+        read_list(saturating_usize::<N>(), context, bytes)
+    }
+}
+
 #[derive(Clone, Debug, Derivative)]
-#[derivative(PartialEq, Eq)]
+#[derivative(PartialEq(bound = ""), Eq(bound = ""))]
 pub struct ValidatorList<N: Unsigned> {
     /// Validator public keys never change, so we keep them separately, to
-    /// structurally share keys even if any other field changes.
-    pubkeys: Vector<PublicKeyBytes>,
+    /// structurally share keys even if any other field changes. The
+    /// accompanying public key -> index map is shared along with them.
+    pubkeys: PubkeyList<N>,
 
     /// Validator effective balances change very frequently, comparing to other
     /// fields, so we keep them separately, so that we don't have to clone every
@@ -176,7 +328,7 @@ impl CacheNode {
 impl<N: Unsigned> Default for ValidatorList<N> {
     fn default() -> Self {
         Self {
-            pubkeys: Vector::new(),
+            pubkeys: PubkeyList::default(),
             effective_balances: Vector::new(),
             items: Vector::new(),
             cache: None,
@@ -218,19 +370,6 @@ impl<N: Unsigned> ValidatorList<N> {
         let index = self.validate_index(index)?;
 
         let pubkey = self.pubkeys.get(index).expect(
-            "validator list invariant violated: \
-                pubkey list is out of sync with current length",
-        );
-
-        Ok(pubkey)
-    }
-
-    pub fn pubkey_mut(&mut self, index: u64) -> Result<&mut PublicKeyBytes, IndexError> {
-        let index = self.validate_index(index)?;
-
-        self.invalidate_index(index);
-
-        let pubkey = self.pubkeys.get_mut(index).expect(
             "validator list invariant violated: \
                 pubkey list is out of sync with current length",
         );
@@ -323,11 +462,11 @@ impl<N: Unsigned> ValidatorList<N> {
     }
 
     #[must_use]
-    pub const fn pubkeys(&self) -> &Vector<PublicKeyBytes> {
+    pub const fn pubkeys(&self) -> &PubkeyList<N> {
         &self.pubkeys
     }
 
-    pub fn set_pubkeys(&mut self, pubkeys: &Vector<PublicKeyBytes>) -> Result<()> {
+    pub fn set_pubkeys(&mut self, pubkeys: &PubkeyList<N>) -> Result<()> {
         let length = self.len_usize();
 
         ensure!(
@@ -336,10 +475,7 @@ impl<N: Unsigned> ValidatorList<N> {
             pubkeys.len(),
         );
 
-        let mut pubkeys = pubkeys.clone();
-        let pubkeys = pubkeys.slice(0..length);
-
-        self.pubkeys = pubkeys;
+        self.pubkeys = pubkeys.prefix(length);
 
         self.cache = (length > 0).then(|| CacheNode::build_empty(length));
 
@@ -354,17 +490,7 @@ impl<N: Unsigned> ValidatorList<N> {
             return;
         }
 
-        let mut pubkeys: Vector<PublicKeyBytes> =
-            iter::repeat_n(PublicKeyBytes::zero(), count).collect();
-
-        let mut tail = self.pubkeys.clone();
-
-        #[cfg(not(target_os = "zkvm"))]
-        pubkeys.append(tail.slice(count..length));
-        #[cfg(target_os = "zkvm")]
-        pubkeys.append(&mut tail.slice(count..length));
-
-        self.pubkeys = pubkeys;
+        self.pubkeys.clear_prefix(count);
 
         self.cache = (length > 0).then(|| CacheNode::build_empty(length));
     }
@@ -435,7 +561,7 @@ impl<N: Unsigned> ValidatorList<N> {
             exit_epoch,
             withdrawable_epoch,
         });
-        self.pubkeys.push_back(pubkey);
+        self.pubkeys.push(pubkey);
         self.effective_balances.push_back(effective_balance);
 
         match &mut self.cache {
@@ -576,7 +702,7 @@ impl<N: Unsigned> TryFromIterator<Validator> for ValidatorList<N> {
             })
             .fuse();
 
-        let (items, (pubkeys, effective_balances)): (Vector<_>, (Vector<_>, Vector<_>)) =
+        let (items, (pubkeys, effective_balances)): (Vector<_>, (PubkeyList<N>, Vector<_>)) =
             iter.by_ref().take(saturating_usize::<N>()).unzip();
 
         if iter.next().is_some() {
@@ -589,7 +715,7 @@ impl<N: Unsigned> TryFromIterator<Validator> for ValidatorList<N> {
         }
 
         Ok(Self {
-            cache: (!pubkeys.is_empty()).then(|| CacheNode::build_empty(pubkeys.len())),
+            cache: (!items.is_empty()).then(|| CacheNode::build_empty(items.len())),
 
             pubkeys,
             effective_balances,

--- a/types/src/phase0/validator_list.rs
+++ b/types/src/phase0/validator_list.rs
@@ -1,0 +1,750 @@
+use core::{fmt, iter, marker::PhantomData};
+use std::sync::Arc;
+
+use anyhow::{Result, ensure};
+use arithmetic::{NonZeroExt as _, U64Ext as _};
+use bls::PublicKeyBytes;
+use derivative::Derivative;
+#[cfg(not(target_os = "zkvm"))]
+use im::{Vector, vector::Iter as VectorIter};
+use once_cell::race::OnceBox;
+use serde::{
+    Deserialize, Serialize,
+    de::{Error as _, Visitor},
+};
+use ssz::{
+    BundleSize, FitsInU64, H256, IndexError, MinimumBundleSize, PushError, SszHash, SszRead,
+    SszSize, SszWrite, U1, hashing, mix_in_length, read_list, saturating_usize, write_list,
+};
+#[cfg(target_os = "zkvm")]
+use std::{slice::Iter as VectorIter, vec::Vec as Vector};
+use std_ext::CopyExt;
+use try_from_iterator::TryFromIterator;
+use typenum::Unsigned;
+
+use crate::phase0::{
+    containers::Validator,
+    primitives::{Epoch, Gwei},
+};
+
+#[cfg(target_os = "zkvm")]
+trait VectorExt<T> {
+    fn push_back(&mut self, value: T);
+    fn slice(&mut self, range: core::ops::Range<usize>) -> Self;
+}
+
+#[cfg(target_os = "zkvm")]
+impl<T> VectorExt<T> for Vec<T> {
+    fn push_back(&mut self, value: T) {
+        self.push(value);
+    }
+
+    fn slice(&mut self, range: core::ops::Range<usize>) -> Self {
+        // Mirror `im::Vector::slice`: remove `range` from `self` and return it as a new vector,
+        // leaving the elements outside the range in `self`.
+        self.drain(range).collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartialValidator {
+    pub withdrawal_credentials: H256,
+    pub slashed: bool,
+    pub activation_eligibility_epoch: Epoch,
+    pub activation_epoch: Epoch,
+    pub exit_epoch: Epoch,
+    pub withdrawable_epoch: Epoch,
+}
+
+impl From<&Validator> for PartialValidator {
+    fn from(value: &Validator) -> Self {
+        Self {
+            withdrawal_credentials: value.withdrawal_credentials.copy(),
+            slashed: value.slashed.copy(),
+            activation_eligibility_epoch: value.activation_eligibility_epoch.copy(),
+            activation_epoch: value.activation_epoch.copy(),
+            exit_epoch: value.exit_epoch.copy(),
+            withdrawable_epoch: value.withdrawable_epoch.copy(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Derivative)]
+#[derivative(PartialEq, Eq)]
+pub struct ValidatorList<N: Unsigned> {
+    /// Validator public keys never change, so we keep them separately, to
+    /// structurally share keys even if any other field changes.
+    pubkeys: Vector<PublicKeyBytes>,
+
+    /// Validator effective balances change very frequently, comparing to other
+    /// fields, so we keep them separately, so that we don't have to clone every
+    /// other field when only balance changes.
+    effective_balances: Vector<Gwei>,
+
+    /// Rest validator fields. These change rarely, so kept separately.
+    items: Vector<PartialValidator>,
+
+    /// Merkle root cache.
+    #[derivative(PartialEq = "ignore")]
+    cache: Option<Arc<CacheNode>>,
+
+    phantom: PhantomData<N>,
+}
+
+#[derive(Clone, Debug)]
+enum CacheNode {
+    Leaf(OnceBox<H256>),
+    Internal {
+        root: OnceBox<H256>,
+        left: Arc<Self>,
+        right: Arc<Self>,
+    },
+}
+
+impl CacheNode {
+    fn empty_leaf() -> Arc<Self> {
+        Arc::new(Self::Leaf(OnceBox::new()))
+    }
+
+    fn build_empty(length: usize) -> Arc<Self> {
+        if length == 1 {
+            return Self::empty_leaf();
+        }
+
+        let left_length = length.next_power_of_two() / 2;
+        let right_length = length
+            .checked_sub(left_length)
+            .expect("left_length never exceeds length");
+
+        Arc::new(Self::Internal {
+            root: OnceBox::new(),
+            left: Self::build_empty(left_length),
+            right: Self::build_empty(right_length),
+        })
+    }
+
+    fn push_leaf(self: &mut Arc<Self>, old_length: usize) {
+        if old_length.is_power_of_two() {
+            *self = Arc::new(Self::Internal {
+                root: OnceBox::new(),
+                left: Arc::clone(self),
+                right: Self::empty_leaf(),
+            });
+
+            return;
+        }
+
+        let left_length = old_length.next_power_of_two() / 2;
+        let right_length = old_length
+            .checked_sub(left_length)
+            .expect("left_length never exceeds old_length");
+
+        match Arc::make_mut(self) {
+            Self::Internal { root, right, .. } => {
+                *root = OnceBox::new();
+                right.push_leaf(right_length);
+            }
+            Self::Leaf(_) => unreachable!("non-power-of-two length implies an internal node"),
+        }
+    }
+
+    fn invalidate(self: &mut Arc<Self>, index: usize, length: usize) {
+        match Arc::make_mut(self) {
+            Self::Leaf(root) => *root = OnceBox::new(),
+            Self::Internal { root, left, right } => {
+                *root = OnceBox::new();
+
+                let left_length = length.next_power_of_two() / 2;
+
+                if index < left_length {
+                    left.invalidate(index, left_length);
+                } else {
+                    let right_index = index
+                        .checked_sub(left_length)
+                        .expect("index >= left_length in this branch");
+                    let right_length = length
+                        .checked_sub(left_length)
+                        .expect("left_length never exceeds length");
+
+                    right.invalidate(right_index, right_length);
+                }
+            }
+        }
+    }
+}
+
+impl<N: Unsigned> Default for ValidatorList<N> {
+    fn default() -> Self {
+        Self {
+            pubkeys: Vector::new(),
+            effective_balances: Vector::new(),
+            items: Vector::new(),
+            cache: None,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<N: Unsigned> ValidatorList<N> {
+    pub fn get(&self, index: u64) -> Result<Validator, IndexError> {
+        let index = self.validate_index(index)?;
+
+        let pubkey = self.pubkeys.get(index).expect(
+            "validator list invariant violated: \
+                pubkey list is out of sync with current length",
+        );
+        let effective_balance = self.effective_balances.get(index).expect(
+            "validator list invariant violated: \
+                effective balance list is out of sync with current length",
+        );
+        let partial_validator = self.items.get(index).expect(
+            "validator list invariant violated: \
+                partial validator list is out of sync with current length",
+        );
+
+        Ok(Validator {
+            pubkey: pubkey.copy(),
+            withdrawal_credentials: partial_validator.withdrawal_credentials.copy(),
+            effective_balance: effective_balance.copy(),
+            slashed: partial_validator.slashed.copy(),
+            activation_eligibility_epoch: partial_validator.activation_eligibility_epoch.copy(),
+            activation_epoch: partial_validator.activation_epoch.copy(),
+            exit_epoch: partial_validator.exit_epoch.copy(),
+            withdrawable_epoch: partial_validator.withdrawable_epoch.copy(),
+        })
+    }
+
+    pub fn pubkey(&self, index: u64) -> Result<&PublicKeyBytes, IndexError> {
+        let index = self.validate_index(index)?;
+
+        let pubkey = self.pubkeys.get(index).expect(
+            "validator list invariant violated: \
+                pubkey list is out of sync with current length",
+        );
+
+        Ok(pubkey)
+    }
+
+    pub fn pubkey_mut(&mut self, index: u64) -> Result<&mut PublicKeyBytes, IndexError> {
+        let index = self.validate_index(index)?;
+
+        self.invalidate_index(index);
+
+        let pubkey = self.pubkeys.get_mut(index).expect(
+            "validator list invariant violated: \
+                pubkey list is out of sync with current length",
+        );
+
+        Ok(pubkey)
+    }
+
+    pub fn effective_balance(&self, index: u64) -> Result<u64, IndexError> {
+        let index = self.validate_index(index)?;
+
+        let effective_balance = self.effective_balances.get(index).expect(
+            "validator list invariant violated: \
+                effective balance list is out of sync with current length",
+        );
+
+        Ok(effective_balance.copy())
+    }
+
+    pub fn effective_balance_mut(&mut self, index: u64) -> Result<&mut u64, IndexError> {
+        let index = self.validate_index(index)?;
+
+        self.invalidate_index(index);
+
+        let effective_balance = self.effective_balances.get_mut(index).expect(
+            "validator list invariant violated: \
+                effective balance list is out of sync with current length",
+        );
+
+        Ok(effective_balance)
+    }
+
+    pub fn partial_validator(&self, index: u64) -> Result<&PartialValidator, IndexError> {
+        let index = self.validate_index(index)?;
+
+        let partial_validator = self.items.get(index).expect(
+            "validator list invariant violated: \
+                partial validator list is out of sync with current length",
+        );
+
+        Ok(partial_validator)
+    }
+
+    pub fn partial_validator_mut(
+        &mut self,
+        index: u64,
+    ) -> Result<&mut PartialValidator, IndexError> {
+        let index = self.validate_index(index)?;
+
+        self.invalidate_index(index);
+
+        let partial_validator = self.items.get_mut(index).expect(
+            "validator list invariant violated: \
+                partial validator list is out of sync with current length",
+        );
+
+        Ok(partial_validator)
+    }
+
+    pub fn update_effective_balances<E>(
+        &mut self,
+        mut updater: impl FnMut(&PartialValidator, Gwei) -> Result<Gwei, E>,
+    ) -> Result<(), E> {
+        let len = self.len_usize();
+
+        let Self {
+            effective_balances,
+            items,
+            cache,
+            ..
+        } = self;
+
+        for (index, (partial_validator, effective_balance)) in
+            items.iter().zip(effective_balances.iter_mut()).enumerate()
+        {
+            let old_effective_balance = *effective_balance;
+            let new_effective_balance = updater(partial_validator, old_effective_balance)?;
+
+            if new_effective_balance == old_effective_balance {
+                continue;
+            }
+
+            if let Some(cache) = cache.as_mut() {
+                cache.invalidate(index, len);
+            }
+
+            *effective_balance = new_effective_balance;
+        }
+
+        Ok(())
+    }
+
+    #[must_use]
+    pub const fn pubkeys(&self) -> &Vector<PublicKeyBytes> {
+        &self.pubkeys
+    }
+
+    pub fn set_pubkeys(&mut self, pubkeys: &Vector<PublicKeyBytes>) -> Result<()> {
+        let length = self.len_usize();
+
+        ensure!(
+            pubkeys.len() >= length,
+            "pubkey list is shorter than validator count (expected at least {length}, got {})",
+            pubkeys.len(),
+        );
+
+        let mut pubkeys = pubkeys.clone();
+        let pubkeys = pubkeys.slice(0..length);
+
+        self.pubkeys = pubkeys;
+
+        self.cache = (length > 0).then(|| CacheNode::build_empty(length));
+
+        Ok(())
+    }
+
+    pub fn clear_pubkeys(&mut self, count: usize) {
+        let length = self.len_usize();
+        let count = count.min(length);
+
+        if count == 0 {
+            return;
+        }
+
+        let mut pubkeys: Vector<PublicKeyBytes> =
+            iter::repeat_n(PublicKeyBytes::zero(), count).collect();
+
+        let mut tail = self.pubkeys.clone();
+
+        #[cfg(not(target_os = "zkvm"))]
+        pubkeys.append(tail.slice(count..length));
+        #[cfg(target_os = "zkvm")]
+        pubkeys.append(&mut tail.slice(count..length));
+
+        self.pubkeys = pubkeys;
+
+        self.cache = (length > 0).then(|| CacheNode::build_empty(length));
+    }
+
+    #[must_use]
+    pub fn partial_validators(&self) -> VectorIter<'_, PartialValidator> {
+        self.items.iter()
+    }
+
+    #[must_use]
+    pub fn effective_balances(&self) -> VectorIter<'_, Gwei> {
+        self.effective_balances.iter()
+    }
+
+    #[must_use]
+    pub fn len_usize(&self) -> usize {
+        self.pubkeys.len()
+    }
+
+    #[must_use]
+    pub fn len_u64(&self) -> u64
+    where
+        N: FitsInU64,
+    {
+        self.len_usize()
+            .try_into()
+            .expect("the bound on N ensures that self.length fits in u64")
+    }
+
+    fn depth(&self) -> u8 {
+        <MinimumBundleSize<Validator> as BundleSize<Validator>>::depth_of_length(self.len_usize())
+    }
+
+    fn max_depth() -> u8 {
+        N::U64
+            .ilog2_ceil()
+            .saturating_sub(MinimumBundleSize::<Validator>::ilog2())
+    }
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "takes the validator by value to mirror the conventional collection \
+                  push API, even though every field happens to be Copy"
+    )]
+    pub fn push(&mut self, validator: Validator) -> Result<(), PushError> {
+        if self.len_usize() >= saturating_usize::<N>() {
+            return Err(PushError::ListFull);
+        }
+
+        let old_length = self.len_usize();
+
+        let Validator {
+            pubkey,
+            withdrawal_credentials,
+            effective_balance,
+            slashed,
+            activation_eligibility_epoch,
+            activation_epoch,
+            exit_epoch,
+            withdrawable_epoch,
+        } = validator;
+
+        self.items.push_back(PartialValidator {
+            withdrawal_credentials,
+            slashed,
+            activation_eligibility_epoch,
+            activation_epoch,
+            exit_epoch,
+            withdrawable_epoch,
+        });
+        self.pubkeys.push_back(pubkey);
+        self.effective_balances.push_back(effective_balance);
+
+        match &mut self.cache {
+            Some(cache) => cache.push_leaf(old_length),
+            None => self.cache = Some(CacheNode::empty_leaf()),
+        }
+
+        Ok(())
+    }
+
+    fn validate_index(&self, index: u64) -> Result<usize, IndexError> {
+        let index = index
+            .try_into()
+            .map_err(|_| IndexError::DoesNotFitInUsize { index })?;
+
+        if index >= self.len_usize() {
+            return Err(IndexError::OutOfBounds {
+                length: self.len_usize(),
+                index,
+            });
+        }
+
+        Ok(index)
+    }
+
+    fn invalidate_index(&mut self, index: usize) {
+        let len = self.len_usize();
+
+        if index >= len {
+            return;
+        }
+
+        if let Some(cache) = self.cache.as_mut() {
+            cache.invalidate(index, len);
+        }
+    }
+
+    fn hash_node(&self, node: &CacheNode, len: usize, offset: usize) -> H256 {
+        match node {
+            CacheNode::Leaf(root) => root
+                .get_or_init(|| {
+                    let PartialValidator {
+                        withdrawal_credentials,
+                        slashed,
+                        activation_eligibility_epoch,
+                        activation_epoch,
+                        exit_epoch,
+                        withdrawable_epoch,
+                    } = self
+                        .items
+                        .get(offset)
+                        .expect(
+                            "validator list invariant violated: \
+                                partial validator list is out of sync with current length",
+                        )
+                        .copy();
+
+                    let validator = Validator {
+                        pubkey: self
+                            .pubkeys
+                            .get(offset)
+                            .expect(
+                                "validator list invariant violated: \
+                                    pubkey list is out of sync with current length",
+                            )
+                            .copy(),
+                        withdrawal_credentials,
+                        effective_balance: self
+                            .effective_balances
+                            .get(offset)
+                            .expect(
+                                "validator list invariant violated: \
+                                    effective balance list is out of sync with current length",
+                            )
+                            .copy(),
+                        slashed,
+                        activation_eligibility_epoch,
+                        activation_epoch,
+                        exit_epoch,
+                        withdrawable_epoch,
+                    };
+
+                    Box::new(validator.hash_tree_root())
+                })
+                .copy(),
+            CacheNode::Internal { root, left, right } => root
+                .get_or_init(|| {
+                    let left_len = len.next_power_of_two() / 2;
+                    let right_len = len
+                        .checked_sub(left_len)
+                        .expect("left_len never exceeds len");
+
+                    let left_height =
+                        <MinimumBundleSize<Validator> as BundleSize<Validator>>::depth_of_length(
+                            left_len,
+                        );
+                    let right_height =
+                        <MinimumBundleSize<Validator> as BundleSize<Validator>>::depth_of_length(
+                            right_len,
+                        );
+
+                    let right_offset = offset
+                        .checked_add(left_len)
+                        .expect("offset + left_len never overflows usize");
+
+                    let left = self.hash_node(left, left_len, offset);
+                    let right = self.hash_node(right, right_len, right_offset);
+
+                    let right_hash = (right_height..left_height)
+                        .map(<MinimumBundleSize<Validator> as BundleSize<Validator>>::zero_hash)
+                        .fold(right, hashing::hash_256_256);
+
+                    Box::new(hashing::hash_256_256(left, right_hash))
+                })
+                .copy(),
+        }
+    }
+}
+
+impl<N: Unsigned> TryFromIterator<Validator> for ValidatorList<N> {
+    type Error = ssz::ReadError;
+
+    fn try_from_iter(items: impl IntoIterator<Item = Validator>) -> Result<Self, Self::Error> {
+        let mut iter = items
+            .into_iter()
+            .map(|validator| {
+                (
+                    PartialValidator {
+                        withdrawal_credentials: validator.withdrawal_credentials,
+                        slashed: validator.slashed,
+                        activation_eligibility_epoch: validator.activation_eligibility_epoch,
+                        activation_epoch: validator.activation_epoch,
+                        exit_epoch: validator.exit_epoch,
+                        withdrawable_epoch: validator.withdrawable_epoch,
+                    },
+                    (validator.pubkey, validator.effective_balance),
+                )
+            })
+            .fuse();
+
+        let (items, (pubkeys, effective_balances)): (Vector<_>, (Vector<_>, Vector<_>)) =
+            iter.by_ref().take(saturating_usize::<N>()).unzip();
+
+        if iter.next().is_some() {
+            return Err(ssz::ReadError::ListTooLong {
+                maximum: saturating_usize::<N>(),
+                actual: saturating_usize::<N>()
+                    .saturating_add(1)
+                    .saturating_add(iter.count()),
+            });
+        }
+
+        Ok(Self {
+            cache: (!pubkeys.is_empty()).then(|| CacheNode::build_empty(pubkeys.len())),
+
+            pubkeys,
+            effective_balances,
+            items,
+
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<N: Unsigned> Serialize for ValidatorList<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self)
+    }
+}
+
+impl<'de, N: Unsigned> Deserialize<'de> for ValidatorList<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValidatorListVisitor<N: Unsigned>(PhantomData<N>);
+
+        impl<'de, N: Unsigned> Visitor<'de> for ValidatorListVisitor<N> {
+            type Value = ValidatorList<N>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "a validator list of length up to {}",
+                    saturating_usize::<N>()
+                )
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: serde::de::SeqAccess<'de>,
+            {
+                itertools::process_results(
+                    iter::from_fn(|| seq.next_element().transpose()),
+                    |elements| ValidatorList::try_from_iter(elements).map_err(S::Error::custom),
+                )?
+            }
+        }
+
+        deserializer.deserialize_seq(ValidatorListVisitor(PhantomData))
+    }
+}
+
+impl<N: Unsigned> SszHash for ValidatorList<N> {
+    type PackingFactor = U1;
+
+    fn hash_tree_root(&self) -> H256 {
+        let root = match self.len_usize() {
+            0 => {
+                <MinimumBundleSize<Validator> as BundleSize<Validator>>::zero_hash(Self::max_depth())
+            }
+            _ => (self.depth()..Self::max_depth())
+                .map(<MinimumBundleSize<Validator> as BundleSize<Validator>>::zero_hash)
+                .fold(
+                    self.hash_node(
+                        self.cache.as_ref().expect("non-empty list has a cache"),
+                        self.len_usize(),
+                        0,
+                    ),
+                    hashing::hash_256_256,
+                ),
+        };
+
+        mix_in_length(root, self.len_usize())
+    }
+}
+
+impl<N: Unsigned> SszSize for ValidatorList<N> {
+    const SIZE: ssz::Size = ssz::Size::Variable { minimum_size: 0 };
+}
+
+impl<N: Unsigned> SszWrite for ValidatorList<N> {
+    fn write_variable(&self, bytes: &mut Vec<u8>) -> Result<(), ssz::WriteError> {
+        write_list(bytes, self)
+    }
+}
+
+impl<C, N: Unsigned> SszRead<C> for ValidatorList<N> {
+    fn from_ssz_unchecked(context: &C, bytes: &[u8]) -> Result<Self, ssz::ReadError> {
+        read_list(saturating_usize::<N>(), context, bytes)
+    }
+}
+
+pub struct ValidatorListIter<'a, N: Unsigned> {
+    pubkeys: VectorIter<'a, PublicKeyBytes>,
+    effective_balances: VectorIter<'a, Gwei>,
+    items: VectorIter<'a, PartialValidator>,
+    phantom: PhantomData<N>,
+}
+
+impl<N: Unsigned> Iterator for ValidatorListIter<'_, N> {
+    type Item = Validator;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let pubkey = self.pubkeys.next()?;
+        let effective_balance = self.effective_balances.next()?;
+        let PartialValidator {
+            withdrawal_credentials,
+            slashed,
+            activation_eligibility_epoch,
+            activation_epoch,
+            exit_epoch,
+            withdrawable_epoch,
+        } = self.items.next()?.copy();
+
+        Some(Validator {
+            pubkey: pubkey.copy(),
+            withdrawal_credentials,
+            effective_balance: effective_balance.copy(),
+            slashed,
+            activation_eligibility_epoch,
+            activation_epoch,
+            exit_epoch,
+            withdrawable_epoch,
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.pubkeys.size_hint()
+    }
+}
+
+impl<N: Unsigned> ExactSizeIterator for ValidatorListIter<'_, N> {
+    fn len(&self) -> usize {
+        self.pubkeys.len()
+    }
+}
+
+impl<'list, N: Unsigned> IntoIterator for &'list ValidatorList<N> {
+    type Item = Validator;
+    type IntoIter = ValidatorListIter<'list, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ValidatorListIter {
+            pubkeys: self.pubkeys.iter(),
+            effective_balances: self.effective_balances.iter(),
+            items: self.items.iter(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<N: Unsigned, const SIZE: usize> TryFrom<[Validator; SIZE]> for ValidatorList<N> {
+    type Error = ssz::ReadError;
+
+    fn try_from(array: [Validator; SIZE]) -> Result<Self, Self::Error> {
+        Self::try_from_iter(array)
+    }
+}

--- a/validator/src/slot_head.rs
+++ b/validator/src/slot_head.rs
@@ -54,15 +54,13 @@ impl<P: Preset> SlotHead<P> {
 
     #[must_use]
     pub fn public_key(&self, validator_index: ValidatorIndex) -> &PublicKeyBytes {
-        &self
-            .beacon_state
+        self.beacon_state
             .validators()
-            .get(validator_index)
+            .pubkey(validator_index)
             .expect(
                 "SlotHead::public_key should only be called with \
                  indices of validators in SlotHead.beacon_state",
             )
-            .pubkey
     }
 
     pub fn proposer_index(&self) -> Result<ValidatorIndex> {


### PR DESCRIPTION
This PR employs Structure of Arrays (SoA) pattern for implementing validator list container. The validator fields are split into three lists - pubkeys, effective balances, and rest of fields. Because pubkey list is strictly append-only, such validator list structure saves memory when loading historical state from disk - instead of  copying every public key from finalized state into a newly loaded one, we can attach whole pubkey list at once, re-using memory for all keys.