### PR TITLE
Request payload envelope after block imported

### DIFF
--- a/fork_choice_control/src/helpers.rs
+++ b/fork_choice_control/src/helpers.rs
@@ -792,7 +792,20 @@ impl<P: Preset> Context<P> {
         self.controller()
             .on_gossip_block(block.clone_arc(), GossipId::default());
         self.controller().wait_for_tasks();
-        self.next_p2p_message()
+
+        // Filter out payload envelope request by the block root message as it is a side effect of importing
+        // Gloas beacon block, not the validation outcome of the block itself.
+        loop {
+            let option = self.next_p2p_message();
+
+            if let Some(P2pMessage::PayloadEnvelopeNeeded(block_root, _)) = option
+                && block_root == block.message().hash_tree_root()
+            {
+                continue;
+            }
+
+            return option;
+        }
     }
 
     fn on_execution_payload(

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -3164,6 +3164,12 @@ where
                 .message
                 .parent_block_hash;
 
+            // Request payload envelope if fork choice hasn't accepted yet.
+            if !self.store.is_payload_verified(block_root) {
+                let peer_id = origin.peer_id();
+                self.send_to_p2p(P2pMessage::PayloadEnvelopeNeeded(block_root, peer_id));
+            }
+
             // Only check in unfinalized path
             if self
                 .store


### PR DESCRIPTION
currently, Grandine only request payload envelope from peers when `Attestation`, `AggregateAndProof` or `PayloadAttestation` reference that missing payload, but never after block acceptance. Without this fix, Grandine can be tricked to think payload is not available, while it never request the payload from peers