### PR TITLE
Upgrade Nethermind to 1.39.1 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ aarch64-apple-darwin: ./target/aarch64-apple-darwin/compact/grandine ./target/aa
 
 # ------ GRANDINE-NETHERMIND INTEGRATION ------
 
-NETHERMIND_VERSION ?= 1.38.0
+NETHERMIND_VERSION ?= 1.39.1
 # If empty, public authentication will happen. Public auth rate limits by ip address, so may fail unexpectedly.
 GITHUB_TOKEN ?=
 

--- a/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
+++ b/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
@@ -33,9 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.1.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.4.0" />
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.38.0" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.39.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
+++ b/bindings/csharp/Grandine.NethermindPlugin/Grandine.NethermindPlugin.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <Target Name="GenerateBindings" BeforeTargets="BeforeBuild;BeforeRebuild">
-    <Exec Command="cargo build" Outputs="../generated/*.cs">
+    <Exec Command="cargo build" EnvironmentVariables="MAKEFLAGS=" Outputs="../generated/*.cs">
       <Output ItemName="Generated" TaskParameter="Outputs" />
     </Exec>
     <ItemGroup>

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
@@ -128,7 +128,7 @@ public class GrandineEngineApi : IGrandineEngineApi
                     ExcessBlobGas = payload.excess_blob_gas,
                     ParentBeaconBlockRoot = parentBeaconBlockRootConverted,
                 },
-                GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr),
+                GrandineUtils.ConvertVersionedHashesToHash256(*versionedHashesPtr),
                 parentBeaconBlockRootConverted)
             .Result;
 
@@ -179,7 +179,7 @@ public class GrandineEngineApi : IGrandineEngineApi
                     ParentBeaconBlockRoot = parentBeaconBlockRootConverted,
                     ExecutionRequests = executionRequestsConverted,
                 },
-                GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr),
+                GrandineUtils.ConvertVersionedHashesToHash256(*versionedHashesPtr),
                 parentBeaconBlockRootConverted,
                 executionRequestsConverted)
             .Result;

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineUtils.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineUtils.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using Grandine.Native;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 
@@ -160,6 +161,30 @@ public static class GrandineUtils
         for (int i = 0; i < span.Length; ++i)
         {
             result[i] = span[i].ToArray();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Starting from Nethermind 1.39.0, some methods (like engine_newPayloadV3)
+    /// accept not `byte[][]` as converted hashes, but `Hash256?[]`.
+    /// </summary>
+    /// <param name="versionedHashes">Raw argument, received through ffi engine API.</param>
+    /// <returns>Hashes, converted into Nethermind-recognized format.</returns>
+    public static Hash256?[] ConvertVersionedHashesToHash256(in CVec_CH256 versionedHashes)
+    {
+        var span = versionedHashes.AsSpan();
+        if (span.Length == 0)
+        {
+            return Array.Empty<Hash256?>();
+        }
+
+        var result = new Hash256[span.Length];
+
+        for (int i = 0; i < span.Length; ++i)
+        {
+            result[i] = new Hash256(span[i].ToArray());
         }
 
         return result;


### PR DESCRIPTION
This PR upgrades Nethermind plugin, so it supports latest 1.39.1 version.