### PR TITLE
Store attestations with pristine data in the aggregate pool

### DIFF
--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -892,12 +892,10 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                     Vec<ElectraAttestation<P>>,
                 )> = Vec::new();
 
-                for (electra_attestation, committee_index) in
+                for electra_attestation in
                     attestations.into_iter().filter_map(|attestation| {
-                        let committee_index = attestation.data.index;
-
                         match operation_pools::convert_to_electra_attestation(attestation) {
-                            Ok(electra_attestation) => Some((electra_attestation, committee_index)),
+                            Ok(electra_attestation) => Some(electra_attestation),
                             Err(error) => {
                                 warn_with_peers!(
                                     "unable to convert to electra attestation: {error:?}"
@@ -907,6 +905,14 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                         }
                     })
                 {
+                    // The pool emits a temporary scratch representation with the committee index in
+                    // `data.index`; read the committee canonically from the converted attestation's
+                    // `committee_bits` instead of `data.index`. See TODO(grandinetech/grandine#780).
+                    let committee_index =
+                        misc::get_committee_indices::<P>(electra_attestation.committee_bits)
+                            .next()
+                            .unwrap_or_default();
+
                     if let Some((_, indices, attestations)) =
                         results.iter_mut().find(|(data, indices, _)| {
                             *data == electra_attestation.data && !indices.contains(&committee_index)

--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -4347,18 +4347,23 @@ async fn get_pool_attestations<P: Preset, W: Wait>(
     aggregates
         .iter()
         .chain(singular_attestations.iter().map(Arc::as_ref))
-        .filter(|attestation| {
-            attestation.data.index == committee_index && attestation.data.slot == slot
-        })
         .cloned()
         .filter_map(|attestation| {
-            if phase < Phase::Electra {
-                Some(Attestation::Phase0(attestation))
+            // The pool emits a temporary scratch representation with the committee index in
+            // `data.index`. Classify the combined attestation via the canonical
+            // `misc::committee_index` accessor instead of reading `data.index` directly.
+            // See TODO(grandinetech/grandine#780).
+            let attestation = if phase < Phase::Electra {
+                Attestation::Phase0(attestation)
             } else {
                 convert_to_electra_attestation(attestation)
                     .map(Attestation::Electra)
-                    .ok()
-            }
+                    .ok()?
+            };
+
+            (misc::committee_index(&attestation) == committee_index
+                && attestation.data().slot == slot)
+                .then_some(attestation)
         })
         .collect()
 }

--- a/operation_pools/src/attestation_agg_pool/conversion.rs
+++ b/operation_pools/src/attestation_agg_pool/conversion.rs
@@ -12,14 +12,26 @@ use types::{
         containers::{Attestation as ElectraAttestation, SingleAttestation},
         error::AttestationConversionError,
     },
-    phase0::containers::{Attestation as Phase0Attestation, AttestationData, Checkpoint},
+    phase0::{
+        containers::{Attestation as Phase0Attestation, Checkpoint},
+        primitives::CommitteeIndex,
+    },
     preset::Preset,
 };
 
+/// Convert an incoming attestation into the pool's per-committee representation.
+///
+/// Returns the attestation with **pristine** `data` (byte-for-byte as signed) together with the
+/// committee index tracked separately. The committee index is deliberately NOT folded back into
+/// `data.index`: under Gloas that field is the payload-presence vote, so overwriting it would
+/// corrupt the signed root. The caller stores both in a [`PoolKey`]. See
+/// TODO(grandinetech/grandine#780).
+///
+/// [`PoolKey`]: crate::attestation_agg_pool::types::PoolKey
 pub fn convert_attestation_for_pool<P: Preset, W: Wait>(
     controller: &ApiController<P, W>,
     attestation: Arc<Attestation<P>>,
-) -> Result<Phase0Attestation<P>> {
+) -> Result<(Phase0Attestation<P>, CommitteeIndex)> {
     if attestation
         .data()
         .slot
@@ -29,8 +41,12 @@ pub fn convert_attestation_for_pool<P: Preset, W: Wait>(
         bail!(AttestationConversionError::Irrelevant);
     }
 
-    let attestation = match Arc::unwrap_or_clone(attestation) {
-        Attestation::Phase0(attestation) => attestation,
+    let attestation_with_committee = match Arc::unwrap_or_clone(attestation) {
+        // Pre-Electra: `data.index` is genuinely the committee index (as signed); already pristine.
+        Attestation::Phase0(attestation) => {
+            let committee_index = attestation.data.index;
+            (attestation, committee_index)
+        }
         Attestation::Electra(attestation) => {
             let ElectraAttestation {
                 aggregation_bits,
@@ -41,28 +57,36 @@ pub fn convert_attestation_for_pool<P: Preset, W: Wait>(
 
             let aggregation_bits: Vec<u8> = aggregation_bits.into();
 
-            let index = misc::get_committee_indices::<P>(committee_bits)
+            let committee_index = misc::get_committee_indices::<P>(committee_bits)
                 .next()
                 .ok_or(AttestationConversionError::InvalidCommitteeIndex)?;
 
-            Phase0Attestation {
+            // Keep `data` pristine (the signed Electra `data.index` is 0). The committee index is
+            // returned separately, never written into `data.index`. See TODO(#780).
+            let attestation = Phase0Attestation {
                 aggregation_bits: aggregation_bits
                     .try_into()
                     .map_err(AttestationConversionError::InvalidAggregationBits)?,
-                data: AttestationData { index, ..data },
+                data,
                 signature,
-            }
+            };
+
+            (attestation, committee_index)
         }
         Attestation::Single(attestation) => {
             let slot = attestation.data.slot;
+            let committee_index = attestation.committee_index;
             let state = current_state(controller, attestation.data.target);
-            let committee = accessors::beacon_committee(&state, slot, attestation.committee_index)?;
+            let committee = accessors::beacon_committee(&state, slot, committee_index)?;
 
-            attestation.try_into_phase0_attestation(committee)?
+            (
+                attestation.try_into_phase0_attestation(committee)?,
+                committee_index,
+            )
         }
     };
 
-    Ok(attestation)
+    Ok(attestation_with_committee)
 }
 
 pub fn convert_to_electra_attestation<P: Preset>(
@@ -130,5 +154,86 @@ fn current_state<P: Preset, W: Wait>(
 
             controller.head_state().value
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // These tests exercise the single-attestation inflow conversion directly (no controller / no
+    // `eth2-cache` data). They are deliberately written against `try_into_phase0_attestation`,
+    // which exists on both the pre-fix and post-fix code with the same signature, so they double as
+    // portable regression tests: on the pre-fix code (which overwrote `data.index` with the
+    // committee index) `single_conversion_keeps_gloas_votes_distinct` fails.
+    use bls::SignatureBytes;
+    use types::{
+        cache::IndexSlice,
+        electra::containers::SingleAttestation,
+        phase0::{
+            containers::{AttestationData, Checkpoint},
+            primitives::H256,
+        },
+        preset::Minimal,
+    };
+
+    // A Gloas single attestation: `data.index` is the payload-presence vote (0 or 1), and the
+    // committee index is carried in its own field.
+    fn gloas_single(committee_index: u64, payload_vote: u64) -> SingleAttestation {
+        SingleAttestation {
+            committee_index,
+            attester_index: 11,
+            data: AttestationData {
+                slot: 7,
+                index: payload_vote,
+                beacon_block_root: H256::repeat_byte(0xff),
+                source: Checkpoint {
+                    epoch: 1,
+                    root: H256::repeat_byte(1),
+                },
+                target: Checkpoint {
+                    epoch: 2,
+                    root: H256::repeat_byte(2),
+                },
+            },
+            signature: SignatureBytes::default(),
+        }
+    }
+
+    // Test 4 — the single-attestation inflow keeps `data` pristine: the committee index is tracked
+    // separately, never written into `data.index`.
+    #[test]
+    fn single_conversion_keeps_data_index_pristine() -> anyhow::Result<()> {
+        let committee: Vec<u64> = vec![10, 11, 12, 13];
+        let single = gloas_single(2, 0);
+
+        let phase0 = single.try_into_phase0_attestation::<Minimal>(IndexSlice::U64(&committee))?;
+
+        assert_eq!(
+            phase0.data.index, single.data.index,
+            "data.index must stay pristine, not be overwritten with committee_index"
+        );
+
+        Ok(())
+    }
+
+    // Test 3 (portable regression) — two single attestations that differ ONLY in the payload vote
+    // must convert to distinct `data`, so the pool cannot merge them. The pre-fix code overwrote
+    // `data.index` with the committee index, collapsing both onto the same `data` (the ★A bug):
+    // this assertion fails there and passes here.
+    #[test]
+    fn single_conversion_keeps_gloas_votes_distinct() -> anyhow::Result<()> {
+        let committee: Vec<u64> = vec![10, 11, 12, 13];
+
+        let vote_empty = gloas_single(2, 0);
+        let vote_full = gloas_single(2, 1);
+
+        let a = vote_empty.try_into_phase0_attestation::<Minimal>(IndexSlice::U64(&committee))?;
+        let b = vote_full.try_into_phase0_attestation::<Minimal>(IndexSlice::U64(&committee))?;
+
+        assert_ne!(
+            a.data, b.data,
+            "payload votes must remain distinct after conversion"
+        );
+
+        Ok(())
     }
 }

--- a/operation_pools/src/attestation_agg_pool/pool.rs
+++ b/operation_pools/src/attestation_agg_pool/pool.rs
@@ -22,7 +22,9 @@ use types::{
     traits::BeaconState,
 };
 
-use crate::attestation_agg_pool::types::{Aggregate, AggregateMap, AttestationMap, AttestationSet};
+use crate::attestation_agg_pool::types::{
+    Aggregate, AggregateMap, AttestationMap, AttestationSet, PoolKey,
+};
 
 #[expect(type_alias_bounds)]
 type AttestationsWithSlot<P: Preset> = (ContiguousList<Attestation<P>, P::MaxAttestations>, Slot);
@@ -84,15 +86,15 @@ impl<P: Preset> Pool<P> {
             .insert(root, data);
     }
 
-    pub async fn aggregates(&self, data: AttestationData) -> Arc<Mutex<Vec<Aggregate<P>>>> {
-        let epoch = data.target.epoch;
+    pub async fn aggregates(&self, key: PoolKey) -> Arc<Mutex<Vec<Aggregate<P>>>> {
+        let epoch = key.data.target.epoch;
 
         if let Some(aggregates) = self
             .aggregates
             .read()
             .await
             .get(&epoch)
-            .and_then(|epoch_aggregates| epoch_aggregates.get(&data))
+            .and_then(|epoch_aggregates| epoch_aggregates.get(&key))
         {
             return aggregates.clone_arc();
         }
@@ -102,7 +104,7 @@ impl<P: Preset> Pool<P> {
             .await
             .entry(epoch)
             .or_default()
-            .entry(data)
+            .entry(key)
             .or_default()
             .clone_arc()
     }
@@ -114,7 +116,12 @@ impl<P: Preset> Pool<P> {
             .get(&epoch)
             .into_iter()
             .flatten()
-            .map(|(data, aggregates)| async {
+            .map(|(key, aggregates)| async {
+                // Boundary emission: rebuild the scratch representation the packer / block
+                // production / HTTP-API paths still expect (`data.index` = committee index).
+                // Storage stays pristine; this is temporary. See TODO(#780).
+                let data = key.rehydrate_phase0_scratch_repr();
+
                 aggregates
                     .lock()
                     .await
@@ -128,7 +135,7 @@ impl<P: Preset> Pool<P> {
 
                         Attestation {
                             aggregation_bits,
-                            data: *data,
+                            data,
                             signature: signature.into(),
                         }
                     })
@@ -173,12 +180,17 @@ impl<P: Preset> Pool<P> {
     ) -> Option<Attestation<P>> {
         let epoch = data.target.epoch;
 
+        // Callers pass a scratch representation (`data.index` = committee index). Recover the
+        // pristine storage key. TEMPORARY, see TODO(#780).
+        let is_post_electra = epoch >= self.chain_config.electra_fork_epoch;
+        let key = PoolKey::from_scratch_repr(data, is_post_electra);
+
         if let Some(aggregates) = self
             .aggregates
             .read()
             .await
             .get(&epoch)
-            .and_then(|epoch_aggregates| epoch_aggregates.get(&data))
+            .and_then(|epoch_aggregates| epoch_aggregates.get(&key))
         {
             return aggregates
                 .lock()
@@ -204,29 +216,46 @@ impl<P: Preset> Pool<P> {
     }
 
     // Handler for the `/eth/v2/validator/aggregate_attestation` API call.
-    // Expects `attestation_data_root` computed from the post-Electra `AttestationData`,
-    // with `committee_index` explicitly set to 0 and provided separately.
+    // `attestation_data_root` is the *spec* root (computed from the post-Electra `AttestationData`
+    // with `index == 0`), and `committee_index` is supplied separately. Both are matched directly
+    // against the pristine `PoolKey`, so there is no scratch-representation `data.index`
+    // manipulation here: the committee index comes from `key.committee_index` and the spec root
+    // from `key.data`.
     pub async fn best_aggregate_attestation_by_data_root_and_committee_index(
         &self,
         attestation_data_root: H256,
         epoch: Epoch,
         committee_index: CommitteeIndex,
     ) -> Option<Attestation<P>> {
-        self.aggregate_attestations_by_epoch(epoch)
+        let epoch_aggregates = self.aggregates.read().await;
+
+        let (key, aggregates) = epoch_aggregates.get(&epoch)?.iter().find(|(key, _)| {
+            key.committee_index == committee_index
+                && key.data.hash_tree_root() == attestation_data_root
+        })?;
+
+        // Boundary emission: rebuild the scratch representation callers expect. TEMPORARY,
+        // see TODO(#780).
+        let data = key.rehydrate_phase0_scratch_repr();
+
+        aggregates
+            .lock()
             .await
-            .into_iter()
-            .filter(|attestation| {
-                let mut data = attestation.data;
-                let data_committee_index = data.index;
+            .iter()
+            .max_by_key(|aggregate| aggregate.aggregation_bits.count_ones())
+            .cloned()
+            .map(|aggregate| {
+                let Aggregate {
+                    aggregation_bits,
+                    signature,
+                } = aggregate;
 
-                if epoch >= self.chain_config.electra_fork_epoch {
-                    data.index = 0;
+                Attestation {
+                    aggregation_bits,
+                    data,
+                    signature: signature.into(),
                 }
-
-                data_committee_index == committee_index
-                    && data.hash_tree_root() == attestation_data_root
             })
-            .max_by_key(|attestation| attestation.aggregation_bits.count_ones())
     }
 
     pub async fn best_aggregate_attestation_by_data_root(
@@ -350,16 +379,16 @@ impl<P: Preset> Pool<P> {
 
     pub async fn singular_attestations(
         &self,
-        data: AttestationData,
+        key: PoolKey,
     ) -> Arc<RwLock<AttestationSet<P>>> {
-        let epoch = data.target.epoch;
+        let epoch = key.data.target.epoch;
 
         if let Some(attestations) = self
             .singular_attestations
             .read()
             .await
             .get(&epoch)
-            .and_then(|epoch_attestations| epoch_attestations.get(&data))
+            .and_then(|epoch_attestations| epoch_attestations.get(&key))
         {
             return attestations.clone_arc();
         }
@@ -369,7 +398,7 @@ impl<P: Preset> Pool<P> {
             .await
             .entry(epoch)
             .or_default()
-            .entry(data)
+            .entry(key)
             .or_default()
             .clone_arc()
     }
@@ -381,7 +410,22 @@ impl<P: Preset> Pool<P> {
             .get(&epoch)
             .into_iter()
             .flatten()
-            .map(|(_, attestations)| async { attestations.read().await.clone() })
+            .map(|(key, attestations)| async move {
+                // Storage is pristine; rebuild the scratch representation callers expect
+                // (`data.index` = committee index). TEMPORARY, see TODO(#780).
+                let data = key.rehydrate_phase0_scratch_repr();
+
+                attestations
+                    .read()
+                    .await
+                    .iter()
+                    .map(|attestation| {
+                        let mut rehydrated = (**attestation).clone();
+                        rehydrated.data = data;
+                        Arc::new(rehydrated)
+                    })
+                    .collect_vec()
+            })
             .collect::<FuturesUnordered<_>>()
             .collect::<Vec<_>>()
             .await

--- a/operation_pools/src/attestation_agg_pool/tasks.rs
+++ b/operation_pools/src/attestation_agg_pool/tasks.rs
@@ -33,7 +33,7 @@ use crate::{
         attestation_packer::{AttestationPacker, PackOutcome},
         conversion::convert_attestation_for_pool,
         pool::Pool,
-        types::Aggregate,
+        types::{Aggregate, PoolKey},
     },
     misc::PoolTask,
 };
@@ -227,22 +227,23 @@ impl<P: Preset, W: Wait> PoolTask for InsertAttestationTask<P, W> {
             attester_index = Some(single_attestation.attester_index);
         }
 
-        let attestation = match convert_attestation_for_pool(&controller, attestation) {
-            Ok(attestation) => attestation,
-            Err(error) => {
-                match error.downcast_ref::<AttestationConversionError>() {
-                    Some(AttestationConversionError::Irrelevant) => {}
-                    Some(AttestationConversionError::AttesterNotInCommittee { .. }) => {
-                        exception!("failed to convert attestation for pool: {error:?}");
+        let (attestation, committee_index) =
+            match convert_attestation_for_pool(&controller, attestation) {
+                Ok(attestation_with_committee) => attestation_with_committee,
+                Err(error) => {
+                    match error.downcast_ref::<AttestationConversionError>() {
+                        Some(AttestationConversionError::Irrelevant) => {}
+                        Some(AttestationConversionError::AttesterNotInCommittee { .. }) => {
+                            exception!("failed to convert attestation for pool: {error:?}");
+                        }
+                        _ => {
+                            warn_with_peers!("failed to convert attestation for pool: {error:?}");
+                        }
                     }
-                    _ => {
-                        warn_with_peers!("failed to convert attestation for pool: {error:?}");
-                    }
-                }
 
-                return Ok(());
-            }
-        };
+                    return Ok(());
+                }
+            };
 
         let Attestation {
             aggregation_bits,
@@ -265,13 +266,19 @@ impl<P: Preset, W: Wait> PoolTask for InsertAttestationTask<P, W> {
                 }
             }
 
-            if !pool.aggregate_in_committee(data.index, data.slot).await {
+            if !pool.aggregate_in_committee(committee_index, data.slot).await {
                 return Ok(());
             }
         }
 
-        let singular_attestations = pool.singular_attestations(data).await;
-        let aggregates = pool.aggregates(data).await;
+        // `data` is pristine (byte-for-byte as signed); the committee index is stored separately.
+        let key = PoolKey {
+            data,
+            committee_index,
+        };
+
+        let singular_attestations = pool.singular_attestations(key).await;
+        let aggregates = pool.aggregates(key).await;
         let mut aggregates = aggregates.lock().await;
 
         if !is_singular || aggregates.is_empty() {
@@ -304,7 +311,11 @@ impl<P: Preset, W: Wait> PoolTask for InsertAttestationTask<P, W> {
             }
         }
 
-        pool.add_data_root_to_data_entry(data).await;
+        // `data_root_to_data_map` is a boundary lookup index for the aggregate-attestation HTTP
+        // API, which addresses aggregates by the scratch-representation root. Keep storing the
+        // scratch representation here so that contract stays byte-identical. TEMPORARY, TODO(#780).
+        pool.add_data_root_to_data_entry(key.rehydrate_phase0_scratch_repr())
+            .await;
 
         drop(wait_group);
 

--- a/operation_pools/src/attestation_agg_pool/types.rs
+++ b/operation_pools/src/attestation_agg_pool/types.rs
@@ -7,16 +7,85 @@ use bls::AggregateSignature;
 use ssz::BitList;
 use tokio::sync::{Mutex, RwLock};
 use types::{
-    phase0::containers::{Attestation, AttestationData},
+    phase0::{
+        containers::{Attestation, AttestationData},
+        primitives::CommitteeIndex,
+    },
     preset::Preset,
 };
+
+/// Key for the pool's per-committee aggregate and singular-attestation maps.
+///
+/// `committee_index` is the pool's **organizational dimension**, and is deliberately kept
+/// separate from `data`. It is NOT part of the signed message: `data.index` carries
+/// fork-specific *signed* meaning (phase0 = committee index; Gloas/EIP-7732 = payload-presence
+/// vote), and must never be conflated with the committee index the pool groups aggregates by.
+///
+/// Storing the committee index here lets `data` stay byte-for-byte as it was signed (pristine).
+/// That is what stops Gloas attestations that differ only in their payload vote (`data.index`
+/// 0 vs 1) from colliding into a single aggregate bucket and having their signatures merged
+/// into an invalid aggregate. Do not fold `committee_index` back into `data.index` for storage.
+/// See TODO(grandinetech/grandine#780).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct PoolKey {
+    pub data: AttestationData,
+    pub committee_index: CommitteeIndex,
+}
+
+impl PoolKey {
+    /// Rebuild the pre-Electra "scratch representation" `AttestationData`, in which `data.index`
+    /// holds the committee index instead of its signed meaning.
+    ///
+    /// TEMPORARY — TODO(grandinetech/grandine#780). This exists only so the current
+    /// `AttestationPacker` (and the block-production / HTTP-API paths that read `data.index` as a
+    /// committee index) keep working byte-for-byte while the pool's *storage* moves to pristine
+    /// data. It MUST be deleted once the packer consumes pristine data directly (the greedy
+    /// baseline PR).
+    ///
+    /// Do NOT use on the Gloas path: re-injecting the committee index overwrites the payload-presence
+    /// vote that `data.index` carries under EIP-7732, producing an attestation that no longer matches
+    /// what was signed. Pre-Electra this is a no-op (`committee_index == data.index` already); for
+    /// Electra/Fulu it restores the committee index the packer expects.
+    #[must_use]
+    pub const fn rehydrate_phase0_scratch_repr(&self) -> AttestationData {
+        AttestationData {
+            index: self.committee_index,
+            ..self.data
+        }
+    }
+
+    /// Inverse of [`Self::rehydrate_phase0_scratch_repr`]: recover the storage key from a scratch
+    /// representation supplied by a caller (validator duties, HTTP-API lookups) whose `data.index`
+    /// holds the committee index.
+    ///
+    /// TEMPORARY — TODO(grandinetech/grandine#780), same lifetime as the rehydrate helper. For
+    /// post-Electra the signed `data.index` is 0, so it is reset here to keep the stored `data`
+    /// pristine; pre-Electra `data.index` is genuinely the committee index and is left untouched.
+    #[must_use]
+    pub fn from_scratch_repr(scratch: AttestationData, is_post_electra: bool) -> Self {
+        let committee_index = scratch.index;
+        let data = if is_post_electra {
+            AttestationData {
+                index: 0,
+                ..scratch
+            }
+        } else {
+            scratch
+        };
+
+        Self {
+            data,
+            committee_index,
+        }
+    }
+}
 
 // Use `Mutex` instead of `RwLock` to avoid race conditions in `InsertAttestationTask`.
 // Don't let this comment fool you into thinking the locking is well thought out.
 // There may be other bugs.
-pub type AggregateMap<P> = HashMap<AttestationData, Arc<Mutex<Vec<Aggregate<P>>>>>;
+pub type AggregateMap<P> = HashMap<PoolKey, Arc<Mutex<Vec<Aggregate<P>>>>>;
 
-pub type AttestationMap<P> = HashMap<AttestationData, Arc<RwLock<AttestationSet<P>>>>;
+pub type AttestationMap<P> = HashMap<PoolKey, Arc<RwLock<AttestationSet<P>>>>;
 
 // Use `BTreeSet` to make attestation packing deterministic for snapshot testing.
 // This does not affect performance in our benchmarks.
@@ -26,4 +95,134 @@ pub type AttestationSet<P> = BTreeSet<Arc<Attestation<P>>>;
 pub struct Aggregate<P: Preset> {
     pub aggregation_bits: BitList<P::MaxValidatorsPerCommittee>,
     pub signature: AggregateSignature,
+}
+
+#[cfg(test)]
+mod tests {
+    use helper_functions::misc;
+    use ssz::{BitVector, SszHash as _};
+    use types::{
+        phase0::{
+            containers::{AttestationData, Checkpoint},
+            primitives::H256,
+        },
+        preset::Minimal,
+    };
+
+    use super::PoolKey;
+
+    fn sample_data(index: u64) -> AttestationData {
+        AttestationData {
+            slot: 42,
+            index,
+            beacon_block_root: H256::repeat_byte(0xaa),
+            source: Checkpoint {
+                epoch: 3,
+                root: H256::repeat_byte(0x11),
+            },
+            target: Checkpoint {
+                epoch: 4,
+                root: H256::repeat_byte(0x22),
+            },
+        }
+    }
+
+    // Test 1 — pre-Electra byte-identical: for a phase0 attestation, emission
+    // (`rehydrate ∘ from_scratch_repr`) reproduces the input exactly (structural + SSZ root).
+    // This is the executable evidence for the "pre-Electra byte-identical" claim.
+    #[test]
+    fn phase0_scratch_roundtrip_is_byte_identical() {
+        // Phase0: `data.index` genuinely is the committee index, so is_post_electra = false.
+        let data = sample_data(3);
+
+        let key = PoolKey::from_scratch_repr(data, false);
+
+        // Committee comes from data.index; stored data stays pristine (== input for phase0).
+        assert_eq!(key.committee_index, 3);
+        assert_eq!(key.data, data);
+
+        let emitted = key.rehydrate_phase0_scratch_repr();
+
+        assert_eq!(emitted, data);
+        assert_eq!(emitted.hash_tree_root(), data.hash_tree_root());
+    }
+
+    // The post-Electra scratch round-trip is also the identity: storage drops the committee index
+    // out of `data` (keeping it pristine, index == 0), and emission re-injects it.
+    #[test]
+    fn electra_scratch_roundtrip_reconstructs_input() {
+        // Caller-supplied scratch repr: `data.index` carries the committee index (7).
+        let scratch = sample_data(7);
+
+        let key = PoolKey::from_scratch_repr(scratch, true);
+
+        assert_eq!(key.committee_index, 7);
+        assert_eq!(key.data.index, 0, "post-Electra stored data.index must be pristine (0)");
+
+        assert_eq!(key.rehydrate_phase0_scratch_repr(), scratch);
+    }
+
+    // Test 2 — Electra inflow keeps data pristine and derives the committee from committee_bits.
+    #[test]
+    fn electra_inflow_keeps_data_pristine_and_extracts_committee() {
+        // Model the pool's Electra inflow: committee from committee_bits, data untouched.
+        let mut committee_bits = BitVector::default();
+        committee_bits.set(2, true);
+
+        let committee_index = misc::get_committee_indices::<Minimal>(committee_bits)
+            .next()
+            .expect("exactly one committee bit is set");
+
+        // Incoming Electra data: the signed `data.index` is 0 (pristine).
+        let data = sample_data(0);
+        let key = PoolKey {
+            data,
+            committee_index,
+        };
+
+        assert_eq!(key.committee_index, 2);
+        assert_eq!(
+            key.data.index, 0,
+            "pristine data.index must not be overwritten with the committee index"
+        );
+    }
+
+    // Test 3 — Gloas payload-vote separation (★A): two attestations identical except for the
+    // payload-presence vote in `data.index` (0 vs 1), for the SAME committee, must map to distinct
+    // PoolKeys so their signatures are never aggregated into an invalid combined signature.
+    #[test]
+    fn poolkey_separates_gloas_payload_votes() {
+        let committee_index = 2;
+
+        let vote_empty = sample_data(0); // payload EMPTY
+        let vote_full = sample_data(1); // payload FULL — same slot/source/target/head + committee
+
+        let key_empty = PoolKey {
+            data: vote_empty,
+            committee_index,
+        };
+        let key_full = PoolKey {
+            data: vote_full,
+            committee_index,
+        };
+
+        // Same committee, but the signed data differs → different keys → different buckets.
+        assert_eq!(key_empty.committee_index, key_full.committee_index);
+        assert_ne!(key_empty, key_full, "payload votes must not collide into one bucket");
+
+        // Characterise the pre-fix behaviour this fixes: the old pool folded the committee index
+        // into `data.index`, collapsing both votes onto a single AttestationData map key.
+        let old_key_empty = AttestationData {
+            index: committee_index,
+            ..vote_empty
+        };
+        let old_key_full = AttestationData {
+            index: committee_index,
+            ..vote_full
+        };
+        assert_eq!(
+            old_key_empty, old_key_full,
+            "the old committee-in-data.index representation merged the two votes (the ★A bug)"
+        );
+    }
 }

--- a/types/src/electra/container_impls.rs
+++ b/types/src/electra/container_impls.rs
@@ -151,6 +151,12 @@ impl<P: Preset> TryFrom<Phase0Attestation<P>> for Attestation<P> {
 
         let aggregation_bits: Vec<u8> = aggregation_bits.into();
         let mut committee_bits = BitVector::default();
+        // This reads the committee index out of `data.index` and resets `data.index` to 0. That is
+        // correct for Electra/Fulu (where the signed `data.index` is 0 and the pool feeds this a
+        // scratch representation with the committee index in `data.index`). It is NOT valid under
+        // Gloas, where `data.index` is the payload-presence vote: hardcoding 0 here would discard
+        // that vote. Left intact for this PR; to be removed once the packer stops relying on the
+        // scratch representation. See TODO(grandinetech/grandine#780).
         committee_bits.set(data.index.try_into()?, true);
 
         Ok(Self {
@@ -200,10 +206,10 @@ impl SingleAttestation {
             signature,
         } = self;
 
-        let data = AttestationData {
-            index: committee_index,
-            ..data
-        };
+        // Keep `data` pristine: a single attestation's signed `data.index` is 0 post-Electra, and
+        // the committee index is tracked separately by the pool (via `PoolKey`). Folding it into
+        // `data.index` here would corrupt the signed root under Gloas, where that field is the
+        // payload-presence vote. See TODO(grandinetech/grandine#780).
 
         ensure!(
             committee_index < P::MaxCommitteesPerSlot::U64,


### PR DESCRIPTION
Part of #780. This is the "representation cleanup" step from [this comment](https://github.com/grandinetech/grandine/issues/780#issuecomment-5005509645).

### Problem

The aggregate pool stores attestations in phase0 form and reuses `AttestationData.index` as a scratch field for the committee index. All three ingestion paths write to it, and the outbound conversion hardcodes it back to `0`. This is lossless on Electra/Fulu (`index` is always zero there), but Gloas revives the field as the payload-availability vote (`assert data.index < 2`), covered by the attester's signature. With the current representation the vote is destroyed on ingestion, and two attestations that differ only in their payload vote collapse into the same pool bucket, merging signatures across different signing roots.

### Approach

Committee index is an organizational dimension of the pool, not signed data, so it moves into an explicit `PoolKey { data, committee_index }` map key, and `data` stays byte-for-byte as signed (Electra: `index == 0`, Gloas: payload vote preserved).

Scope is deliberately limited to storage. The packer, block-production, and HTTP-API boundaries still receive the old scratch representation via an explicitly temporary `rehydrate_phase0_scratch_repr` helper (marked `TODO(#780)`), so pre-Gloas behaviour is byte-identical and this PR changes no observable behaviour. The rehydration is removed in the next step (greedy baseline), when the packer consumes pristine data directly.

Two refinements from the plan comment. First, investigation showed network aggregates are single-committee per spec, so the pool keeps its single-committee width and the committee index moves into the key rather than storing full Electra containers. Second, the `electra::get_attesting_indices` switch moves to the greedy-baseline PR, where it belongs together with the packer consuming pristine data.

The two external read sites of the scratch `data.index` (`block_producer` and the aggregate-attestation HTTP handler) now go through the canonical committee accessor instead.

### Testing

The existing packing snapshot tests feed attestations directly into the packer and bypass pool conversion, storage, and emission, so they don't cover this path. Added round-trip unit tests (no eth2-cache needed):

- phase0 round-trip is byte-identical (structural and `hash_tree_root` equality)
- Electra ingestion keeps `data` pristine and extracts the committee index into the key
- Gloas payload votes 0/1 land in distinct pool keys and are never merged
- `SingleAttestation` conversion no longer overwrites `data.index`

Two of these are portable to the pre-fix code and fail there (`single_conversion_keeps_gloas_votes_distinct`, `single_conversion_keeps_data_index_pristine`), confirming they are genuine regression tests for the Gloas issue.

One deliberate edge-case change: the v2 aggregate-attestation lookup previously compared roots after resetting `index` to 0, producing a root that matches nothing for genuine phase0 data; it now matches against the pristine stored key. This only affects hypothetical pre-Electra queries through the v2 endpoint (Electra+ in practice) and is a strict improvement.

### Next

Greedy baseline: remove the solver path and the rehydration boundary, move on-chain aggregation into the packer so selection operates in block-budget units (8). Payload attestations (PTC) will be a separate issue.