### PR TITLE
Remove the solver-based attestation packing path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6406,16 +6406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "good_lp"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf53d2a05420f562c917615b80018647ca03766aa58376de077034627da0fb10"
-dependencies = [
- "fnv",
- "highs",
-]
-
-[[package]]
 name = "grandine"
 version = "0.0.0"
 dependencies = [
@@ -6881,26 +6871,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "highs"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f739d4b9d063219b2dfa00705d8f2127fcead4d053867a5557c953dc3a4b99"
-dependencies = [
- "highs-sys",
- "log",
-]
-
-[[package]]
-name = "highs-sys"
-version = "1.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a9fa9dea5b5f277075460b695db30ad7e5ce28554f2dd27c312c640acd101f"
-dependencies = [
- "bindgen 0.72.1",
- "cmake",
 ]
 
 [[package]]
@@ -9791,13 +9761,11 @@ dependencies = [
  "fork_choice_control",
  "fork_choice_store",
  "futures",
- "good_lp",
  "helper_functions",
  "itertools 0.14.0",
  "logging",
  "prometheus_metrics",
  "pubkey_cache",
- "rayon",
  "serde",
  "ssz",
  "std_ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,7 +339,6 @@ gag = '1'
 generic-array = { version = '=0.14.7', features = ['serde'] }
 git-version = '0.3'
 glob = '0.3'
-good_lp = { version = '1', default-features = false, features = ['highs'] }
 hash_hasher = '2'
 hex = { version = '0.4', features = ['serde'] }
 hex-literal = '1'

--- a/benches/benches/operation_pools.rs
+++ b/benches/benches/operation_pools.rs
@@ -11,7 +11,6 @@ use allocator as _;
 use criterion::{Criterion, Throughput};
 use easy_ext::ext;
 use eth2_cache_utils::{LazyBeaconState, goerli, holesky};
-use helper_functions::accessors;
 use operation_pools::AttestationPacker;
 use std_ext::ArcExt as _;
 use types::{config::Config, phase0::containers::Attestation, preset::Preset};
@@ -28,22 +27,8 @@ fn main() {
             }),
             LazyCell::new(|| goerli::attestations_sorted_by_data("aggregate_attestations", 17119)),
         )
-        .benchmark_optimal_attestation_packing(
-            "optimal attestation packing in Goerli at slot 547813",
-            LazyBeaconState::new(|| goerli::beacon_state(547_813, 6)),
-            LazyCell::new(|| {
-                goerli::attestations_sorted_by_data("aggregate_attestations", 17119 - 1)
-            }),
-            LazyCell::new(|| goerli::attestations_sorted_by_data("aggregate_attestations", 17119)),
-        )
         .benchmark_greedy_attestation_packing(
             "greedy attestation packing in Holesky at slot 50015",
-            LazyBeaconState::new(|| holesky::beacon_state(50_015, 8)),
-            LazyCell::new(|| holesky::aggregate_attestations_by_epoch_sorted_by_data(1562 - 1)),
-            LazyCell::new(|| holesky::aggregate_attestations_by_epoch_sorted_by_data(1562)),
-        )
-        .benchmark_optimal_attestation_packing(
-            "optimal attestation packing in Holesky at slot 50015",
             LazyBeaconState::new(|| holesky::beacon_state(50_015, 8)),
             LazyCell::new(|| holesky::aggregate_attestations_by_epoch_sorted_by_data(1562 - 1)),
             LazyCell::new(|| holesky::aggregate_attestations_by_epoch_sorted_by_data(1562)),
@@ -64,9 +49,8 @@ impl Criterion {
 
         let packer = LazyCell::new(|| {
             let state = state.force().clone_arc();
-            let latest_block_root = accessors::latest_block_root(&state);
 
-            AttestationPacker::new(config, latest_block_root, state, true)
+            AttestationPacker::new(config, state, true)
                 .expect("AttestationPacker should be constructed successfully")
         });
 
@@ -84,44 +68,6 @@ impl Criterion {
                             previous_aggregates,
                             current_aggregates,
                         )
-                    })
-                },
-            );
-
-        self
-    }
-
-    fn benchmark_optimal_attestation_packing<P: Preset>(
-        &mut self,
-        group_name: &str,
-        state: LazyBeaconState<P>,
-        previous_aggregates: LazyCell<Vec<Attestation<P>>>,
-        current_aggregates: LazyCell<Vec<Attestation<P>>>,
-    ) -> &mut Self {
-        let config = Arc::new(Config::mainnet());
-
-        let packer = LazyCell::new(|| {
-            let state = state.force().clone_arc();
-            let latest_block_root = accessors::latest_block_root(&state);
-
-            AttestationPacker::new(config, latest_block_root, state, true)
-                .expect("AttestationPacker should be constructed successfully")
-        });
-
-        self.benchmark_group(group_name)
-            .throughput(Throughput::Elements(1))
-            .bench_function(
-                "AttestationPacker::pack_proposable_attestations_optimally",
-                |bencher| {
-                    let packer = LazyCell::force(&packer);
-                    let previous_aggregates = LazyCell::force(&previous_aggregates);
-                    let current_aggregates = LazyCell::force(&current_aggregates);
-
-                    bencher.iter_with_large_drop(|| {
-                        packer.pack_proposable_attestations_optimally(
-                            previous_aggregates,
-                            current_aggregates,
-                        );
                     })
                 },
             );

--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -892,12 +892,10 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                     Vec<ElectraAttestation<P>>,
                 )> = Vec::new();
 
