### PR TITLE
Publish Gloas beacon block before data column sidecars

### DIFF
--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -96,8 +96,8 @@ use types::{
             ProposerSlashing, SignedVoluntaryExit,
         },
         primitives::{
-            CommitteeIndex, Epoch, ExecutionAddress, ExecutionBlockHash, H256, Slot, Uint256,
-            ValidatorIndex,
+            CommitteeIndex, Epoch, ExecutionAddress, ExecutionBlockHash, ExecutionBlockNumber,
+            H256, Slot, Uint256, ValidatorIndex,
         },
     },
     preset::{Preset, SyncSubcommitteeSize},
@@ -2072,6 +2072,47 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         Ok(Some(payload_attributes))
     }
 
+    /// Execution block that the payload prepared for this context will extend.
+    ///
+    /// Post-Gloas this must not be taken from `latest_execution_payload_header`: that accessor is
+    /// aliased to `latest_execution_payload_bid`, whose `block_hash` is only the parent proposer's
+    /// promise and may never be revealed.
+    #[must_use]
+    pub fn execution_payload_parent(
+        &self,
+    ) -> Option<(Option<ExecutionBlockNumber>, ExecutionBlockHash)> {
+        let state = self.beacon_state.as_ref();
+
+        if let Some(state) = state.post_gloas() {
+            return Some((None, self.gloas_payload_parent_hash(state)));
+        }
+
+        let payload = state.post_bellatrix()?.latest_execution_payload_header();
+
+        Some((payload.block_number(), payload.block_hash()))
+    }
+
+    fn gloas_payload_parent_hash(
+        &self,
+        state: &(impl PostGloasBeaconState<P> + ?Sized),
+    ) -> ExecutionBlockHash {
+        let parent_bid = state.latest_execution_payload_bid();
+        let parent_slot = state.latest_block_header().slot;
+        let snapshot = self.producer_context.controller.snapshot();
+
+        if snapshot.should_build_on_full(state.slot())
+            || self
+                .producer_context
+                .chain_config
+                .phase_at_slot::<P>(parent_slot)
+                < Phase::Gloas
+        {
+            parent_bid.block_hash
+        } else {
+            parent_bid.parent_block_hash
+        }
+    }
+
     #[instrument(skip_all, level = "debug")]
     pub async fn prepare_execution_payload_for_slot(
         &self,
@@ -2136,17 +2177,7 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
         //
         // See <https://github.com/ethereum/consensus-specs/pull/3350>.
         let parent_hash = if let Some(state) = state.post_gloas() {
-            let parent_bid = state.latest_execution_payload_bid();
-            let parent_slot = state.latest_block_header().slot;
-            let snapshot = self.producer_context.controller.snapshot();
-
-            if snapshot.should_build_on_full(state.slot())
-                || chain_config.phase_at_slot::<P>(parent_slot) < Phase::Gloas
-            {
-                parent_bid.block_hash
-            } else {
-                parent_bid.parent_block_hash
-            }
+            self.gloas_payload_parent_hash(state)
         } else if let Some(state) = state.post_capella() {
             state.latest_execution_payload_header().block_hash()
         } else if let Some(state) = post_merge_state(state) {

--- a/http_api/src/standard.rs
+++ b/http_api/src/standard.rs
@@ -4663,11 +4663,19 @@ fn publish_block_with_data_column_sidecars_to_network<P: Preset>(
     data_column_sidecars: &[Arc<DataColumnSidecar<P>>],
     api_to_p2p_tx: &UnboundedSender<ApiToP2p<P>>,
 ) {
-    for data_column_sidecar in data_column_sidecars {
-        ApiToP2p::PublishDataColumnSidecar(data_column_sidecar.clone_arc()).send(api_to_p2p_tx);
-    }
+    let publish_data_column_sidecars = || {
+        for data_column_sidecar in data_column_sidecars {
+            ApiToP2p::PublishDataColumnSidecar(data_column_sidecar.clone_arc()).send(api_to_p2p_tx);
+        }
+    };
 
-    ApiToP2p::PublishBeaconBlock(block).send(api_to_p2p_tx);
+    if block.phase() >= Phase::Gloas {
+        ApiToP2p::PublishBeaconBlock(block).send(api_to_p2p_tx);
+        publish_data_column_sidecars();
+    } else {
+        publish_data_column_sidecars();
+        ApiToP2p::PublishBeaconBlock(block).send(api_to_p2p_tx);
+    }
 }
 
 #[instrument(skip_all, level = "debug")]

--- a/validator/src/validator.rs
+++ b/validator/src/validator.rs
@@ -604,17 +604,17 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                 }
             };
 
-            if let Some(state) = slot_head.beacon_state.post_bellatrix() {
-                let payload = state.latest_execution_payload_header();
-
+            if let Some((parent_block_number, parent_block_hash)) =
+                block_build_context.execution_payload_parent()
+            {
                 self.event_channels.send_payload_attributes_event(
                     slot_head.beacon_state.phase(),
                     slot,
                     proposer_index,
                     slot_head.beacon_block_root,
                     &payload_attributes,
-                    payload.block_number(),
-                    payload.block_hash(),
+                    parent_block_number,
+                    parent_block_hash,
                 );
             }
 
@@ -1145,7 +1145,20 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                     .payload_bid()
                     .is_some_and(|bid| bid.builder_index == BUILDER_INDEX_SELF_BUILD);
 
-                if (slot_head.phase() < Phase::Gloas || self_built)
+                let post_gloas = slot_head.phase() >= Phase::Gloas;
+
+                let import_and_publish_block = |block: &Arc<SignedBeaconBlock<P>>| {
+                    self.controller
+                        .on_own_block(wait_group.clone(), block.clone_arc());
+
+                    ValidatorToP2p::PublishBeaconBlock(block.clone_arc()).send(&self.p2p_tx);
+                };
+
+                if post_gloas {
+                    import_and_publish_block(&block);
+                }
+
+                if (!post_gloas || self_built)
                     && let Some(blobs) = block_blobs
                     && !blobs.is_empty()
                 {
@@ -1153,10 +1166,9 @@ impl<P: Preset, W: Wait + Sync> Validator<P, W> {
                         .await?;
                 }
 
-                self.controller
-                    .on_own_block(wait_group.clone(), block.clone_arc());
-
-                ValidatorToP2p::PublishBeaconBlock(block).send(&self.p2p_tx);
+                if !post_gloas {
+                    import_and_publish_block(&block);
+                }
 
                 // If self-building:
                 // Publish the execution payload envelope after the beacon block so PTC members


### PR DESCRIPTION
This commit also fix `payload_attributes` SSE for post-Gloas to consult with fork-choice whether to use parent block hash or grant-parent block hash