### PR TITLE
Add Gloas global circuit breaker

### DIFF
--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -1349,33 +1349,36 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             }
         };
 
-        let mut without_state_root_with_payload =
-            if let Some(state) = self.beacon_state.post_gloas() {
-                let signed_payload_bid =
-                    if let Some(bid) = self.select_best_builder_bid(state, block_mev) {
-                        // Set block_mev value to the in-protocol builder bid value
-                        block_mev =
-                            Some(Uint256::from_u64(bid.message.value).saturating_mul(WEI_IN_GWEI));
+        let has_local_payload = execution_payload.is_some();
 
-                        Some(bid)
-                    } else {
-                        // No builder bid selected — self-build using the local payload that was
-                        // already prepared via engine_forkchoiceUpdated
-                        self.cache_and_build_self_payload_bid(state, execution_payload, commitments)
-                            .await?
-                    };
+        let mut without_state_root_with_payload = if let Some(state) =
+            self.beacon_state.post_gloas()
+        {
+            let builder_bid = self.select_best_builder_bid(state, block_mev, has_local_payload);
 
-                let Some(signed_payload_bid) = signed_payload_bid else {
-                    return Ok(None);
-                };
+            let signed_payload_bid = if let Some(bid) = builder_bid {
+                // Set block_mev value to the in-protocol builder bid value
+                block_mev = Some(Uint256::from_u64(bid.message.value).saturating_mul(WEI_IN_GWEI));
 
-                block_without_state_root.with_signed_execution_payload_bid(Some(signed_payload_bid))
+                Some(bid)
             } else {
-                block_without_state_root
-                    .with_execution_payload(execution_payload)?
-                    .with_blob_kzg_commitments(commitments)
-                    .with_execution_requests(execution_requests)
+                // No builder bid selected — self-build using the local payload that was
+                // already prepared via engine_forkchoiceUpdated
+                self.cache_and_build_self_payload_bid(state, execution_payload, commitments)
+                    .await?
             };
+
+            let Some(signed_payload_bid) = signed_payload_bid else {
+                return Ok(None);
+            };
+
+            block_without_state_root.with_signed_execution_payload_bid(Some(signed_payload_bid))
+        } else {
+            block_without_state_root
+                .with_execution_payload(execution_payload)?
+                .with_blob_kzg_commitments(commitments)
+                .with_execution_requests(execution_requests)
+        };
 
         if !self.options.disable_blockprint_graffiti {
             let graffiti = build_graffiti(self.options.graffiti, client_versions);
@@ -2217,14 +2220,21 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
     /// Returns the most valuable bid that the node is willing to propose on top of the head block.
     ///
     /// [`None`] means the node should build the payload itself, either because there is no bid
-    /// worth taking or because the local payload is worth more.
+    /// worth taking, the local payload is worth more, or the circuit breaker tripped.
     // TODO: allow to configure bid selection, e.g. builders preference over highest bid
     fn select_best_builder_bid(
         &self,
         state: &(impl PostGloasBeaconState<P> + ?Sized),
         local_mev: Option<Uint256>,
+        local_payload_available: bool,
     ) -> Option<SignedExecutionPayloadBid<P>> {
         let snapshot = self.producer_context.controller.snapshot();
+
+        if local_payload_available && snapshot.builder_circuit_breaker_tripped() {
+            warn_with_peers!("builders are withholding payloads, building the payload locally");
+
+            return None;
+        }
 
         let parent_block_hash = if snapshot.should_build_on_full() {
             state.latest_execution_payload_bid().block_hash

--- a/builder_api/src/api.rs
+++ b/builder_api/src/api.rs
@@ -529,12 +529,14 @@ fn validate_phase(computed: Phase, in_response: Phase) -> Result<()> {
 mod tests {
     use reqwest::Client;
     use test_case::test_case;
-    use types::preset::Mainnet;
-
-    use crate::{
-        BuilderApi, BuilderConfig,
-        config::{DEFAULT_BUILDER_MAX_SKIPPED_SLOTS, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH},
+    use types::{
+        nonstandard::{
+            DEFAULT_BUILDER_MAX_SKIPPED_SLOTS, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH,
+        },
+        preset::Mainnet,
     };
+
+    use crate::{BuilderApi, BuilderConfig};
 
     use super::*;
 

--- a/builder_api/src/config.rs
+++ b/builder_api/src/config.rs
@@ -1,9 +1,6 @@
 use derive_more::{Debug, Display, FromStr};
 use types::redacting_url::RedactingUrl;
 
-pub const DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH: u64 = 8;
-pub const DEFAULT_BUILDER_MAX_SKIPPED_SLOTS: u64 = 3;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Display, FromStr)]
 pub enum BuilderApiFormat {
     Json,

--- a/builder_api/src/lib.rs
+++ b/builder_api/src/lib.rs
@@ -1,9 +1,6 @@
 pub use crate::{
     api::Api as BuilderApi,
-    config::{
-        BuilderApiFormat, Config as BuilderConfig, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS,
-        DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH,
-    },
+    config::{BuilderApiFormat, Config as BuilderConfig},
     consts::PREFERRED_EXECUTION_GAS_LIMIT,
 };
 

--- a/fork_choice_control/src/queries.rs
+++ b/fork_choice_control/src/queries.rs
@@ -1472,6 +1472,11 @@ impl<P: Preset> Snapshot<'_, P> {
         self.store_snapshot
             .selectable_payload_bids(slot, parent_block_hash, parent_block_root)
     }
+
+    #[must_use]
+    pub fn builder_circuit_breaker_tripped(&self) -> bool {
+        self.store_snapshot.builder_circuit_breaker_tripped()
+    }
 }
 
 #[derive(Debug, Error)]

--- a/fork_choice_store/src/builder_circuit_breaker.rs
+++ b/fork_choice_store/src/builder_circuit_breaker.rs
@@ -1,0 +1,459 @@
+//! Circuit breaker for Gloas builders that win an auction but do not reveal the payload.
+//!
+//! The pre-Gloas circuit breaker in `builder_api` counts missing blocks. That signal is meaningless
+//! under Gloas, where the payload is decoupled from the block: a builder can win the auction, the
+//! block can land, and the payload can simply never appear. The thresholds are shared with it,
+//! because "this many bad slots" means the same thing on both sides of the fork.
+
+use arithmetic::NonZeroExt as _;
+use derivative::Derivative;
+use typenum::Unsigned as _;
+use types::{
+    nonstandard::{DEFAULT_BUILDER_MAX_SKIPPED_SLOTS, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH},
+    phase0::primitives::{Epoch, Slot},
+    preset::Preset,
+};
+
+/// Epochs the node builds payloads locally for after the circuit breaker trips.
+const TRIP_PERIOD: Epoch = 1;
+
+/// Percentage of a slot's committee that must have attested a block before an untimely payload is
+/// blamed on its builder.
+pub const ATTESTED_PERCENT: u64 = 60;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Derivative)]
+#[derivative(Default)]
+pub struct BuilderCircuitBreakerConfig {
+    pub disabled: bool,
+    /// Consecutive canonical blocks with withheld payloads tolerated before the node self-builds.
+    #[derivative(Default(value = "DEFAULT_BUILDER_MAX_SKIPPED_SLOTS"))]
+    pub max_skipped_slots: u64,
+    /// Withheld payloads tolerated in the last rolling epoch before the node self-builds.
+    #[derivative(Default(value = "DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH"))]
+    pub max_skipped_slots_per_epoch: u64,
+}
+
+/// Watches the canonical chain for withheld payloads and, if they are frequent enough, has the node
+/// fall back to self-building until the builder ecosystem recovers.
+#[derive(Clone, Debug)]
+pub struct BuilderCircuitBreaker {
+    config: BuilderCircuitBreakerConfig,
+    evaluated_slot: Slot,
+    consecutive_withheld: Slot,
+    consecutive_delivered: Slot,
+    /// Slots of the last rolling epoch whose payload was withheld, store in bitmask, indexed by slot position in the epoch.
+    withheld_slots: Slot,
+    tripped_until: Slot,
+}
+
+impl BuilderCircuitBreaker {
+    #[must_use]
+    pub const fn new(config: BuilderCircuitBreakerConfig, anchor_slot: Slot) -> Self {
+        Self {
+            config,
+            evaluated_slot: anchor_slot,
+            consecutive_withheld: 0,
+            consecutive_delivered: 0,
+            withheld_slots: 0,
+            tripped_until: 0,
+        }
+    }
+
+    #[must_use]
+    pub const fn config(&self) -> BuilderCircuitBreakerConfig {
+        self.config
+    }
+
+    #[must_use]
+    pub const fn evaluated_slot(&self) -> Slot {
+        self.evaluated_slot
+    }
+
+    pub const fn set_evaluated_slot(&mut self, slot: Slot) {
+        self.evaluated_slot = slot;
+    }
+
+    /// Resumes at `slot`, discarding evidence gathered before the slots that are being skipped.
+    pub const fn skip_to(&mut self, slot: Slot) {
+        self.evaluated_slot = slot;
+        self.consecutive_withheld = 0;
+        self.consecutive_delivered = 0;
+        self.withheld_slots = 0;
+    }
+
+    #[must_use]
+    pub const fn is_tripped(&self, current_slot: Slot) -> bool {
+        !self.config.disabled && current_slot < self.tripped_until
+    }
+
+    /// Judges the canonical block of `slot`.
+    ///
+    /// Returns the threshold this outcome crossed if it tripped the circuit breaker, [`None`]
+    /// otherwise. Slots must be reported in ascending order.
+    pub fn record_canonical_outcome<P: Preset>(
+        &mut self,
+        slot: Slot,
+        outcome: PayloadOutcome,
+        current_slot: Slot,
+    ) -> Option<Trip> {
+        let slot_bit = 1 << (slot % P::SlotsPerEpoch::non_zero());
+
+        match outcome {
+            PayloadOutcome::Delivered => {
+                self.consecutive_withheld = 0;
+                self.consecutive_delivered = self.consecutive_delivered.saturating_add(1);
+                self.withheld_slots &= !slot_bit;
+            }
+            PayloadOutcome::Withheld => {
+                self.consecutive_withheld = self.consecutive_withheld.saturating_add(1);
+                self.consecutive_delivered = 0;
+                self.withheld_slots |= slot_bit;
+            }
+            // A slot nobody can be blamed for still ages out of the rolling window.
+            PayloadOutcome::Unknown => self.withheld_slots &= !slot_bit,
+        }
+
+        // Builders recovered, so the trip is cleared ahead of its expiry.
+        if self.consecutive_delivered > self.config.max_skipped_slots {
+            self.tripped_until = 0;
+        }
+
+        let withheld_in_epoch = self.withheld_slots.count_ones().into();
+
+        // Both thresholds are inclusive, like the pre-Gloas circuit breaker they are shared with.
+        let trip = if self.consecutive_withheld > self.config.max_skipped_slots {
+            Trip::ConsecutiveWithheld(self.consecutive_withheld)
+        } else if withheld_in_epoch > self.config.max_skipped_slots_per_epoch {
+            Trip::WithheldInEpoch(withheld_in_epoch)
+        } else {
+            return None;
+        };
+
+        // The trip lasts one trip period, after which it re-arms. The expiry is what clears it when
+        // recovery cannot be observed: this node's own slots are no evidence about builders while it
+        // self-builds, so a node proposing most of them would stay tripped forever.
+        self.tripped_until = self
+            .tripped_until
+            .max(current_slot.saturating_add(TRIP_PERIOD.saturating_mul(P::SlotsPerEpoch::U64)));
+
+        // Both counters are reset, or the evidence that tripped the breaker would keep tripping it
+        // every slot until it ages out of the window.
+        self.consecutive_withheld = 0;
+        self.withheld_slots = 0;
+
+        Some(trip)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PayloadOutcome {
+    Delivered,
+    /// The builder did not reveal the payload in time, whether it revealed it later or not at all.
+    Withheld,
+    /// No conclusion: the slot was skipped, the block was self-built, or nobody attested it.
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Trip {
+    ConsecutiveWithheld(Slot),
+    WithheldInEpoch(Slot),
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools as _;
+    use types::preset::Mainnet;
+
+    use super::*;
+
+    const SLOTS_PER_EPOCH: u64 = <Mainnet as Preset>::SlotsPerEpoch::U64;
+    const CURRENT_SLOT: Slot = 10 * SLOTS_PER_EPOCH + 7;
+
+    fn new_breaker() -> BuilderCircuitBreaker {
+        BuilderCircuitBreaker::new(BuilderCircuitBreakerConfig::default(), 0)
+    }
+
+    #[test]
+    fn disabled_circuit_breaker_never_trips() {
+        let mut breaker = BuilderCircuitBreaker::new(
+            BuilderCircuitBreakerConfig {
+                disabled: true,
+                ..BuilderCircuitBreakerConfig::default()
+            },
+            0,
+        );
+
+        for slot in 0..SLOTS_PER_EPOCH {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+        }
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT));
+    }
+
+    #[test]
+    fn consecutive_withheld_payloads_trip_the_circuit_breaker() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        for slot in 0..config.max_skipped_slots {
+            assert_eq!(
+                breaker.record_canonical_outcome::<Mainnet>(
+                    slot,
+                    PayloadOutcome::Withheld,
+                    CURRENT_SLOT
+                ),
+                None,
+            );
+            assert!(!breaker.is_tripped(CURRENT_SLOT));
+        }
+
+        assert_eq!(
+            breaker.record_canonical_outcome::<Mainnet>(
+                config.max_skipped_slots,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            ),
+            Some(Trip::ConsecutiveWithheld(config.max_skipped_slots + 1)),
+        );
+
+        assert!(breaker.is_tripped(CURRENT_SLOT));
+        assert!(!breaker.is_tripped(CURRENT_SLOT + TRIP_PERIOD * SLOTS_PER_EPOCH));
+    }
+
+    #[test]
+    fn withheld_payloads_in_a_rolling_epoch_trip_the_circuit_breaker() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        // Alternating slots never accumulate consecutive failures.
+        let trips = (0..=(2 * config.max_skipped_slots_per_epoch))
+            .filter_map(|slot| {
+                let outcome = if slot.is_multiple_of(2) {
+                    PayloadOutcome::Withheld
+                } else {
+                    PayloadOutcome::Delivered
+                };
+
+                breaker.record_canonical_outcome::<Mainnet>(slot, outcome, CURRENT_SLOT)
+            })
+            .collect_vec();
+
+        assert_eq!(
+            trips,
+            [Trip::WithheldInEpoch(
+                config.max_skipped_slots_per_epoch + 1
+            )],
+        );
+        assert!(breaker.is_tripped(CURRENT_SLOT));
+
+        // The window is cleared on the trip, so the payloads that tripped it cannot trip it again.
+        assert_eq!(
+            breaker.record_canonical_outcome::<Mainnet>(
+                2 * config.max_skipped_slots_per_epoch + 1,
+                PayloadOutcome::Delivered,
+                CURRENT_SLOT,
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn skipped_slots_discard_evidence() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        for slot in 0..config.max_skipped_slots {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+        }
+
+        breaker.skip_to(CURRENT_SLOT);
+
+        assert_eq!(breaker.evaluated_slot(), CURRENT_SLOT);
+
+        // A run cannot continue across the gap.
+        assert_eq!(
+            breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn delivered_payload_resets_consecutive_withheld_payloads() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        for slot in 0..config.max_skipped_slots {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+        }
+
+        breaker.record_canonical_outcome::<Mainnet>(
+            config.max_skipped_slots,
+            PayloadOutcome::Delivered,
+            CURRENT_SLOT,
+        );
+
+        for slot in 0..config.max_skipped_slots {
+            let slot = slot + config.max_skipped_slots + 1;
+
+            assert_eq!(
+                breaker.record_canonical_outcome::<Mainnet>(
+                    slot,
+                    PayloadOutcome::Withheld,
+                    CURRENT_SLOT
+                ),
+                None,
+            );
+        }
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT));
+    }
+
+    #[test]
+    fn delivered_payloads_untrip_the_circuit_breaker_before_it_expires() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        for slot in 0..=config.max_skipped_slots {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+        }
+
+        assert!(breaker.is_tripped(CURRENT_SLOT));
+
+        // A single timely reveal says nothing about the builder that would win the next auction.
+        for slot in 0..config.max_skipped_slots {
+            let slot = slot + config.max_skipped_slots + 1;
+
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Delivered,
+                CURRENT_SLOT,
+            );
+
+            assert!(breaker.is_tripped(CURRENT_SLOT));
+        }
+
+        breaker.record_canonical_outcome::<Mainnet>(
+            2 * config.max_skipped_slots + 1,
+            PayloadOutcome::Delivered,
+            CURRENT_SLOT,
+        );
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT));
+    }
+
+    #[test]
+    fn withheld_payloads_break_a_run_of_delivered_ones() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        for slot in 0..=config.max_skipped_slots {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+        }
+
+        assert!(breaker.is_tripped(CURRENT_SLOT));
+
+        // Alternating outcomes are the flapping the threshold exists to prevent.
+        for slot in 0..(4 * config.max_skipped_slots) {
+            let slot = slot + config.max_skipped_slots + 1;
+
+            let outcome = if slot.is_multiple_of(2) {
+                PayloadOutcome::Withheld
+            } else {
+                PayloadOutcome::Delivered
+            };
+
+            breaker.record_canonical_outcome::<Mainnet>(slot, outcome, CURRENT_SLOT);
+
+            assert!(breaker.is_tripped(CURRENT_SLOT));
+        }
+    }
+
+    #[test]
+    fn unknown_outcomes_neither_trip_nor_reset_the_circuit_breaker() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        for slot in 0..config.max_skipped_slots {
+            breaker.record_canonical_outcome::<Mainnet>(
+                2 * slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+            breaker.record_canonical_outcome::<Mainnet>(
+                2 * slot + 1,
+                PayloadOutcome::Unknown,
+                CURRENT_SLOT,
+            );
+        }
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT));
+
+        // Self-built and skipped slots do not mask a builder-wide failure.
+        assert_eq!(
+            breaker.record_canonical_outcome::<Mainnet>(
+                2 * config.max_skipped_slots,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            ),
+            Some(Trip::ConsecutiveWithheld(config.max_skipped_slots + 1)),
+        );
+    }
+
+    #[test]
+    fn withheld_payloads_age_out_of_the_rolling_epoch() {
+        let mut breaker = new_breaker();
+
+        for slot in 0..SLOTS_PER_EPOCH {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT,
+            );
+        }
+
+        assert!(breaker.is_tripped(CURRENT_SLOT));
+
+        // A full epoch of delivered payloads clears the window.
+        for slot in SLOTS_PER_EPOCH..(2 * SLOTS_PER_EPOCH) {
+            breaker.record_canonical_outcome::<Mainnet>(
+                slot,
+                PayloadOutcome::Delivered,
+                CURRENT_SLOT + 1,
+            );
+        }
+
+        assert_eq!(
+            breaker.record_canonical_outcome::<Mainnet>(
+                2 * SLOTS_PER_EPOCH,
+                PayloadOutcome::Withheld,
+                CURRENT_SLOT + 1,
+            ),
+            None,
+        );
+    }
+}