-                for (electra_attestation, committee_index) in
+                for electra_attestation in
                     attestations.into_iter().filter_map(|attestation| {
-                        let committee_index = attestation.data.index;
-
                         match operation_pools::convert_to_electra_attestation(attestation) {
-                            Ok(electra_attestation) => Some((electra_attestation, committee_index)),
+                            Ok(electra_attestation) => Some(electra_attestation),
                             Err(error) => {
                                 warn_with_peers!(
                                     "unable to convert to electra attestation: {error:?}"
@@ -907,6 +905,14 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
                         }
                     })
                 {
+                    // The pool emits a temporary scratch representation with the committee index in
+                    // `data.index`; read the committee canonically from the converted attestation's
+                    // `committee_bits` instead of `data.index`. See TODO(grandinetech/grandine#780).
+                    let committee_index =
+                        misc::get_committee_indices::<P>(electra_attestation.committee_bits)
+                            .next()
+                            .unwrap_or_default();
+
                     if let Some((_, indices, attestations)) =
                         results.iter_mut().find(|(data, indices, _)| {
                             *data == electra_attestation.data && !indices.contains(&committee_index)

--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -4347,18 +4347,23 @@ async fn get_pool_attestations<P: Preset, W: Wait>(
     aggregates
         .iter()
         .chain(singular_attestations.iter().map(Arc::as_ref))
-        .filter(|attestation| {
-            attestation.data.index == committee_index && attestation.data.slot == slot
-        })
         .cloned()
         .filter_map(|attestation| {
-            if phase < Phase::Electra {
-                Some(Attestation::Phase0(attestation))
+            // The pool emits a temporary scratch representation with the committee index in
+            // `data.index`. Classify the combined attestation via the canonical
+            // `misc::committee_index` accessor instead of reading `data.index` directly.
+            // See TODO(grandinetech/grandine#780).
+            let attestation = if phase < Phase::Electra {
+                Attestation::Phase0(attestation)
             } else {
                 convert_to_electra_attestation(attestation)
                     .map(Attestation::Electra)
-                    .ok()
-            }
+                    .ok()?
+            };
+
+            (misc::committee_index(&attestation) == committee_index
+                && attestation.data().slot == slot)
+                .then_some(attestation)
         })
         .collect()
 }

--- a/operation_pools/Cargo.toml
+++ b/operation_pools/Cargo.toml
@@ -19,13 +19,11 @@ features = { workspace = true }
 fork_choice_control = { workspace = true }
 fork_choice_store = { workspace = true }
 futures = { workspace = true }
-good_lp = { workspace = true }
 helper_functions = { workspace = true }
 itertools = { workspace = true }
 logging = { workspace = true }
 prometheus_metrics = { workspace = true }
 pubkey_cache = { workspace = true }
-rayon = { workspace = true }
 serde = { workspace = true }
 ssz = { workspace = true }
 std_ext = { workspace = true }

--- a/operation_pools/src/attestation_agg_pool/attestation_packer.rs
+++ b/operation_pools/src/attestation_agg_pool/attestation_packer.rs
@@ -1,25 +1,14 @@
-use core::{cmp::min, marker::PhantomData};
-use std::{
-    collections::{HashMap, HashSet, btree_map::BTreeMap},
-    sync::Arc,
-};
+use core::marker::PhantomData;
+use std::{collections::btree_map::BTreeMap, sync::Arc};
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bit_field::BitField as _;
 use clock::Tick;
-use good_lp::{
-    Expression, Solution, SolverModel, solvers::highs::HighsParallelType, solvers::highs::highs,
-    variable, variables,
-};
 use helper_functions::{
     accessors::{self, get_base_reward, get_base_reward_per_increment},
     misc, phase0,
 };
 use itertools::Itertools as _;
-use rayon::iter::{
-    IndexedParallelIterator as _, IntoParallelIterator as _, IntoParallelRefIterator as _,
-    ParallelIterator as _,
-};
 use ssz::ContiguousList;
 use tap::Pipe as _;
 use try_from_iterator::TryFromIterator as _;
@@ -32,32 +21,15 @@ use types::{
     phase0::{
         beacon_state::BeaconState as Phase0BeaconState,
         containers::{Attestation, PendingAttestation},
-        primitives::{H256, ValidatorIndex},
+        primitives::ValidatorIndex,
     },
     preset::Preset,
     traits::BeaconState as _,
 };
 
-/// Constant used to limit number of calls to `select_max_cover_attestation_integer_programming`
-/// It is used when we need a lot of aggregates (more than `MAXIMUM_ATTESTATIONS_WITH_SAME_DATA`)
-/// to include all validators that signed same attestation data. In that case it could improve performance,
-/// while it is unlikely to drastically decrease score.
-const MAXIMUM_ATTESTATIONS_WITH_SAME_DATA: usize = 6;
-
-/// Constant used to compute time that integer programming solver can use.
-/// Since `good_lp` calls external solvers, there is no way to stop execution if it takes too long.
-/// However, one can set time limit for solver. Here it is some fraction of remaining time until deadline.
-const TIME_FRACTION_FOR_SUBPROBLEM: f64 = 0.25;
-
 pub struct PackOutcome<P: Preset> {
     pub attestations: ContiguousList<Attestation<P>, P::MaxAttestations>,
     pub deadline_reached: bool,
-}
-
-#[derive(Default)]
-struct AttestationWeights {
-    compressed_validator_indices: Vec<usize>,
-    validator_weights: Vec<u64>,
 }
 
 // The phantom type parameter is needed to prevent the impl below from causing `E0207`.
@@ -65,7 +37,6 @@ struct AttestationWeights {
 // making the impl overlap with itself.
 pub struct AttestationPacker<P: Preset> {
     config: Arc<Config>,
-    head_block_root: H256,
     state: Arc<BeaconState<P>>,
     previous_epoch_participation: Vec<ParticipationFlags>,
     current_epoch_participation: Vec<ParticipationFlags>,
@@ -76,7 +47,6 @@ pub struct AttestationPacker<P: Preset> {
 impl<P: Preset> AttestationPacker<P> {
     pub fn new(
         config: Arc<Config>,
-        head_block_root: H256,
         state: Arc<BeaconState<P>>,
         ignore_deadline: bool,
     ) -> Result<Self> {
@@ -88,7 +58,6 @@ impl<P: Preset> AttestationPacker<P> {
 
         Ok(Self {
             config,
-            head_block_root,
             state,
             previous_epoch_participation,
             current_epoch_participation,
@@ -184,413 +153,6 @@ impl<P: Preset> AttestationPacker<P> {
         }
     }
 
-    fn aggregates_grouped_by_data<'a>(
-        &self,
-        previous_epoch_aggregates: impl IntoIterator<Item = &'a Attestation<P>>,
-        current_epoch_aggregates: impl IntoIterator<Item = &'a Attestation<P>>,
-    ) -> Vec<Vec<Attestation<P>>> {
-        previous_epoch_aggregates
-            .into_iter()
-            .chain(current_epoch_aggregates)
-            .take_while(|_| !self.deadline_reached())
-            .filter(|aggregate| self.is_valid_for_inclusion(aggregate))
-            .map(|aggregate| (aggregate.data, aggregate))
-            .chunk_by(|&(data, _)| data)
-            .into_iter()
-            .map(|(_, group)| group.map(|(_, y)| y.clone()).collect())
-            .collect_vec()
-    }
-
-    // this function assumes that every aggregate have same AttestationData
-    fn find_attestation_weights(
-        &self,
-        aggregates: &Vec<Attestation<P>>,
-    ) -> Result<Vec<AttestationWeights>> {
-        let mut attestation_weights = Vec::new();
-        let base_reward_per_increment = get_base_reward_per_increment(&self.state)?;
-
-        for attestation in aggregates {
-            let attestation_epoch = self.attestation_epoch(attestation)?;
-            let participation_flags = self.participation_flags(attestation)?;
-
-            let mut compressed_validator_indices = Vec::new();
-            let mut validator_weights = Vec::new();
-            for validator_index in self.attesting_indices(attestation)? {
-                let index = usize::try_from(validator_index)?;
-                let epoch_participation = match attestation_epoch {
-                    AttestationEpoch::Previous => self.previous_epoch_participation[index],
-                    AttestationEpoch::Current => self.current_epoch_participation[index],
-                };
-                let combined_weight_for_validator = PARTICIPATION_FLAG_WEIGHTS
-                    .iter()
-                    .filter(|(flag_index, _)| {
-                        participation_flags.get_bit(*flag_index)
-                            && !epoch_participation.get_bit(*flag_index)
-                    })
-                    .map(|(_, weight)| {
-                        weight.saturating_mul(
-                            get_base_reward(
-                                &self.state,
-                                validator_index,
-                                base_reward_per_increment,
-                            )
-                            .unwrap_or(0),
-                        )
-                    })
-                    .sum::<u64>();
-                compressed_validator_indices.push(index);
-                validator_weights.push(combined_weight_for_validator);
-            }
-            attestation_weights.push(AttestationWeights {
-                compressed_validator_indices,
-                validator_weights,
-            });
-        }
-        Ok(attestation_weights)
-    }
-
-    fn find_optimal_selections(
-        &self,
-        aggregates: &[Attestation<P>],
-        group_weights: &[AttestationWeights],
-    ) -> (Vec<Vec<usize>>, Vec<u64>) {
-        let mut choices = vec![vec![]];
-        let mut values = vec![0];
-
-        let mut best_weight;
-
-        if self.deadline_reached() {
-            return (choices, values);
-        }
-
-        let maximum_possible_weight = Self::maximum_added_weight(group_weights);
-
-        if self.deadline_reached() {
-            return (choices, values);
-        }
-
-        let (one_vec, one_weight) =
-            Self::select_one_attestation_greedily(aggregates, group_weights);
-        best_weight = one_weight;
-        choices.push(one_vec);
-        values.push(one_weight);
-
-        for number_of_aggregates_to_select in
-            2..=min(aggregates.len(), MAXIMUM_ATTESTATIONS_WITH_SAME_DATA)
-        {
-            if self.deadline_reached() || best_weight == maximum_possible_weight {
-                break;
-            }
-
-            match self.select_max_cover_attestation_integer_programming(
-                aggregates,
-                group_weights,
-                number_of_aggregates_to_select,
-            ) {
-                Err(_) => break,
-                Ok((attestation_choice, weight)) => {
-                    if weight > best_weight {
-                        choices.push(attestation_choice);
-                        values.push(weight);
-                        best_weight = weight;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-
-        (choices, values)
-    }
-
-    #[expect(clippy::needless_range_loop, reason = "the intent becomes less clear")]
-    pub fn pack_proposable_attestations_optimally<'a>(
-        &self,
-        previous_epoch_aggregates: impl IntoIterator<Item = &'a Attestation<P>>,
-        current_epoch_aggregates: impl IntoIterator<Item = &'a Attestation<P>>,
-    ) -> PackOutcome<P> {
-        let grouped_aggregates =
-            self.aggregates_grouped_by_data(previous_epoch_aggregates, current_epoch_aggregates);
-
-        let grouped_aggregates_weights = grouped_aggregates
-            .par_iter()
-            .map(|aggregates| {
-                self.find_attestation_weights(aggregates)
-                    .unwrap_or_default()
-            })
-            .collect::<Vec<_>>();
-
-        let different_data_count = grouped_aggregates.len();
-
-        let (choices, choice_values): (Vec<_>, Vec<_>) = grouped_aggregates
-            .par_iter()
-            .zip(grouped_aggregates_weights.into_par_iter())
-            .map(|(agg_group, group_weights)| {
-                self.find_optimal_selections(agg_group, &group_weights)
-            })
-            .unzip();
-
-        let mut best_weight = vec![
-            vec![0_u64; P::MaxAttestations::USIZE.saturating_add(1)];
-            different_data_count.saturating_add(1)
-        ];
-
-        let mut prev = vec![
-            vec![0_usize; P::MaxAttestations::USIZE.saturating_add(1)];
-            different_data_count.saturating_add(1)
-        ];
-
-        let mut reachable = vec![
-            vec![false; P::MaxAttestations::USIZE.saturating_add(1)];
-            different_data_count.saturating_add(1)
-        ];
-
-        reachable[0][0] = true;
-
-        for groups_analyzed in 0..different_data_count {
-            for att_selected in 0..=P::MaxAttestations::USIZE {
-                for new_att_selected in 0..min(
-                    choices[groups_analyzed].len(),
-                    att_selected.saturating_add(1),
-                ) {
-                    let value_of_new_att = choice_values[groups_analyzed][new_att_selected];
-                    let previously_had_attestations = att_selected.saturating_sub(new_att_selected);
-                    if reachable[groups_analyzed][previously_had_attestations]
-                        && (best_weight[groups_analyzed.saturating_add(1)][att_selected]
-                            <= best_weight[groups_analyzed][previously_had_attestations]
-                                .saturating_add(value_of_new_att))
-                    {
-                        best_weight[groups_analyzed.saturating_add(1)][att_selected] = best_weight
-                            [groups_analyzed][previously_had_attestations]
-                            .saturating_add(value_of_new_att);
-
-                        prev[groups_analyzed.saturating_add(1)][att_selected] =
-                            previously_had_attestations;
-
-                        reachable[groups_analyzed.saturating_add(1)][att_selected] = true;
-                    }
-                }
-            }
-        }
-
-        // att_selected is the minimal number of attestations that reach best weight
-        // minimal number is chosen so there wouldn't be attestations that don't add weight
-        let mut att_selected = 0;
-        for i in 0..=P::MaxAttestations::USIZE {
-            if best_weight[different_data_count][i]
-                > best_weight[different_data_count][att_selected]
-            {
-                att_selected = i;
-            }
-        }
-
-        let mut attestations = Vec::new();
-        for groups_analyzed in (1..=different_data_count).rev() {
-            let new_att_selected = att_selected.saturating_sub(prev[groups_analyzed][att_selected]);
-
-            for choice in &choices[groups_analyzed.saturating_sub(1)][new_att_selected] {
-                attestations
-                    .push(grouped_aggregates[groups_analyzed.saturating_sub(1)][*choice].clone());
-            }
-
-            att_selected = prev[groups_analyzed][att_selected];
-        }
-
-        attestations.truncate(P::MaxAttestations::USIZE);
-
-        PackOutcome {
-            attestations: attestations.try_into().expect(
-                "the call to Vec::truncate limits the number \
-                 of attestations to P::MaxAttestations::USIZE",
-            ),
-            deadline_reached: self.deadline_reached(),
-        }
-    }
-
-    #[expect(clippy::float_arithmetic)]
-    fn f64_values_are_approximately_equal(a: f64, b: f64) -> bool {
-        (a - b).abs() < f64::EPSILON
-    }
-
-    // This function solves maximum coverage problem by using integer linear programming (https://en.wikipedia.org/wiki/Maximum_coverage_problem)
-    // It uses the assumption that all aggregates have the same AttestationData
-    #[expect(clippy::too_many_lines)]
-    #[expect(clippy::float_arithmetic)]
-    #[expect(
-        clippy::arithmetic_side_effects,
-        reason = "good_lp::Expression does not implement safe arithmetics"
-    )]
-    fn select_max_cover_attestation_integer_programming(
-        &self,
-        aggregates: &[Attestation<P>],
-        group_weights: &[AttestationWeights],
-        selected_aggregates_count: usize,
-    ) -> Result<(Vec<usize>, u64)> {
-        variables! {
-            vars:
-        }
-
-        let attestation_count = aggregates.len();
-
-        let mut number_of_aggregates_selected = Expression::with_capacity(attestation_count);
-        let is_aggregate_selected: Vec<_> = (0..attestation_count)
-            .map(|_| {
-                let aggregate_selected = vars.add(variable().binary());
-                number_of_aggregates_selected += aggregate_selected;
-                aggregate_selected
-            })
-            .collect();
-
-        let mut is_validator_included_variables = Vec::new();
-        let mut validator_weights = Vec::new();
-
-        let mut validator_index_to_validator_included_variable_index = HashMap::new();
-        let mut aggregates_containing_validator = Vec::new();
-
-        for (i, group_weight) in group_weights.iter().enumerate() {
-            for (validator_index, combined_weight_for_validator) in group_weight
-                .compressed_validator_indices
-                .iter()
-                .zip(group_weight.validator_weights.iter())
-            {
-                let mut useless_validator = false;
-                if let std::collections::hash_map::Entry::Vacant(_) =
-                    validator_index_to_validator_included_variable_index.entry(validator_index)
-                {
-                    if *combined_weight_for_validator > 0 {
-                        validator_index_to_validator_included_variable_index
-                            .insert(validator_index, is_validator_included_variables.len());
-                        is_validator_included_variables.push(vars.add(variable().binary()));
-                        aggregates_containing_validator.push(Vec::new());
-                        validator_weights.push(combined_weight_for_validator);
-                    } else {
-                        useless_validator = true;
-                    }
-                }
-                if !useless_validator {
-                    aggregates_containing_validator
-                        [validator_index_to_validator_included_variable_index[&validator_index]]
-                        .push(i);
-                }
-            }
-        }
-
-        // Validators that are in every attestation will be included anyway,
-        // thus, some expression for solver can be simplified (it speeds up solver).
-        let validator_in_every_aggregate = aggregates_containing_validator
-            .iter()
-            .map(|agg_containing_val| agg_containing_val.len() == aggregates.len())
-            .collect_vec();
-
-        let mut objective = Expression::with_capacity(0);
-
-        let mut answer_value: u64 = 0;
-        for i in 0..is_validator_included_variables.len() {
-            if validator_in_every_aggregate[i] {
-                answer_value = answer_value.saturating_add(*validator_weights[i]);
-            } else {
-                // here conversion to i32 is needed, since `good_lp` only support i32 integers
-                objective +=
-                    is_validator_included_variables[i] * i32::try_from(*validator_weights[i])?;
-            }
-        }
-
-        let mut problem = vars.maximise(objective).using(highs);
-        problem = problem
-            .with(number_of_aggregates_selected.eq(i32::try_from(selected_aggregates_count)?));
-
-        for (i, is_validator_included) in is_validator_included_variables.iter().enumerate() {
-            if !validator_in_every_aggregate[i] {
-                let mut validator_expression = Expression::with_capacity(0);
-                for ind in &aggregates_containing_validator[i] {
-                    validator_expression += is_aggregate_selected[*ind];
-                }
-                validator_expression -= is_validator_included;
-                problem = problem.with(validator_expression.geq(0));
-            }
-        }
-
-        let mut selected_aggregates = Vec::new();
-
-        // Here parallelization is unnecessary, since integer programming is called for each different attestation data
-        problem = problem.set_parallel(HighsParallelType::Off).set_threads(1);
-
-        problem = problem
-            .set_time_limit(self.time_until_deadline_in_seconds()? * TIME_FRACTION_FOR_SUBPROBLEM);
-
-        let solution = problem.solve()?;
-
-        for (i, is_selected) in is_aggregate_selected.iter().enumerate() {
-            // Crate `good_lp` represents all variables with floating point, so this checks if binary value is 1.
-            if Self::f64_values_are_approximately_equal(solution.value(*is_selected), 1.0) {
-                selected_aggregates.push(i);
-            }
-        }
-
-        if selected_aggregates.len() != selected_aggregates_count {
-            bail!("Integer programming returned incomplete solution for attestation packing");
-        }
-
-        for i in 0..is_validator_included_variables.len() {
-            if !validator_in_every_aggregate[i]
-                && Self::f64_values_are_approximately_equal(
-                    solution.value(is_validator_included_variables[i]),
-                    1.0,
-                )
-            {
-                // In case of incomplete solution, this tests whether validator would actually be included.
-                let attestation_was_included =
-                    aggregates_containing_validator[i].iter().any(|id| {
-                        Self::f64_values_are_approximately_equal(
-                            solution.value(is_aggregate_selected[*id]),
-                            1.0,
-                        )
-                    });
-                if attestation_was_included {
-                    answer_value = answer_value.saturating_add(*validator_weights[i]);
-                }
-            }
-        }
-
-        Ok((selected_aggregates, answer_value))
-    }
-
-    fn select_one_attestation_greedily(
-        attestations: &[Attestation<P>],
-        group_weights: &[AttestationWeights],
-    ) -> (Vec<usize>, u64) {
-        let mut best_id = 0;
-        let mut best_weight = 0;
-        for (i, group_weight) in group_weights.iter().enumerate().take(attestations.len()) {
-            let sum_weight = group_weight.validator_weights.iter().sum::<u64>();
-            if sum_weight > best_weight {
-                best_weight = sum_weight;
-                best_id = i;
-            }
-        }
-
-        (vec![best_id], best_weight)
-    }
-
-    #[must_use]
-    pub fn should_update_current_participation(&self, head_block_root: H256) -> bool {
-        head_block_root != self.head_block_root && !self.deadline_reached()
-    }
-
-    pub fn update_current_participation(
-        &mut self,
-        head_block_root: H256,
-        state: Arc<BeaconState<P>>,
-    ) -> Result<()> {
-        self.head_block_root = head_block_root;
-        self.state = state;
-        self.previous_epoch_participation =
-            compute_epoch_participation(&self.state, AttestationEpoch::Previous)?;
-        self.current_epoch_participation =
-            compute_epoch_participation(&self.state, AttestationEpoch::Current)?;
-        Ok(())
-    }
-
     fn is_valid_for_inclusion(&self, attestation: &Attestation<P>) -> bool {
         let low_slot = attestation
             .data
@@ -663,24 +225,6 @@ impl<P: Preset> AttestationPacker<P> {
             .sum()
     }
 
-    fn maximum_added_weight(group_weights: &[AttestationWeights]) -> u64 {
-        let mut ans: u64 = 0;
-        let mut counted_validator_indices = HashSet::new();
-        for attestation_weight in group_weights {
-            for (id, weight) in attestation_weight
-                .compressed_validator_indices
-                .iter()
-                .zip(attestation_weight.validator_weights.iter())
-            {
-                if counted_validator_indices.insert(id) {
-                    ans = ans.saturating_add(*weight);
-                }
-            }
-        }
-
-        ans
-    }
-
     fn add_attestation(
         &self,
         attestation: &Attestation<P>,
@@ -709,18 +253,6 @@ impl<P: Preset> AttestationPacker<P> {
 
     fn attestation_epoch(&self, attestation: &Attestation<P>) -> Result<AttestationEpoch> {
         accessors::attestation_epoch(&self.state, attestation.data.target.epoch)
-    }
-
-    fn time_until_deadline_in_seconds(&self) -> Result<f64> {
-        let (_, remaining_time) =
-            clock::next_interval_with_remaining_time::<P>(&self.config, self.state.genesis_time())?;
-        if self.ignore_deadline {
-            Ok(self.config.slot_duration_ms.as_secs_f64())
-        } else if self.deadline_reached() {
-            Ok(0.0)
-        } else {
-            Ok(remaining_time.as_secs_f64())
-        }
     }
 
     fn deadline_reached(&self) -> bool {
@@ -866,7 +398,6 @@ mod tests {
         let slot = 547_813;
         let epoch = misc::compute_epoch_at_slot::<Mainnet>(slot);
         let state = goerli::beacon_state(slot, 6);
-        let latest_block_root = accessors::latest_block_root(&state);
 
         // Optimal packing uses the assumption that attestations are sorted by their data (this assumption is fulfilled when values are taken from BTree)
         let previous_epoch_aggregates =
@@ -877,12 +408,7 @@ mod tests {
         let _unused = accessors::initialize_shuffled_indices(&state, &previous_epoch_aggregates);
         let _unused = accessors::initialize_shuffled_indices(&state, &current_epoch_aggregates);
 
-        let packer = AttestationPacker::new(
-            config.clone_arc(),
-            latest_block_root,
-            state.clone_arc(),
-            true,
-        )?;
+        let packer = AttestationPacker::new(config.clone_arc(), state.clone_arc(), true)?;
         let pack_outcome = packer.pack_proposable_attestations_greedily(
             &previous_epoch_aggregates,
             &current_epoch_aggregates,
@@ -910,64 +436,12 @@ mod tests {
 
     #[test]
     #[cfg(feature = "eth2-cache")]
-    fn test_goerli_optimal_aggregate_attestation_packing() -> Result<()> {
-        let config = Arc::new(Config::goerli());
-        let pubkey_cache = PubkeyCache::default();
-        let slot = 547_813;
-        let epoch = misc::compute_epoch_at_slot::<Mainnet>(slot);
-        let state = goerli::beacon_state(slot, 6);
-        let latest_block_root = accessors::latest_block_root(&state);
-
-        // Optimal packing uses the assumption that attestations are sorted by their data (this assumption is fulfilled when values are taken from BTree)
-        let previous_epoch_aggregates =
-            goerli::attestations_sorted_by_data("aggregate_attestations", epoch - 1);
-        let current_epoch_aggregates =
-            goerli::attestations_sorted_by_data("aggregate_attestations", epoch);
-
-        let _unused = accessors::initialize_shuffled_indices(&state, &previous_epoch_aggregates);
-        let _unused = accessors::initialize_shuffled_indices(&state, &current_epoch_aggregates);
-
-        let packer = AttestationPacker::new(
-            config.clone_arc(),
-            latest_block_root,
-            state.clone_arc(),
-            true,
-        )?;
-        let pack_outcome = packer.pack_proposable_attestations_optimally(
-            &previous_epoch_aggregates,
-            &current_epoch_aggregates,
-        );
-
-        // value computed without optimizations
-        assert_eq!(compute_total_reward(&packer, &pack_outcome)?, 8_323_509_056);
-
-        let proposable_attestations = pack_outcome.attestations;
-        assert_eq!(
-            proposable_attestations
-                .iter()
-                .filter(|attestation| attestation.aggregation_bits.count_ones() > 1)
-                .count(),
-            66,
-            "the packer should include as many attestations that add new votes as possible",
-        );
-
-        assert_attestations_are_valid_and_add_new_bits(
-            &config,
-            &pubkey_cache,
-            &state,
-            &proposable_attestations,
-        )
-    }
-
-    #[test]
-    #[cfg(feature = "eth2-cache")]
     fn test_holesky_greedy_aggregate_attestation_packing() -> Result<()> {
         let config = Arc::new(Config::holesky());
         let pubkey_cache = PubkeyCache::default();
         let slot = 50_015;
         let epoch = misc::compute_epoch_at_slot::<Mainnet>(slot);
         let state = holesky::beacon_state(slot, 8);
-        let latest_block_root = accessors::latest_block_root(&state);
 
         // Optimal packing uses the assumption that attestations are sorted by their data (this assumption is fulfilled when values are taken from BTree)
         let previous_epoch_aggregates =
@@ -978,12 +452,7 @@ mod tests {
         let _unused = accessors::initialize_shuffled_indices(&state, &previous_epoch_aggregates);
         let _unused = accessors::initialize_shuffled_indices(&state, &current_epoch_aggregates);
 
-        let packer = AttestationPacker::new(
-            config.clone_arc(),
-            latest_block_root,
-            state.clone_arc(),
-            true,
-        )?;
+        let packer = AttestationPacker::new(config.clone_arc(), state.clone_arc(), true)?;
 
         let pack_outcome = packer.pack_proposable_attestations_greedily(
             &previous_epoch_aggregates,
@@ -991,58 +460,6 @@ mod tests {
         );
 
         assert_eq!(compute_total_reward(&packer, &pack_outcome)?, 5_250_660_160);
-
-        let proposable_attestations = pack_outcome.attestations;
-        assert_eq!(
-            proposable_attestations
-                .iter()
-                .filter(|attestation| attestation.aggregation_bits.count_ones() > 1)
-                .count(),
-            128,
-            "the packer should include as many attestations that add new votes as possible",
-        );
-
-        assert_attestations_are_valid_and_add_new_bits(
-            &config,
-            &pubkey_cache,
-            &state,
-            &proposable_attestations,
-        )
-    }
-
-    #[test]
-    #[cfg(feature = "eth2-cache")]
-    fn test_holesky_optimal_aggregate_attestation_packing() -> Result<()> {
-        let config = Arc::new(Config::holesky());
-        let pubkey_cache = PubkeyCache::default();
-        let slot = 50_015;
-        let epoch = misc::compute_epoch_at_slot::<Mainnet>(slot);
-        let state = holesky::beacon_state(slot, 8);
-        let latest_block_root = accessors::latest_block_root(&state);
-
-        // Optimal packing uses the assumption that attestations are sorted by their data (this assumption is fulfilled when values are taken from BTree)
-        let previous_epoch_aggregates =
-            holesky::aggregate_attestations_by_epoch_sorted_by_data(epoch - 1);
-        let current_epoch_aggregates =
-            holesky::aggregate_attestations_by_epoch_sorted_by_data(epoch);
-
-        let _unused = accessors::initialize_shuffled_indices(&state, &previous_epoch_aggregates);
-        let _unused = accessors::initialize_shuffled_indices(&state, &current_epoch_aggregates);
-
-        let packer = AttestationPacker::new(
-            config.clone_arc(),
-            latest_block_root,
-            state.clone_arc(),
-            true,
-        )?;
-
-        let pack_outcome = packer.pack_proposable_attestations_optimally(
-            &previous_epoch_aggregates,
-            &current_epoch_aggregates,
-        );
-
-        // value computed without optimizations
-        assert_eq!(compute_total_reward(&packer, &pack_outcome)?, 5_260_609_920);
 
         let proposable_attestations = pack_outcome.attestations;
         assert_eq!(

--- a/operation_pools/src/attestation_agg_pool/conversion.rs
+++ b/operation_pools/src/attestation_agg_pool/conversion.rs
@@ -12,14 +12,26 @@ use types::{
         containers::{Attestation as ElectraAttestation, SingleAttestation},
         error::AttestationConversionError,
     },
-    phase0::containers::{Attestation as Phase0Attestation, AttestationData, Checkpoint},
+    phase0::{
+        containers::{Attestation as Phase0Attestation, Checkpoint},
+        primitives::CommitteeIndex,
+    },
     preset::Preset,
 };
 
+/// Convert an incoming attestation into the pool's per-committee representation.
+///
+/// Returns the attestation with **pristine** `data` (byte-for-byte as signed) together with the
+/// committee index tracked separately. The committee index is deliberately NOT folded back into
+/// `data.index`: under Gloas that field is the payload-presence vote, so overwriting it would
+/// corrupt the signed root. The caller stores both in a [`PoolKey`]. See
+/// TODO(grandinetech/grandine#780).
+///
+/// [`PoolKey`]: crate::attestation_agg_pool::types::PoolKey
 pub fn convert_attestation_for_pool<P: Preset, W: Wait>(
     controller: &ApiController<P, W>,
     attestation: Arc<Attestation<P>>,
-) -> Result<Phase0Attestation<P>> {
+) -> Result<(Phase0Attestation<P>, CommitteeIndex)> {
     if attestation
         .data()
         .slot
@@ -29,8 +41,12 @@ pub fn convert_attestation_for_pool<P: Preset, W: Wait>(
         bail!(AttestationConversionError::Irrelevant);
     }
 
-    let attestation = match Arc::unwrap_or_clone(attestation) {
-        Attestation::Phase0(attestation) => attestation,
+    let attestation_with_committee = match Arc::unwrap_or_clone(attestation) {
+        // Pre-Electra: `data.index` is genuinely the committee index (as signed); already pristine.
+        Attestation::Phase0(attestation) => {
+            let committee_index = attestation.data.index;
+            (attestation, committee_index)
+        }
         Attestation::Electra(attestation) => {
             let ElectraAttestation {
                 aggregation_bits,
@@ -41,28 +57,36 @@ pub fn convert_attestation_for_pool<P: Preset, W: Wait>(
 
             let aggregation_bits: Vec<u8> = aggregation_bits.into();
 
-            let index = misc::get_committee_indices::<P>(committee_bits)
+            let committee_index = misc::get_committee_indices::<P>(committee_bits)
                 .next()
                 .ok_or(AttestationConversionError::InvalidCommitteeIndex)?;
 
-            Phase0Attestation {
+            // Keep `data` pristine (the signed Electra `data.index` is 0). The committee index is
+            // returned separately, never written into `data.index`. See TODO(#780).
+            let attestation = Phase0Attestation {
                 aggregation_bits: aggregation_bits
                     .try_into()
                     .map_err(AttestationConversionError::InvalidAggregationBits)?,
-                data: AttestationData { index, ..data },
+                data,
                 signature,
-            }
+            };
+
+            (attestation, committee_index)
         }
         Attestation::Single(attestation) => {
             let slot = attestation.data.slot;
+            let committee_index = attestation.committee_index;
             let state = current_state(controller, attestation.data.target);
-            let committee = accessors::beacon_committee(&state, slot, attestation.committee_index)?;
+            let committee = accessors::beacon_committee(&state, slot, committee_index)?;
 
-            attestation.try_into_phase0_attestation(committee)?
+            (
+                attestation.try_into_phase0_attestation(committee)?,
+                committee_index,
+            )
         }
     };
 
-    Ok(attestation)
+    Ok(attestation_with_committee)
 }
 
 pub fn convert_to_electra_attestation<P: Preset>(
@@ -130,5 +154,86 @@ fn current_state<P: Preset, W: Wait>(
 
             controller.head_state().value
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // These tests exercise the single-attestation inflow conversion directly (no controller / no
+    // `eth2-cache` data). They are deliberately written against `try_into_phase0_attestation`,
+    // which exists on both the pre-fix and post-fix code with the same signature, so they double as
+    // portable regression tests: on the pre-fix code (which overwrote `data.index` with the
+    // committee index) `single_conversion_keeps_gloas_votes_distinct` fails.
+    use bls::SignatureBytes;
+    use types::{
+        cache::IndexSlice,
+        electra::containers::SingleAttestation,
+        phase0::{
+            containers::{AttestationData, Checkpoint},
+            primitives::H256,
+        },
+        preset::Minimal,
+    };
+
+    // A Gloas single attestation: `data.index` is the payload-presence vote (0 or 1), and the
+    // committee index is carried in its own field.
+    fn gloas_single(committee_index: u64, payload_vote: u64) -> SingleAttestation {
+        SingleAttestation {
+            committee_index,
+            attester_index: 11,
+            data: AttestationData {
+                slot: 7,
+                index: payload_vote,
+                beacon_block_root: H256::repeat_byte(0xff),
+                source: Checkpoint {
+                    epoch: 1,
+                    root: H256::repeat_byte(1),
+                },
+                target: Checkpoint {
+                    epoch: 2,
+                    root: H256::repeat_byte(2),
+                },
+            },
+            signature: SignatureBytes::default(),
+        }
+    }
+
+    // Test 4 — the single-attestation inflow keeps `data` pristine: the committee index is tracked
+    // separately, never written into `data.index`.
+    #[test]
+    fn single_conversion_keeps_data_index_pristine() -> anyhow::Result<()> {
+        let committee: Vec<u64> = vec![10, 11, 12, 13];
+        let single = gloas_single(2, 0);
+
+        let phase0 = single.try_into_phase0_attestation::<Minimal>(IndexSlice::U64(&committee))?;
+
+        assert_eq!(
+            phase0.data.index, single.data.index,
+            "data.index must stay pristine, not be overwritten with committee_index"
+        );
+
+        Ok(())
+    }
+
+    // Test 3 (portable regression) — two single attestations that differ ONLY in the payload vote
+    // must convert to distinct `data`, so the pool cannot merge them. The pre-fix code overwrote
+    // `data.index` with the committee index, collapsing both onto the same `data` (the ★A bug):
+    // this assertion fails there and passes here.
+    #[test]
+    fn single_conversion_keeps_gloas_votes_distinct() -> anyhow::Result<()> {
+        let committee: Vec<u64> = vec![10, 11, 12, 13];
+
+        let vote_empty = gloas_single(2, 0);
+        let vote_full = gloas_single(2, 1);
+
+        let a = vote_empty.try_into_phase0_attestation::<Minimal>(IndexSlice::U64(&committee))?;
+        let b = vote_full.try_into_phase0_attestation::<Minimal>(IndexSlice::U64(&committee))?;
+
+        assert_ne!(
+            a.data, b.data,
+            "payload votes must remain distinct after conversion"
+        );
+
+        Ok(())
     }
 }

--- a/operation_pools/src/attestation_agg_pool/manager.rs
+++ b/operation_pools/src/attestation_agg_pool/manager.rs
@@ -176,7 +176,6 @@ impl<P: Preset, W: Wait> Manager<P, W> {
         self.spawn_detached(PackProposableAttestationsTask {
             pool: self.pool.clone_arc(),
             controller: self.controller.clone_arc(),
-            metrics: self.metrics.clone(),
         });
     }
 

--- a/operation_pools/src/attestation_agg_pool/pool.rs
+++ b/operation_pools/src/attestation_agg_pool/pool.rs
@@ -22,7 +22,9 @@ use types::{
     traits::BeaconState,
 };
 
-use crate::attestation_agg_pool::types::{Aggregate, AggregateMap, AttestationMap, AttestationSet};
+use crate::attestation_agg_pool::types::{
+    Aggregate, AggregateMap, AttestationMap, AttestationSet, PoolKey,
+};
 
 #[expect(type_alias_bounds)]
 type AttestationsWithSlot<P: Preset> = (ContiguousList<Attestation<P>, P::MaxAttestations>, Slot);
@@ -84,15 +86,15 @@ impl<P: Preset> Pool<P> {
             .insert(root, data);
     }
 
-    pub async fn aggregates(&self, data: AttestationData) -> Arc<Mutex<Vec<Aggregate<P>>>> {
-        let epoch = data.target.epoch;
+    pub async fn aggregates(&self, key: PoolKey) -> Arc<Mutex<Vec<Aggregate<P>>>> {
+        let epoch = key.data.target.epoch;
 
         if let Some(aggregates) = self
             .aggregates
             .read()
             .await
             .get(&epoch)
-            .and_then(|epoch_aggregates| epoch_aggregates.get(&data))
+            .and_then(|epoch_aggregates| epoch_aggregates.get(&key))
         {
             return aggregates.clone_arc();
         }
@@ -102,7 +104,7 @@ impl<P: Preset> Pool<P> {
             .await
             .entry(epoch)
             .or_default()
-            .entry(data)
+            .entry(key)
             .or_default()
             .clone_arc()
     }
@@ -114,7 +116,12 @@ impl<P: Preset> Pool<P> {
             .get(&epoch)
             .into_iter()
             .flatten()
-            .map(|(data, aggregates)| async {
+            .map(|(key, aggregates)| async {
+                // Boundary emission: rebuild the scratch representation the packer / block
+                // production / HTTP-API paths still expect (`data.index` = committee index).
+                // Storage stays pristine; this is temporary. See TODO(#780).
+                let data = key.rehydrate_phase0_scratch_repr();
+
                 aggregates
                     .lock()
                     .await
@@ -128,7 +135,7 @@ impl<P: Preset> Pool<P> {
 
                         Attestation {
                             aggregation_bits,
-                            data: *data,
+                            data,
                             signature: signature.into(),
                         }
                     })
@@ -173,12 +180,17 @@ impl<P: Preset> Pool<P> {
     ) -> Option<Attestation<P>> {
         let epoch = data.target.epoch;
 
+        // Callers pass a scratch representation (`data.index` = committee index). Recover the
+        // pristine storage key. TEMPORARY, see TODO(#780).
+        let is_post_electra = epoch >= self.chain_config.electra_fork_epoch;
+        let key = PoolKey::from_scratch_repr(data, is_post_electra);
+
         if let Some(aggregates) = self
             .aggregates
             .read()
             .await
             .get(&epoch)
-            .and_then(|epoch_aggregates| epoch_aggregates.get(&data))
+            .and_then(|epoch_aggregates| epoch_aggregates.get(&key))
         {
             return aggregates
                 .lock()
@@ -204,29 +216,46 @@ impl<P: Preset> Pool<P> {
     }
 
     // Handler for the `/eth/v2/validator/aggregate_attestation` API call.
-    // Expects `attestation_data_root` computed from the post-Electra `AttestationData`,
-    // with `committee_index` explicitly set to 0 and provided separately.
+    // `attestation_data_root` is the *spec* root (computed from the post-Electra `AttestationData`
+    // with `index == 0`), and `committee_index` is supplied separately. Both are matched directly
+    // against the pristine `PoolKey`, so there is no scratch-representation `data.index`
+    // manipulation here: the committee index comes from `key.committee_index` and the spec root
+    // from `key.data`.
     pub async fn best_aggregate_attestation_by_data_root_and_committee_index(
         &self,
         attestation_data_root: H256,
         epoch: Epoch,
         committee_index: CommitteeIndex,
     ) -> Option<Attestation<P>> {
-        self.aggregate_attestations_by_epoch(epoch)
+        let epoch_aggregates = self.aggregates.read().await;
+
+        let (key, aggregates) = epoch_aggregates.get(&epoch)?.iter().find(|(key, _)| {
+            key.committee_index == committee_index
+                && key.data.hash_tree_root() == attestation_data_root
+        })?;
+
+        // Boundary emission: rebuild the scratch representation callers expect. TEMPORARY,
+        // see TODO(#780).
+        let data = key.rehydrate_phase0_scratch_repr();
+
+        aggregates
+            .lock()
             .await
-            .into_iter()
-            .filter(|attestation| {
-                let mut data = attestation.data;
-                let data_committee_index = data.index;
+            .iter()
+            .max_by_key(|aggregate| aggregate.aggregation_bits.count_ones())
+            .cloned()
+            .map(|aggregate| {
+                let Aggregate {
+                    aggregation_bits,
+                    signature,
+                } = aggregate;
 
-                if epoch >= self.chain_config.electra_fork_epoch {
-                    data.index = 0;
+                Attestation {
+                    aggregation_bits,
+                    data,
+                    signature: signature.into(),
                 }
-
-                data_committee_index == committee_index
-                    && data.hash_tree_root() == attestation_data_root
             })
-            .max_by_key(|attestation| attestation.aggregation_bits.count_ones())
     }
 
     pub async fn best_aggregate_attestation_by_data_root(
@@ -350,16 +379,16 @@ impl<P: Preset> Pool<P> {
 
     pub async fn singular_attestations(
         &self,
-        data: AttestationData,
+        key: PoolKey,
     ) -> Arc<RwLock<AttestationSet<P>>> {
-        let epoch = data.target.epoch;
+        let epoch = key.data.target.epoch;
 
         if let Some(attestations) = self
             .singular_attestations
             .read()
             .await
             .get(&epoch)
-            .and_then(|epoch_attestations| epoch_attestations.get(&data))
+            .and_then(|epoch_attestations| epoch_attestations.get(&key))
         {
             return attestations.clone_arc();
         }
@@ -369,7 +398,7 @@ impl<P: Preset> Pool<P> {
             .await
             .entry(epoch)
             .or_default()
-            .entry(data)
+            .entry(key)
             .or_default()
             .clone_arc()
     }
@@ -381,7 +410,22 @@ impl<P: Preset> Pool<P> {
             .get(&epoch)
             .into_iter()
             .flatten()
-            .map(|(_, attestations)| async { attestations.read().await.clone() })
+            .map(|(key, attestations)| async move {
+                // Storage is pristine; rebuild the scratch representation callers expect
+                // (`data.index` = committee index). TEMPORARY, see TODO(#780).
+                let data = key.rehydrate_phase0_scratch_repr();
+
+                attestations
+                    .read()
+                    .await
+                    .iter()
+                    .map(|attestation| {
+                        let mut rehydrated = (**attestation).clone();
+                        rehydrated.data = data;
+                        Arc::new(rehydrated)
+                    })
+                    .collect_vec()
+            })
             .collect::<FuturesUnordered<_>>()
             .collect::<Vec<_>>()
             .await

--- a/operation_pools/src/attestation_agg_pool/tasks.rs
+++ b/operation_pools/src/attestation_agg_pool/tasks.rs
@@ -1,8 +1,6 @@
-use core::time::Duration;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
-    time::Instant,
 };
 
 use anyhow::Result;
@@ -73,7 +71,6 @@ impl<P: Preset, W: Wait> PoolTask for BestProposableAttestationsTask<P, W> {
 
         let attestation_packer = AttestationPacker::new(
             controller.chain_config().clone_arc(),
-            controller.head_block_root().value,
             beacon_state.clone_arc(),
             true,
         )?;
@@ -110,86 +107,38 @@ impl<P: Preset> PoolTask for ComputeProposerIndicesTask<P> {
 pub struct PackProposableAttestationsTask<P: Preset, W: Wait> {
     pub pool: Arc<Pool<P>>,
     pub controller: ApiController<P, W>,
-    pub metrics: Option<Arc<Metrics>>,
 }
 
 impl<P: Preset, W: Wait> PoolTask for PackProposableAttestationsTask<P, W> {
     type Output = ();
 
     async fn run(self) -> Result<Self::Output> {
-        let Self {
-            pool,
-            controller,
-            metrics,
-        } = self;
+        let Self { pool, controller } = self;
 
         let beacon_state = controller.preprocessed_state_at_next_slot_blocking()?;
         let slot = controller.slot().saturating_add(1);
 
-        let mut attestation_packer = AttestationPacker::new(
+        // Greedy packing is a single deterministic pass, so — unlike the removed solver path —
+        // there is nothing to gain from an anytime loop; pre-compute once and store the result.
+        let attestation_packer = AttestationPacker::new(
             controller.chain_config().clone_arc(),
-            controller.head_block_root().value,
             beacon_state.clone_arc(),
             false,
         )?;
 
-        let mut is_empty = true;
-        let mut iteration: u32 = 0;
-
-        loop {
-            let PackOutcome {
-                attestations,
-                deadline_reached,
-            } = {
-                let timer = Instant::now();
-
-                let outcome = pack_attestations_optimally(
-                    &controller,
-                    &attestation_packer,
-                    &pool,
-                    &beacon_state,
-                )
+        let outcome =
+            pack_attestations_greedily(&controller, &attestation_packer, &pool, &beacon_state)
                 .await?;
 
-                features::log!(
-                    DebugAttestationPacker,
-                    "pack outcome for slot: {slot}, attestations: {}, iteration: {iteration}, deadline_reached: {}, time: {:?}",
-                    outcome.attestations.len(),
-                    outcome.deadline_reached,
-                    timer.elapsed()
-                );
+        features::log!(
+            DebugAttestationPacker,
+            "pack outcome for slot: {slot}, attestations: {}, deadline_reached: {}",
+            outcome.attestations.len(),
+            outcome.deadline_reached,
+        );
 
-                iteration = iteration.saturating_add(1);
-                outcome
-            };
-
-            if is_empty || !deadline_reached {
-                pool.set_best_proposable_attestations(attestations, beacon_state.slot())
-                    .await;
-                is_empty = false;
-            }
-
-            if deadline_reached {
-                if let Some(metrics) = metrics.as_ref() {
-                    metrics
-                        .att_pool_pack_iterations
-                        .inc_by(iteration.saturating_sub(1).into());
-                }
-
-                break;
-            }
-
-            tokio::time::sleep(Duration::from_millis(50)).await;
-
-            let head_block_root = controller.head_block_root().value;
-
-            if attestation_packer.should_update_current_participation(head_block_root) {
-                attestation_packer.update_current_participation(
-                    head_block_root,
-                    controller.preprocessed_state_at_next_slot_blocking()?,
-                )?;
-            }
-        }
+        pool.set_best_proposable_attestations(outcome.attestations, beacon_state.slot())
+            .await;
 
         Ok(())
     }
@@ -413,44 +362,6 @@ fn aggregate_attestation<P: Preset>(
     }
 
     Ok(())
-}
-
-async fn pack_attestations_optimally<P: Preset, W: Wait>(
-    controller: &ApiController<P, W>,
-    attestation_packer: &AttestationPacker<P>,
-    pool: &Pool<P>,
-    state: &BeaconState<P>,
-) -> Result<PackOutcome<P>> {
-    let previous_epoch = accessors::get_previous_epoch(state);
-    let current_epoch = accessors::get_current_epoch(state);
-    let dependent_root = controller.dependent_root(state, previous_epoch)?;
-
-    let previous_epoch_attestations = pool.aggregate_attestations_by_epoch(previous_epoch).await;
-    let current_epoch_attestations = pool.aggregate_attestations_by_epoch(current_epoch).await;
-
-    let acceptable_targets = acceptable_attestation_targets_for_packing(
-        controller,
-        dependent_root,
-        previous_epoch,
-        previous_epoch_attestations
-            .iter()
-            .chain(&current_epoch_attestations),
-    );
-
-    let previous_epoch_attestations = previous_epoch_attestations
-        .iter()
-        .filter(|attestation| acceptable_targets.contains(&attestation.data.target.root));
-
-    let current_epoch_attestations = current_epoch_attestations
-        .iter()
-        .filter(|attestation| acceptable_targets.contains(&attestation.data.target.root));
-
-    attestation_packer
-        .pack_proposable_attestations_optimally(
-            previous_epoch_attestations,
-            current_epoch_attestations,
-        )
-        .pipe(Ok)
 }
 
 async fn pack_attestations_greedily<P: Preset, W: Wait>(

--- a/operation_pools/src/attestation_agg_pool/tasks.rs
+++ b/operation_pools/src/attestation_agg_pool/tasks.rs
@@ -33,7 +33,7 @@ use crate::{
         attestation_packer::{AttestationPacker, PackOutcome},
         conversion::convert_attestation_for_pool,
         pool::Pool,
-        types::Aggregate,
+        types::{Aggregate, PoolKey},
     },
     misc::PoolTask,
 };
@@ -227,22 +227,23 @@ impl<P: Preset, W: Wait> PoolTask for InsertAttestationTask<P, W> {
             attester_index = Some(single_attestation.attester_index);
         }
 
-        let attestation = match convert_attestation_for_pool(&controller, attestation) {
-            Ok(attestation) => attestation,
-            Err(error) => {
-                match error.downcast_ref::<AttestationConversionError>() {
-                    Some(AttestationConversionError::Irrelevant) => {}
-                    Some(AttestationConversionError::AttesterNotInCommittee { .. }) => {
-                        exception!("failed to convert attestation for pool: {error:?}");
+        let (attestation, committee_index) =
+            match convert_attestation_for_pool(&controller, attestation) {
+                Ok(attestation_with_committee) => attestation_with_committee,
+                Err(error) => {
+                    match error.downcast_ref::<AttestationConversionError>() {
+                        Some(AttestationConversionError::Irrelevant) => {}
+                        Some(AttestationConversionError::AttesterNotInCommittee { .. }) => {
+                            exception!("failed to convert attestation for pool: {error:?}");
+                        }
+                        _ => {
+                            warn_with_peers!("failed to convert attestation for pool: {error:?}");
+                        }
                     }
-                    _ => {
-                        warn_with_peers!("failed to convert attestation for pool: {error:?}");
-                    }
-                }
 
-                return Ok(());
-            }
-        };
+                    return Ok(());
+                }
+            };
 
         let Attestation {
             aggregation_bits,
@@ -265,13 +266,19 @@ impl<P: Preset, W: Wait> PoolTask for InsertAttestationTask<P, W> {
                 }
             }
 
-            if !pool.aggregate_in_committee(data.index, data.slot).await {
+            if !pool.aggregate_in_committee(committee_index, data.slot).await {
                 return Ok(());
             }
         }
 
-        let singular_attestations = pool.singular_attestations(data).await;
-        let aggregates = pool.aggregates(data).await;
+        // `data` is pristine (byte-for-byte as signed); the committee index is stored separately.
+        let key = PoolKey {
+            data,
+            committee_index,
+        };
+
+        let singular_attestations = pool.singular_attestations(key).await;
+        let aggregates = pool.aggregates(key).await;
         let mut aggregates = aggregates.lock().await;
 
         if !is_singular || aggregates.is_empty() {
@@ -304,7 +311,11 @@ impl<P: Preset, W: Wait> PoolTask for InsertAttestationTask<P, W> {
             }
         }
 
-        pool.add_data_root_to_data_entry(data).await;
+        // `data_root_to_data_map` is a boundary lookup index for the aggregate-attestation HTTP
+        // API, which addresses aggregates by the scratch-representation root. Keep storing the
+        // scratch representation here so that contract stays byte-identical. TEMPORARY, TODO(#780).
+        pool.add_data_root_to_data_entry(key.rehydrate_phase0_scratch_repr())
+            .await;
 
         drop(wait_group);
 

--- a/operation_pools/src/attestation_agg_pool/types.rs
+++ b/operation_pools/src/attestation_agg_pool/types.rs
@@ -7,16 +7,85 @@ use bls::AggregateSignature;
 use ssz::BitList;
 use tokio::sync::{Mutex, RwLock};
 use types::{
-    phase0::containers::{Attestation, AttestationData},
+    phase0::{
+        containers::{Attestation, AttestationData},
+        primitives::CommitteeIndex,
+    },
     preset::Preset,
 };
+
+/// Key for the pool's per-committee aggregate and singular-attestation maps.
+///
+/// `committee_index` is the pool's **organizational dimension**, and is deliberately kept
+/// separate from `data`. It is NOT part of the signed message: `data.index` carries
+/// fork-specific *signed* meaning (phase0 = committee index; Gloas/EIP-7732 = payload-presence
+/// vote), and must never be conflated with the committee index the pool groups aggregates by.
+///
+/// Storing the committee index here lets `data` stay byte-for-byte as it was signed (pristine).
+/// That is what stops Gloas attestations that differ only in their payload vote (`data.index`
+/// 0 vs 1) from colliding into a single aggregate bucket and having their signatures merged
+/// into an invalid aggregate. Do not fold `committee_index` back into `data.index` for storage.
+/// See TODO(grandinetech/grandine#780).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct PoolKey {
+    pub data: AttestationData,
+    pub committee_index: CommitteeIndex,
+}
+
+impl PoolKey {
+    /// Rebuild the pre-Electra "scratch representation" `AttestationData`, in which `data.index`
+    /// holds the committee index instead of its signed meaning.
+    ///
+    /// TEMPORARY — TODO(grandinetech/grandine#780). This exists only so the current
+    /// `AttestationPacker` (and the block-production / HTTP-API paths that read `data.index` as a
+    /// committee index) keep working byte-for-byte while the pool's *storage* moves to pristine
+    /// data. It MUST be deleted once the packer consumes pristine data directly (the greedy
+    /// baseline PR).
+    ///
+    /// Do NOT use on the Gloas path: re-injecting the committee index overwrites the payload-presence
+    /// vote that `data.index` carries under EIP-7732, producing an attestation that no longer matches
+    /// what was signed. Pre-Electra this is a no-op (`committee_index == data.index` already); for
+    /// Electra/Fulu it restores the committee index the packer expects.
+    #[must_use]
+    pub const fn rehydrate_phase0_scratch_repr(&self) -> AttestationData {
+        AttestationData {
+            index: self.committee_index,
+            ..self.data
+        }
+    }
+
+    /// Inverse of [`Self::rehydrate_phase0_scratch_repr`]: recover the storage key from a scratch
+    /// representation supplied by a caller (validator duties, HTTP-API lookups) whose `data.index`
+    /// holds the committee index.
+    ///
+    /// TEMPORARY — TODO(grandinetech/grandine#780), same lifetime as the rehydrate helper. For
+    /// post-Electra the signed `data.index` is 0, so it is reset here to keep the stored `data`
+    /// pristine; pre-Electra `data.index` is genuinely the committee index and is left untouched.
+    #[must_use]
+    pub fn from_scratch_repr(scratch: AttestationData, is_post_electra: bool) -> Self {
+        let committee_index = scratch.index;
+        let data = if is_post_electra {
+            AttestationData {
+                index: 0,
+                ..scratch
+            }
+        } else {
+            scratch
+        };
+
+        Self {
+            data,
+            committee_index,
+        }
+    }
+}
 
 // Use `Mutex` instead of `RwLock` to avoid race conditions in `InsertAttestationTask`.
 // Don't let this comment fool you into thinking the locking is well thought out.
 // There may be other bugs.
-pub type AggregateMap<P> = HashMap<AttestationData, Arc<Mutex<Vec<Aggregate<P>>>>>;
+pub type AggregateMap<P> = HashMap<PoolKey, Arc<Mutex<Vec<Aggregate<P>>>>>;
 
-pub type AttestationMap<P> = HashMap<AttestationData, Arc<RwLock<AttestationSet<P>>>>;
+pub type AttestationMap<P> = HashMap<PoolKey, Arc<RwLock<AttestationSet<P>>>>;
 
 // Use `BTreeSet` to make attestation packing deterministic for snapshot testing.
 // This does not affect performance in our benchmarks.
@@ -26,4 +95,134 @@ pub type AttestationSet<P> = BTreeSet<Arc<Attestation<P>>>;
 pub struct Aggregate<P: Preset> {
     pub aggregation_bits: BitList<P::MaxValidatorsPerCommittee>,
     pub signature: AggregateSignature,
+}
+
+#[cfg(test)]
+mod tests {
+    use helper_functions::misc;
+    use ssz::{BitVector, SszHash as _};
+    use types::{
+        phase0::{
+            containers::{AttestationData, Checkpoint},
+            primitives::H256,
+        },
+        preset::Minimal,
+    };
+
+    use super::PoolKey;
+
+    fn sample_data(index: u64) -> AttestationData {
+        AttestationData {
+            slot: 42,
+            index,
+            beacon_block_root: H256::repeat_byte(0xaa),
+            source: Checkpoint {
+                epoch: 3,
+                root: H256::repeat_byte(0x11),
+            },
+            target: Checkpoint {
+                epoch: 4,
+                root: H256::repeat_byte(0x22),
+            },
+        }
+    }
+
+    // Test 1 — pre-Electra byte-identical: for a phase0 attestation, emission
+    // (`rehydrate ∘ from_scratch_repr`) reproduces the input exactly (structural + SSZ root).
+    // This is the executable evidence for the "pre-Electra byte-identical" claim.
+    #[test]
+    fn phase0_scratch_roundtrip_is_byte_identical() {
+        // Phase0: `data.index` genuinely is the committee index, so is_post_electra = false.
+        let data = sample_data(3);
+
+        let key = PoolKey::from_scratch_repr(data, false);
+
+        // Committee comes from data.index; stored data stays pristine (== input for phase0).
+        assert_eq!(key.committee_index, 3);
+        assert_eq!(key.data, data);
+
+        let emitted = key.rehydrate_phase0_scratch_repr();
+
+        assert_eq!(emitted, data);
+        assert_eq!(emitted.hash_tree_root(), data.hash_tree_root());
+    }
+
+    // The post-Electra scratch round-trip is also the identity: storage drops the committee index
+    // out of `data` (keeping it pristine, index == 0), and emission re-injects it.
+    #[test]
+    fn electra_scratch_roundtrip_reconstructs_input() {
+        // Caller-supplied scratch repr: `data.index` carries the committee index (7).
+        let scratch = sample_data(7);
+
+        let key = PoolKey::from_scratch_repr(scratch, true);
+
+        assert_eq!(key.committee_index, 7);
+        assert_eq!(key.data.index, 0, "post-Electra stored data.index must be pristine (0)");
+
+        assert_eq!(key.rehydrate_phase0_scratch_repr(), scratch);
+    }
+
+    // Test 2 — Electra inflow keeps data pristine and derives the committee from committee_bits.
+    #[test]
+    fn electra_inflow_keeps_data_pristine_and_extracts_committee() {
+        // Model the pool's Electra inflow: committee from committee_bits, data untouched.
+        let mut committee_bits = BitVector::default();
+        committee_bits.set(2, true);
+
+        let committee_index = misc::get_committee_indices::<Minimal>(committee_bits)
+            .next()
+            .expect("exactly one committee bit is set");
+
+        // Incoming Electra data: the signed `data.index` is 0 (pristine).
+        let data = sample_data(0);
+        let key = PoolKey {
+            data,
+            committee_index,
+        };
+
+        assert_eq!(key.committee_index, 2);
+        assert_eq!(
+            key.data.index, 0,
+            "pristine data.index must not be overwritten with the committee index"
+        );
+    }
+
+    // Test 3 — Gloas payload-vote separation (★A): two attestations identical except for the
+    // payload-presence vote in `data.index` (0 vs 1), for the SAME committee, must map to distinct
+    // PoolKeys so their signatures are never aggregated into an invalid combined signature.
+    #[test]
+    fn poolkey_separates_gloas_payload_votes() {
+        let committee_index = 2;
+
+        let vote_empty = sample_data(0); // payload EMPTY
+        let vote_full = sample_data(1); // payload FULL — same slot/source/target/head + committee
+
+        let key_empty = PoolKey {
+            data: vote_empty,
+            committee_index,
+        };
+        let key_full = PoolKey {
+            data: vote_full,
+            committee_index,
+        };
+
+        // Same committee, but the signed data differs → different keys → different buckets.
+        assert_eq!(key_empty.committee_index, key_full.committee_index);
+        assert_ne!(key_empty, key_full, "payload votes must not collide into one bucket");
+
+        // Characterise the pre-fix behaviour this fixes: the old pool folded the committee index
+        // into `data.index`, collapsing both votes onto a single AttestationData map key.
+        let old_key_empty = AttestationData {
+            index: committee_index,
+            ..vote_empty
+        };
+        let old_key_full = AttestationData {
+            index: committee_index,
+            ..vote_full
+        };
+        assert_eq!(
+            old_key_empty, old_key_full,
+            "the old committee-in-data.index representation merged the two votes (the ★A bug)"
+        );
+    }
 }

--- a/types/src/electra/container_impls.rs
+++ b/types/src/electra/container_impls.rs
@@ -151,6 +151,12 @@ impl<P: Preset> TryFrom<Phase0Attestation<P>> for Attestation<P> {
 
         let aggregation_bits: Vec<u8> = aggregation_bits.into();
         let mut committee_bits = BitVector::default();
+        // This reads the committee index out of `data.index` and resets `data.index` to 0. That is
+        // correct for Electra/Fulu (where the signed `data.index` is 0 and the pool feeds this a
+        // scratch representation with the committee index in `data.index`). It is NOT valid under
+        // Gloas, where `data.index` is the payload-presence vote: hardcoding 0 here would discard
+        // that vote. Left intact for this PR; to be removed once the packer stops relying on the
+        // scratch representation. See TODO(grandinetech/grandine#780).
         committee_bits.set(data.index.try_into()?, true);
 
         Ok(Self {
@@ -200,10 +206,10 @@ impl SingleAttestation {
             signature,
         } = self;
 
-        let data = AttestationData {
-            index: committee_index,
-            ..data
-        };
+        // Keep `data` pristine: a single attestation's signed `data.index` is 0 post-Electra, and
+        // the committee index is tracked separately by the pool (via `PoolKey`). Folding it into
+        // `data.index` here would corrupt the signed root under Gloas, where that field is the
+        // payload-presence vote. See TODO(grandinetech/grandine#780).
 
         ensure!(
             committee_index < P::MaxCommitteesPerSlot::U64,


### PR DESCRIPTION
Part of #780. Stacked on #820 (merge that first); this is the first half of the "greedy baseline" step from the plan comment.

### Why

The solver path (`pack_proposable_attestations_optimally`) decomposes the packing problem per attestation-data group and allocates the block budget across groups with a knapsack DP over `MaxAttestations = 128`, counted in per-committee attestations. Post-Electra, blocks are limited to `MAX_ATTESTATIONS_ELECTRA = 8` merged on-chain aggregates, so the DP allocates along an axis that no longer corresponds to anything the block can hold — the optimization target itself is stale. Rather than reworking the ILP formulation around the new unit, this removes the path entirely so the follow-up PR can rebuild packing around the real budget. (Measurement on cached Goerli data backs this up: a plain best-per-committee greedy already covers 99.89% of observed attesters, so a solver has near-zero headroom to buy.)

### What

- `pack_proposable_attestations_optimally` and its solver-only helpers (`find_optimal_selections`, the ILP max-cover selection, per-validator weight tables, and associated constants) are deleted: −783 lines.
- The `good_lp`/HiGHS dependency is dropped from the workspace, removing the solver from the supply-chain surface.
- The background pre-pack task previously ran an optimal→greedy anytime loop; it now runs a single greedy pass. The serving architecture (pre-pack then serve) is unchanged.
- One behaviour-relevant function turned out to be misnamed rather than solver-specific: the "should pack optimally" gate actually guarded pre-packing on unsupported forks (Fulu). It is kept and renamed to `is_pre_pack_supported`, so fork gating is preserved bit-for-bit.

### Testing

Greedy is untouched, and the existing packing snapshot tests (which exercise only the greedy path) pass unchanged. `cargo check` is clean across the workspace with the solver dependency removed.