### PR TITLE
Support IPv6-only network listening via `--disable-ipv4` (#787)

### DIFF
--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -204,7 +204,10 @@ impl<P: Preset, W: Wait> Network<P, W> {
 
         let mut port_mappings = None;
 
-        if network_config.upnp_enabled && !network_config.disable_discovery {
+        if network_config.upnp_enabled
+            && !network_config.disable_discovery
+            && network_config.listen_addrs().v4().is_some()
+        {
             match PortMappings::new(&network_config) {
                 Ok(mappings) => port_mappings = Some(mappings),
                 Err(error) => warn_with_peers!("error while initializing UPnP: {error}"),

--- a/runtime/src/grandine_args.rs
+++ b/runtime/src/grandine_args.rs
@@ -491,8 +491,9 @@ struct BeaconNodeOptions {
 #[derive(Debug, Args)]
 struct NetworkConfigOptions {
     /// Listen IPv4 address
-    #[clap(long, default_value_t = Ipv4Addr::UNSPECIFIED)]
-    listen_address: Ipv4Addr,
+    /// [default: 0.0.0.0, unless --disable-ipv4 is set]
+    #[clap(long)]
+    listen_address: Option<Ipv4Addr>,
 
     /// Listen IPv6 address
     /// [default: None]
@@ -528,6 +529,21 @@ struct NetworkConfigOptions {
     /// [default: enabled]
     #[clap(long)]
     disable_enr_auto_update: bool,
+
+    /// Disable listening on IPv4
+    /// [default: enabled]
+    #[clap(
+        long,
+        requires = "listen_address_ipv6",
+        conflicts_with_all = [
+            "listen_address",
+            "enr_address",
+            "enr_tcp_port",
+            "enr_udp_port",
+            "enr_quic_port",
+        ],
+    )]
+    disable_ipv4: bool,
 
     /// discv5 IPv4 port
     #[clap(long, default_value_t = DEFAULT_LIBP2P_IPV4_PORT)]
@@ -636,6 +652,7 @@ impl NetworkConfigOptions {
             libp2p_port,
             libp2p_port_ipv6,
             disable_enr_auto_update,
+            disable_ipv4,
             disable_quic,
             disable_peer_scoring,
             disable_rate_limiting,
@@ -683,24 +700,35 @@ impl NetworkConfigOptions {
                 Some(OutboundRateLimiterConfig::default());
         }
 
-        if let Some(listen_address_ipv6) = listen_address_ipv6 {
-            network_config.set_ipv4_ipv6_listening_addresses(
-                listen_address,
-                libp2p_port.into(),
-                discovery_port.into(),
-                quic_port.into(),
-                listen_address_ipv6,
-                libp2p_port_ipv6.into(),
-                discovery_port_ipv6.into(),
-                quic_port_ipv6.into(),
-            );
-        } else {
-            network_config.set_ipv4_listening_address(
-                listen_address,
-                libp2p_port.into(),
-                discovery_port.into(),
-                quic_port.into(),
-            );
+        match (listen_address, listen_address_ipv6) {
+            (_, Some(listen_address_ipv6)) if disable_ipv4 => {
+                network_config.set_ipv6_listening_address(
+                    listen_address_ipv6,
+                    libp2p_port_ipv6.into(),
+                    discovery_port_ipv6.into(),
+                    quic_port_ipv6.into(),
+                );
+            }
+            (listen_address, None) => {
+                network_config.set_ipv4_listening_address(
+                    listen_address.unwrap_or(Ipv4Addr::UNSPECIFIED),
+                    libp2p_port.into(),
+                    discovery_port.into(),
+                    quic_port.into(),
+                );
+            }
+            (listen_address, Some(listen_address_ipv6)) => {
+                network_config.set_ipv4_ipv6_listening_addresses(
+                    listen_address.unwrap_or(Ipv4Addr::UNSPECIFIED),
+                    libp2p_port.into(),
+                    discovery_port.into(),
+                    quic_port.into(),
+                    listen_address_ipv6,
+                    libp2p_port_ipv6.into(),
+                    discovery_port_ipv6.into(),
+                    quic_port_ipv6.into(),
+                );
+            }
         }
 
         network_config.enr_address = (enr_address, enr_address_ipv6);
@@ -708,7 +736,7 @@ impl NetworkConfigOptions {
         // Set ENR fields of `NetworkConfig` only if the value is specified.
         if let Some(enr_tcp_port) = enr_tcp_port {
             network_config.enr_tcp4_port = Some(enr_tcp_port);
-        } else {
+        } else if !disable_ipv4 {
             // Don't allow discv5 to overwrite ENR port
             // as it won't be open via Upnp
             network_config.enr_tcp4_port = Some(libp2p_port);
@@ -1692,7 +1720,7 @@ fn headers_to_allow_origin(allowed_origins: Vec<HeaderValue>) -> Option<AllowOri
 
 #[cfg(test)]
 mod tests {
-    use core::net::{Ipv4Addr, SocketAddr};
+    use core::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use ssz::Uint256;
     use tempfile::NamedTempFile;
@@ -1730,6 +1758,123 @@ mod tests {
                     .expect("home directory should be accessible")
                     .join(".grandine/mainnet/network"),
             ),
+        );
+    }
+
+    #[test]
+    fn listen_address_defaults_to_unspecified_ipv4() {
+        let config = config_from_args([]);
+        let listen_addrs = config.network_config.listen_addrs();
+
+        assert_eq!(
+            listen_addrs.v4().map(|addr| addr.addr),
+            Some(Ipv4Addr::UNSPECIFIED),
+        );
+
+        assert_eq!(listen_addrs.v6().map(|addr| addr.addr), None);
+    }
+
+    #[test]
+    fn listen_address_ipv4_only_uses_given_address() {
+        let config = config_from_args(["--listen-address", "127.0.0.1"]);
+        let listen_addrs = config.network_config.listen_addrs();
+
+        let v4 = listen_addrs
+            .v4()
+            .expect("IPv4 listen address should be set");
+
+        assert_eq!(v4.addr, Ipv4Addr::LOCALHOST);
+        assert_eq!(v4.tcp_port, DEFAULT_LIBP2P_IPV4_PORT.get());
+        assert_eq!(v4.disc_port, DEFAULT_LIBP2P_IPV4_PORT.get());
+        assert_eq!(v4.quic_port, DEFAULT_LIBP2P_QUIC_IPV4_PORT.get());
+        assert_eq!(listen_addrs.v6().map(|addr| addr.addr), None);
+    }
+
+    #[test]
+    fn listen_address_ipv6_defaults_to_dual_stack() {
+        let config = config_from_args(["--listen-address-ipv6", "::1"]);
+        let listen_addrs = config.network_config.listen_addrs();
+
+        assert_eq!(
+            listen_addrs.v4().map(|addr| addr.addr),
+            Some(Ipv4Addr::UNSPECIFIED),
+        );
+
+        assert_eq!(
+            listen_addrs.v6().map(|addr| addr.addr),
+            Some(Ipv6Addr::LOCALHOST),
+        );
+    }
+
+    #[test]
+    fn disable_ipv4_produces_ipv6_only() {
+        let config = config_from_args(["--disable-ipv4", "--listen-address-ipv6", "::1"]);
+        let listen_addrs = config.network_config.listen_addrs();
+
+        assert_eq!(listen_addrs.v4().map(|addr| addr.addr), None);
+
+        let v6 = listen_addrs
+            .v6()
+            .expect("IPv6 listen address should be set");
+
+        assert_eq!(v6.addr, Ipv6Addr::LOCALHOST);
+        assert_eq!(v6.tcp_port, DEFAULT_LIBP2P_IPV6_PORT.get());
+        assert_eq!(v6.disc_port, DEFAULT_LIBP2P_IPV6_PORT.get());
+        assert_eq!(v6.quic_port, DEFAULT_LIBP2P_QUIC_IPV6_PORT.get());
+
+        // The ENR must not advertise an IPv4 TCP port when IPv4 is disabled.
+        assert_eq!(config.network_config.enr_tcp4_port, None);
+    }
+
+    #[test]
+    fn disable_ipv4_requires_listen_address_ipv6() {
+        try_config_from_args(["--disable-ipv4"])
+            .expect_err("--disable-ipv4 requires --listen-address-ipv6");
+    }
+
+    #[test]
+    fn disable_ipv4_conflicts_with_listen_address() {
+        try_config_from_args([
+            "--disable-ipv4",
+            "--listen-address",
+            "127.0.0.1",
+            "--listen-address-ipv6",
+            "::1",
+        ])
+        .expect_err("--disable-ipv4 conflicts with --listen-address");
+    }
+
+    #[test]
+    fn disable_ipv4_conflicts_with_enr_tcp_port() {
+        try_config_from_args([
+            "--disable-ipv4",
+            "--listen-address-ipv6",
+            "::1",
+            "--enr-tcp-port",
+            "9000",
+        ])
+        .expect_err("--disable-ipv4 conflicts with --enr-tcp-port");
+    }
+
+    #[test]
+    fn listen_address_dual_stack_uses_both_addresses() {
+        let config = config_from_args([
+            "--listen-address",
+            "127.0.0.1",
+            "--listen-address-ipv6",
+            "::1",
+        ]);
+
+        let listen_addrs = config.network_config.listen_addrs();
+
+        assert_eq!(
+            listen_addrs.v4().map(|addr| addr.addr),
+            Some(Ipv4Addr::LOCALHOST),
+        );
+
+        assert_eq!(
+            listen_addrs.v6().map(|addr| addr.addr),
+            Some(Ipv6Addr::LOCALHOST),
         );
     }
 

--- a/runtime/src/predefined_network.rs
+++ b/runtime/src/predefined_network.rs
@@ -38,7 +38,7 @@ pub enum PredefinedNetwork {
 }
 
 impl PredefinedNetwork {
-    /// [Mainnet bootnode ENRs](https://github.com/eth-clients/mainnet/blob/6c9a688d289697d44614c7dfaf9154cc6565cb06/metadata/bootstrap_nodes.yaml)
+    /// [Mainnet bootnode ENRs](https://github.com/eth-clients/mainnet/blob/b3fc01ff2bac624880f2e6dbafbf67532760f611/metadata/bootstrap_nodes.yaml)
     #[cfg(any(feature = "network-mainnet", test))]
     pub const MAINNET_BOOTNODES: &'static [&'static str] = &[
         // > Teku team's bootnodes
@@ -63,7 +63,7 @@ impl PredefinedNetwork {
         "enr:-LK4QKWrXTpV9T78hNG6s8AM6IO4XH9kFT91uZtFg1GcsJ6dKovDOr1jtAAFPnS2lvNltkOGA9k29BUN7lFh_sjuc9QBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhANAdd-Jc2VjcDI1NmsxoQLQa6ai7y9PMN5hpLe5HmiJSlYzMuzP7ZhwRiwHvqNXdoN0Y3CCI4yDdWRwgiOM",
         // > Lodestar team's bootnodes
         "enr:-IS4QPi-onjNsT5xAIAenhCGTDl4z-4UOR25Uq-3TmG4V3kwB9ljLTb_Kp1wdjHNj-H8VVLRBSSWVZo3GUe3z6k0E-IBgmlkgnY0gmlwhKB3_qGJc2VjcDI1NmsxoQMvAfgB4cJXvvXeM6WbCG86CstbSxbQBSGx31FAwVtOTYN1ZHCCIyg",
-        "enr:-KG4QCb8NC3gEM3I0okStV5BPX7Bg6ZXTYCzzbYyEXUPGcZtHmvQtiJH4C4F2jG7azTcb9pN3JlgpfxAnRVFzJ3-LykBgmlkgnY0gmlwhFPlR9KDaXA2kP6AAAAAAAAAAlBW__4my5iJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
+        "enr:-KG4QPUf8-g_jU-KrwzG42AGt0wWM1BTnQxgZXlvCEIfTQ5hSmptkmgmMbRkpOqv6kzb33SlhPHJp7x4rLWWiVq5lSECgmlkgnY0gmlwhFPlR9KDaXA2kCoGxcAJAAAVAAAAAAAAABCJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
     ];
 
     /// [Sepolia bootnode ENRs](https://github.com/eth-clients/sepolia/blob/2bae9336a2d13998faf4c9f5574ccb2d15718721/metadata/bootstrap_nodes.yaml)
@@ -100,7 +100,7 @@ impl PredefinedNetwork {
         "enr:-KG4QC9Wm32mtzB5Fbj2ri2TEKglHmIWgvwTQCvNHBopuwpNAi1X6qOsBg_Z1-Bee-kfSrhzUQZSgDUyfH5outUprtoBgmlkgnY0gmlwhHEel3eDaXA2kP6AAAAAAAAAAlBW__4Srr-Jc2VjcDI1NmsxoQO7KE63Z4eSI55S1Yn7q9_xFkJ1Wt-a3LgiXuKGs19s0YN1ZHCCIyiEdWRwNoIjKA",
     ];
 
-    /// [Hoodi bootnode ENRs](https://github.com/eth-clients/hoodi/blob/12da21411825d4c998dc71daf3b553c46e90a1a7/metadata/bootstrap_nodes.yaml)
+    /// [Hoodi bootnode ENRs](https://github.com/eth-clients/hoodi/blob/a130c03daa6dbb1ae9a1a722544570b6b8035aee/metadata/bootstrap_nodes.yaml)
     #[cfg(any(feature = "network-hoodi", test))]
     const HOODI_BOOTNODES: &'static [&'static str] = &[
         // EF
@@ -114,7 +114,7 @@ impl PredefinedNetwork {
         "enr:-LK4QDwhXMitMbC8xRiNL-XGMhRyMSOnxej-zGifjv9Nm5G8EF285phTU-CAsMHRRefZimNI7eNpAluijMQP7NDC8kEMh2F0dG5ldHOIAAAAAAAABgCEZXRoMpDS8Zl_YAAJEAAIAAAAAAAAgmlkgnY0gmlwhAOIT_SJc2VjcDI1NmsxoQMoHWNL4MAvh6YpQeM2SUjhUrLIPsAVPB8nyxbmckC6KIN0Y3CCIyiDdWRwgiMo",
         "enr:-LK4QPYl2HnMPQ7b1es6Nf_tFYkyya5bj9IqAKOEj2cmoqVkN8ANbJJJK40MX4kciL7pZszPHw6vLNyeC-O3HUrLQv8Mh2F0dG5ldHOIAAAAAAAAAMCEZXRoMpDS8Zl_YAAJEAAIAAAAAAAAgmlkgnY0gmlwhAMYRG-Jc2VjcDI1NmsxoQPQ35tjr6q1qUqwAnegQmYQyfqxC_6437CObkZneI9n34N0Y3CCIyiDdWRwgiMo",
         // Lodestar
-        "enr:-KG4QJk_4IQHQw3DAdKIuGcEauKU8-nmRPPMj_hIQPRHmsFGMPPeOj6_xX09aHCndOzLnOZimVRzNM56_EQWYVbEpJMBgmlkgnY0gmlwhLkvrBODaXA2kP6AAAAAAAAAAhY-__4PR6OJc2VjcDI1NmsxoQPU7g2jQGTz8BYbB2vLTb39S_PrcZAehwMM0b3bWsM5rIN1ZHCCIyiEdWRwNoIjKA",
+        "enr:-KG4QKRSUi4IOAIK_xt5ERrwW_J47wmNCLWFh7Jo0hFE69drZsiZ5Pb5CEcM_njFTTLlIR6SCf67HTcSV1g6hCXdhWkCgmlkgnY0gmlwhLkvrBODaXA2kCoGxcAWAAAYAAAAAAAAABCJc2VjcDI1NmsxoQPU7g2jQGTz8BYbB2vLTb39S_PrcZAehwMM0b3bWsM5rIN1ZHCCIyiEdWRwNoIjKA",
     ];
 
     #[must_use]


### PR DESCRIPTION
- Make `--listen-address` an optional type
- Add `--disable-ipv4` for an IPv6-only setup & backward copatibility

Passing only `--listen-address-ipv6` still configures a dual-stack setup as before; for IPv6-only additionally pass `--disable-ipv4`. The flag requires `--listen-address-ipv6` and conflicts with the IPv4-only options (`--listen-address`, `--enr-address`, `--enr-{tcp,udp,quic}-port`).

In IPv6-only mode:
- don't default `enr_tcp4_port`, so the ENR no longer advertises an IPv4 TCP port with no accompanying IPv4 address;
- skip the igd/UPnP port mapping, which can only map IPv4 and would otherwise fail mapping an IPv6 service through an IPv4 gateway.

Refresh mainnet and hoodi bootnodes from eth-clients metadata

Add tests for the listen-address combinations and the new flag conflicts.