--- a/fork_choice_store/src/lib.rs
+++ b/fork_choice_store/src/lib.rs
@@ -76,6 +76,7 @@
 //! [`proto_array`]:            https://github.com/protolambda/lmd-ghost/tree/242f0dced3b34feed0d4e9d2fd0e5e66e448c359#array-based-stateful-dag-proto_array
 
 pub use crate::{
+    builder_circuit_breaker::{BuilderCircuitBreaker, BuilderCircuitBreakerConfig},
     error::Error,
     misc::{
         AggregateAndProofAction, AggregateAndProofOrigin, ApplyBlockChanges, ApplyTickChanges,
@@ -96,6 +97,7 @@ pub use crate::{
 };
 
 mod blob_cache;
+mod builder_circuit_breaker;
 mod data_column_cache;
 mod error;
 mod execution_payload_envelope_cache;

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -1,6 +1,6 @@
 use core::{
     cell::OnceCell,
-    ops::Bound,
+    ops::{Bound, RangeInclusive},
     sync::atomic::{AtomicUsize, Ordering},
 };
 use std::{
@@ -86,6 +86,7 @@ use unwrap_none::UnwrapNone as _;
 use crate::{
     BlockItem, PayloadAttestationOrigin,
     blob_cache::BlobCache,
+    builder_circuit_breaker::{ATTESTED_PERCENT, BuilderCircuitBreaker, PayloadOutcome, Trip},
     data_column_cache::DataColumnCache,
     error::Error,
     execution_payload_envelope_cache::ExecutionPayloadEnvelopeCache,
@@ -273,6 +274,7 @@ pub struct Store<P: Preset, S: Storage<P>> {
     accepted_execution_payload_envelopes: HashSet<(Slot, H256, BuilderIndex)>,
     accepted_proposer_preferences:
         HashMap<(H256, Slot, ValidatorIndex), Arc<SignedProposerPreferences>>,
+    builder_circuit_breaker: BuilderCircuitBreaker,
     blob_cache: BlobCache<P>,
     state_cache: Arc<StateCacheProcessor<P>>,
     storage: Arc<S>,
@@ -334,6 +336,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             parent_payload_presence: PayloadPresence::default(),
         };
 
+        let anchor_slot = anchor_state.slot();
         let validator_count = anchor_state.validators().len_usize();
         let latest_messages = core::iter::repeat_n(None, validator_count).collect();
 
@@ -380,6 +383,10 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             accepted_payload_bids: HashMap::default(),
             accepted_execution_payload_envelopes: HashSet::default(),
             accepted_proposer_preferences: HashMap::default(),
+            builder_circuit_breaker: BuilderCircuitBreaker::new(
+                store_config.builder_circuit_breaker,
+                anchor_slot,
+            ),
             blob_cache: BlobCache::default(),
             state_cache: Arc::new(StateCacheProcessor::new(
                 store_config.state_cache_lock_timeout,
@@ -478,6 +485,11 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
                 bid.message.parent_block_hash == parent_block_hash
                     && bid.message.parent_block_root == parent_block_root
             })
+    }
+
+    #[must_use]
+    pub const fn builder_circuit_breaker_tripped(&self) -> bool {
+        self.builder_circuit_breaker.is_tripped(self.slot())
     }
 
     #[must_use]
@@ -742,13 +754,17 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
     }
 
     fn unfinalized_before_or_at(&self, slot: Slot) -> Option<&ChainLink<P>> {
+        self.unfinalized_block_before_or_at(slot)
+            .map(|unfinalized_block| &unfinalized_block.chain_link)
+    }
+
+    fn unfinalized_block_before_or_at(&self, slot: Slot) -> Option<&UnfinalizedBlock<P>> {
         self.canonical_chain_segments()
             .find_map(|(segment, position)| {
                 segment
                     .block_before_or_at(slot, position)
                     .filter(|block| block.non_invalid())
             })
-            .map(|unfinalized_block| &unfinalized_block.chain_link)
     }
 
     #[must_use]
@@ -1348,6 +1364,107 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         }
 
         Ok(head_weight < reorg_threshold)
+    }
+
+    fn update_builder_circuit_breaker(&mut self) {
+        let current_slot = self.slot();
+
+        let config = self.builder_circuit_breaker.config();
+
+        if config.disabled || self.chain_config.phase_at_slot::<P>(current_slot) < Phase::Gloas {
+            return;
+        }
+
+        if !self.is_forward_synced() {
+            self.builder_circuit_breaker.skip_to(current_slot);
+            return;
+        }
+
+        // Payload delivery can be decided in the next slot after its block was proposed
+        let Some(last_slot) = current_slot.checked_sub(1) else {
+            return;
+        };
+
+        let earliest_slot = last_slot.saturating_sub(P::SlotsPerEpoch::U64);
+
+        if self.builder_circuit_breaker.evaluated_slot() < earliest_slot {
+            self.builder_circuit_breaker.skip_to(earliest_slot);
+        }
+
+        let first_slot = self
+            .builder_circuit_breaker
+            .evaluated_slot()
+            .saturating_add(1);
+
+        if first_slot <= last_slot {
+            self.evaluate_canonical_payloads_in(first_slot..=last_slot);
+            self.builder_circuit_breaker.set_evaluated_slot(last_slot);
+        }
+    }
+
+    /// Judges the canonical block of every slot in `slots`.
+    ///
+    /// A run of failures is only meaningful along a single chain, so blocks that lost the head race
+    /// are not counted.
+    fn evaluate_canonical_payloads_in(&mut self, slots: RangeInclusive<Slot>) {
+        let attested_threshold = self.calculate_committee_fraction(ATTESTED_PERCENT);
+        let current_slot = self.slot();
+
+        for slot in slots {
+            let outcome = self.canonical_payload_outcome(slot, attested_threshold);
+
+            match self.builder_circuit_breaker.record_canonical_outcome::<P>(
+                slot,
+                outcome,
+                current_slot,
+            ) {
+                Some(Trip::ConsecutiveWithheld(withheld_payloads)) => warn_with_peers!(
+                    "builders withheld {withheld_payloads} payloads in a row, \
+                     building payloads locally"
+                ),
+                Some(Trip::WithheldInEpoch(withheld_payloads)) => warn_with_peers!(
+                    "builders withheld {withheld_payloads} payloads in the last epoch, \
+                     building payloads locally"
+                ),
+                None => {}
+            }
+        }
+    }
+
+    /// Whether the builder that won the auction for the canonical block of `slot` revealed its
+    /// payload in time.
+    fn canonical_payload_outcome(&self, slot: Slot, attested_threshold: Gwei) -> PayloadOutcome {
+        let Some(unfinalized_block) = self
+            .unfinalized_block_before_or_at(slot)
+            .filter(|unfinalized_block| unfinalized_block.slot() == slot)
+        else {
+            return PayloadOutcome::Unknown;
+        };
+
+        let chain_link = &unfinalized_block.chain_link;
+
+        let Some(payload_bid) = chain_link.block.message().payload_bid() else {
+            return PayloadOutcome::Unknown;
+        };
+
+        if payload_bid.builder_index == BUILDER_INDEX_SELF_BUILD {
+            return PayloadOutcome::Unknown;
+        }
+
+        // A PTC majority voting the payload timely stands in for this node's own view: the reveal
+        // was on time and this node was slow to see it.
+        if self.is_payload_present_timely(chain_link.block_root)
+            || self.payload_timeliness(chain_link.block_root, true)
+        {
+            return PayloadOutcome::Delivered;
+        }
+
+        // The network has attested the block, so we can blame the builder for not revealing it in time.
+        if unfinalized_block.attesting_balances.pending >= attested_threshold {
+            return PayloadOutcome::Withheld;
+        }
+
+        PayloadOutcome::Unknown
     }
 
     fn should_apply_proposer_boost(&self) -> bool {
@@ -4101,6 +4218,10 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         self.apply_balance_differences(differences)?;
         self.update_head_segment_id();
+
+        // The circuit breaker compares attesting balances against the canonical chain, both of
+        // which are only up to date after `update_head_segment_id`.
+        self.update_builder_circuit_breaker();
 
         // Pruning the state cache requires the head slot, which depends on head_segment_id
         // pointing to the correct head. Therefore, prune state cache after the head_segment_id

--- a/fork_choice_store/src/store_config.rs
+++ b/fork_choice_store/src/store_config.rs
@@ -4,6 +4,8 @@ use derivative::Derivative;
 use kzg_utils::{DEFAULT_KZG_BACKEND, KzgBackend};
 use types::config::Config as ChainConfig;
 
+use crate::builder_circuit_breaker::BuilderCircuitBreakerConfig;
+
 pub const DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS: u64 = 1500;
 
 #[derive(Clone, Copy, Derivative)]
@@ -21,6 +23,8 @@ pub struct StoreConfig {
     pub kzg_backend: KzgBackend,
     #[derivative(Default(value = "false"))]
     pub sync_without_reconstruction: bool,
+    // No `derivative` attribute: `BuilderCircuitBreakerConfig` supplies its own defaults.
+    pub builder_circuit_breaker: BuilderCircuitBreakerConfig,
 }
 
 impl StoreConfig {

--- a/runtime/src/grandine_args.rs
+++ b/runtime/src/grandine_args.rs
@@ -15,10 +15,7 @@ use std::{path::PathBuf, sync::Arc};
 use anyhow::{Result, ensure};
 use binary_utils::TelemetryConfig;
 use bls::PublicKeyBytes;
-use builder_api::{
-    BuilderApiFormat, BuilderConfig, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS,
-    DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH, PREFERRED_EXECUTION_GAS_LIMIT,
-};
+use builder_api::{BuilderApiFormat, BuilderConfig, PREFERRED_EXECUTION_GAS_LIMIT};
 use bytesize::ByteSize;
 use clap::{Args, CommandFactory as _, Error as ClapError, Parser, ValueEnum, error::ErrorKind};
 use derivative::Derivative;
@@ -32,7 +29,9 @@ use eth2_libp2p::{
 };
 use features::Feature;
 use fork_choice_control::{DEFAULT_ARCHIVAL_EPOCH_INTERVAL, DEFAULT_MAX_EVENTS};
-use fork_choice_store::{DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS, StoreConfig};
+use fork_choice_store::{
+    BuilderCircuitBreakerConfig, DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS, StoreConfig,
+};
 use grandine_version::{APPLICATION_NAME, APPLICATION_VERSION};
 use helper_functions::misc;
 use http_api::HttpApiConfig;
@@ -56,7 +55,10 @@ use tracing::Level;
 use types::{
     bellatrix::primitives::{Difficulty, Gas},
     config::Config as ChainConfig,
-    nonstandard::{CustodyMode, Phase, StorageMode},
+    nonstandard::{
+        CustodyMode, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS,
+        DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH, Phase, StorageMode,
+    },
     phase0::primitives::{
         Epoch, ExecutionAddress, ExecutionBlockHash, ExecutionBlockNumber, H256, Slot,
     },
@@ -857,11 +859,11 @@ struct ValidatorOptions {
     #[clap(long)]
     builder_disable_checks: bool,
 
-    /// Max allowed consecutive missing blocks to trigger circuit breaker condition and switch to local execution engine for payload construction
+    /// Max allowed consecutive missing blocks (missing payloads post-Gloas) to trigger circuit breaker condition and switch to local execution engine for payload construction
     #[clap(long, default_value_t = DEFAULT_BUILDER_MAX_SKIPPED_SLOTS)]
     builder_max_skipped_slots: u64,
 
-    /// Max allowed missing blocks in the last rolling epoch to trigger circuit breaker condition and switch to local execution engine for payload construction
+    /// Max allowed missing blocks (missing payloads post-Gloas) in the last rolling epoch to trigger circuit breaker condition and switch to local execution engine for payload construction
     #[clap(long, default_value_t = DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH)]
     builder_max_skipped_slots_per_epoch: u64,
 
@@ -1410,6 +1412,12 @@ impl GrandineArgs {
             builder_max_skipped_slots_per_epoch,
         });
 
+        let builder_circuit_breaker = BuilderCircuitBreakerConfig {
+            disabled: builder_disable_checks,
+            max_skipped_slots: builder_max_skipped_slots,
+            max_skipped_slots_per_epoch: builder_max_skipped_slots_per_epoch,
+        };
+
         let web3signer_urls = if web3signer_urls.is_empty() && !web3signer_api_urls.is_empty() {
             warn_with_peers!(
                 "--web3signer-api-urls option is deprecated. Use --web3signer-urls instead."
@@ -1492,6 +1500,7 @@ impl GrandineArgs {
             state_slot,
             auth_options,
             builder_config,
+            builder_circuit_breaker,
             web3signer_config,
             http_api_config,
             max_events,
@@ -1737,6 +1746,39 @@ mod tests {
     fn back_sync_disabled_by_default() {
         let config = config_from_args([]);
         assert!(!config.back_sync_enabled);
+    }
+
+    #[test]
+    fn default_builder_circuit_breaker_settings() {
+        let config = config_from_args([]);
+
+        assert_eq!(
+            config.builder_circuit_breaker,
+            BuilderCircuitBreakerConfig::default(),
+        );
+    }
+
+    #[test]
+    fn builder_disable_checks_disables_the_gloas_circuit_breaker() {
+        let config = config_from_args(["--builder-disable-checks"]);
+
+        assert!(config.builder_circuit_breaker.disabled);
+    }
+
+    #[test]
+    fn skipped_slot_thresholds_are_shared_with_the_gloas_circuit_breaker() {
+        let config = config_from_args([
+            "--builder-max-skipped-slots",
+            "5",
+            "--builder-max-skipped-slots-per-epoch",
+            "9",
+        ]);
+
+        assert_eq!(config.builder_circuit_breaker.max_skipped_slots, 5);
+        assert_eq!(
+            config.builder_circuit_breaker.max_skipped_slots_per_epoch,
+            9,
+        );
     }
 
     #[test]

--- a/runtime/src/grandine_config.rs
+++ b/runtime/src/grandine_config.rs
@@ -4,6 +4,7 @@ use std::{collections::HashSet, path::PathBuf, sync::Arc};
 use binary_utils::TelemetryConfig;
 use builder_api::BuilderConfig;
 use eth1_api::AuthOptions;
+use fork_choice_store::BuilderCircuitBreakerConfig;
 use http_api::HttpApiConfig;
 use itertools::Itertools as _;
 use kzg_utils::KzgBackend;
@@ -62,6 +63,7 @@ pub struct GrandineConfig {
     pub state_slot: Option<Slot>,
     pub auth_options: AuthOptions,
     pub builder_config: Option<BuilderConfig>,
+    pub builder_circuit_breaker: BuilderCircuitBreakerConfig,
     pub web3signer_config: Web3SignerConfig,
     pub http_api_config: Option<HttpApiConfig>,
     pub max_events: usize,

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -1294,6 +1294,7 @@ pub fn run(parsed_args: GrandineArgs) -> Result<()> {
         state_slot,
         auth_options,
         builder_config,
+        builder_circuit_breaker,
         web3signer_config,
         http_api_config,
         max_events,
@@ -1359,6 +1360,7 @@ pub fn run(parsed_args: GrandineArgs) -> Result<()> {
         unfinalized_states_in_memory,
         kzg_backend,
         sync_without_reconstruction,
+        builder_circuit_breaker,
     };
 
     let eth1_auth = Arc::new(Auth::new(auth_options)?);

--- a/types/src/nonstandard.rs
+++ b/types/src/nonstandard.rs
@@ -38,6 +38,14 @@ pub use smallvec::smallvec;
 
 pub const WEI_IN_GWEI: Uint256 = Uint256::from_u64(1_000_000_000);
 
+/// Defaults for the builder circuit breaker thresholds.
+///
+/// Defined here because they are shared by the pre-Gloas checks in `builder_api`, which count
+/// missing blocks, and the Gloas circuit breaker in `fork_choice_store`, which counts withheld
+/// payloads.
+pub const DEFAULT_BUILDER_MAX_SKIPPED_SLOTS: u64 = 3;
+pub const DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH: u64 = 8;
+
 pub type Publishable = bool;
 
 #[derive(


### PR DESCRIPTION
Implement #795 by reusing existing flags from pre-Gloas config for builder API, therefore no new flags are introduced.

This PR doesn't contains builder blacklisting mechanism, I will defer to the another PR