### PR TITLE
Add missing Gloas spec values to /eth/v1/config/spec

### DIFF
--- a/http_api/src/full_config.rs
+++ b/http_api/src/full_config.rs
@@ -22,7 +22,10 @@ use types::{
     bellatrix::primitives::Gas,
     capella::consts::DOMAIN_BLS_TO_EXECUTION_CHANGE,
     config::Config,
-    gloas::consts::{DOMAIN_BEACON_BUILDER, DOMAIN_PROPOSER_PREFERENCES, DOMAIN_PTC_ATTESTER},
+    gloas::consts::{
+        DOMAIN_BEACON_BUILDER, DOMAIN_BUILDER_DEPOSIT, DOMAIN_PROPOSER_PREFERENCES,
+        DOMAIN_PTC_ATTESTER,
+    },
     nonstandard::Phase,
     phase0::{
         consts::{
@@ -158,6 +161,7 @@ pub struct FullConfig {
     domain_beacon_builder: DomainType,
     domain_ptc_attester: DomainType,
     domain_proposer_preferences: DomainType,
+    domain_builder_deposit: DomainType,
 
     // TODO(feature/deneb): Add constants from the Polynomial Commitments specification if needed.
 
@@ -276,6 +280,7 @@ impl FullConfig {
             domain_beacon_builder: DOMAIN_BEACON_BUILDER,
             domain_ptc_attester: DOMAIN_PTC_ATTESTER,
             domain_proposer_preferences: DOMAIN_PROPOSER_PREFERENCES,
+            domain_builder_deposit: DOMAIN_BUILDER_DEPOSIT,
 
             // Builder constants
             builder_proposal_delay_tolerance: BUILDER_PROPOSAL_DELAY_TOLERANCE,

--- a/types/src/config.rs
+++ b/types/src/config.rs
@@ -95,6 +95,8 @@ pub struct Config {
     #[serde(with = "As::<DurationMilliSeconds<String>>")]
     pub slot_duration_ms: Duration,
     #[serde(with = "serde_utils::string_or_native")]
+    pub proposer_reorg_cutoff_bps: u64,
+    #[serde(with = "serde_utils::string_or_native")]
     pub attestation_due_bps: u64,
     #[serde(with = "serde_utils::string_or_native")]
     pub aggregate_due_bps: u64,
@@ -152,6 +154,10 @@ pub struct Config {
     pub reorg_max_epochs_since_finalization: u64,
     #[serde(with = "serde_utils::string_or_native")]
     pub reorg_parent_weight_threshold: u64,
+
+    // Fast confirmation rule
+    #[serde(with = "serde_utils::string_or_native")]
+    pub confirmation_byzantine_threshold: u64,
 
     // Deposit contract
     #[serde(with = "serde_utils::string_or_native")]
@@ -273,6 +279,7 @@ impl Default for Config {
             seconds_per_eth1_block: 14,
             shard_committee_period: 256,
             slot_duration_ms: Duration::from_secs(12),
+            proposer_reorg_cutoff_bps: 1667,
             attestation_due_bps: 3333,
             aggregate_due_bps: 6667,
             sync_message_due_bps: 3333,
@@ -305,6 +312,9 @@ impl Default for Config {
             reorg_head_weight_threshold: 20,
             reorg_max_epochs_since_finalization: 2,
             reorg_parent_weight_threshold: 160,
+
+            // Fast confirmation rule
+            confirmation_byzantine_threshold: 25,
 
             // Deposit contract
             deposit_chain_id: 0,

--- a/types/src/preset.rs
+++ b/types/src/preset.rs
@@ -348,6 +348,13 @@ pub trait Preset: Copy + Eq + Ord + Hash + Default + Debug + Send + Sync + 'stat
     // Gloas
     const MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: u64 = 1 << 14;
 
+    // Gloas type-specific SSZ bounds
+    const MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE: u64 = 16_829;
+    const MAX_ATTESTER_SLASHING_SIZE: u64 = 2_097_616;
+    const MAX_DATA_COLUMN_SIDECAR_SIZE: u64 = 8_585_272;
+    const MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE: u64 = 8_585_741;
+    const MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE: u64 = 196_932;
+
     /// Returns the default configuration associated with a preset.
     ///
     /// This should only be used in tests and benchmarks.
@@ -560,6 +567,10 @@ impl Preset for Minimal {
 
     // Gloas
     const MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: u64 = 16;
+
+    // Gloas type-specific SSZ bounds
+    const MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE: u64 = 1462;
+    const MAX_ATTESTER_SLASHING_SIZE: u64 = 131_536;
 }
 
 /// [Medalla preset](https://github.com/eth-clients/eth2-networks/blob/674f7a1d01d9c18345456eab76e3871b3df2126b/shared/medalla/config.yaml).
@@ -1156,6 +1167,16 @@ pub struct GloasPreset {
     max_builder_deposit_requests_per_payload: u64,
     #[serde(with = "serde_utils::string_or_native")]
     max_builder_exit_requests_per_payload: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    max_signed_aggregate_and_proof_size: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    max_attester_slashing_size: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    max_data_column_sidecar_size: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    max_partial_data_column_sidecar_size: u64,
+    #[serde(with = "serde_utils::string_or_native")]
+    max_signed_execution_payload_bid_size: u64,
 }
 
 impl GloasPreset {
@@ -1169,6 +1190,11 @@ impl GloasPreset {
             max_builders_per_withdrawals_sweep: P::MAX_BUILDERS_PER_WITHDRAWALS_SWEEP,
             max_builder_deposit_requests_per_payload: P::MaxBuilderDepositRequestsPerPayload::U64,
             max_builder_exit_requests_per_payload: P::MaxBuilderExitRequestsPerPayload::U64,
+            max_signed_aggregate_and_proof_size: P::MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE,
+            max_attester_slashing_size: P::MAX_ATTESTER_SLASHING_SIZE,
+            max_data_column_sidecar_size: P::MAX_DATA_COLUMN_SIDECAR_SIZE,
+            max_partial_data_column_sidecar_size: P::MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE,
+            max_signed_execution_payload_bid_size: P::MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE,
         }
     }
 }


### PR DESCRIPTION
Grandine's `/eth/v1/config/spec` response was missing several values that other clients serve, which shows up as mismatches in cross-client spec comparisons on glamsterdam-devnet-8:

- `PROPOSER_REORG_CUTOFF_BPS`
- `CONFIRMATION_BYZANTINE_THRESHOLD`
- `MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE`
- `MAX_ATTESTER_SLASHING_SIZE`
- `MAX_DATA_COLUMN_SIDECAR_SIZE`
- `MAX_PARTIAL_DATA_COLUMN_SIDECAR_SIZE`
- `MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE`
- `DOMAIN_BUILDER_DEPOSIT`

### Changes

- **`types/src/config.rs`**: `PROPOSER_REORG_CUTOFF_BPS` (default 1667) and `CONFIRMATION_BYZANTINE_THRESHOLD` (default 25) are now proper `Config` fields, so they are parsed from `config.yaml` (previously logged as unknown variables) and serialized into the spec response. Defaults match [`configs/mainnet.yaml`](https://github.com/ethereum/consensus-specs/blob/master/configs/mainnet.yaml) / `minimal.yaml` (identical in both).
- **`types/src/preset.rs`**: the Gloas type-specific SSZ bounds from [`presets/mainnet/gloas.yaml`](https://github.com/ethereum/consensus-specs/blob/master/presets/mainnet/gloas.yaml) are added to the `Preset` trait and exposed via `GloasPreset`, with the `minimal` overrides (`MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE: 1462`, `MAX_ATTESTER_SLASHING_SIZE: 131536`).
- **`http_api/src/full_config.rs`**: `DOMAIN_BUILDER_DEPOSIT` (already defined in `types/src/gloas/consts.rs`) is now included with the other Gloas domain types.
- **`grandine-snapshot-tests`**: submodule bumped to regenerated `spec.response` snapshots — companion PR: grandinetech/grandine-snapshot-tests#9 (that PR should be merged first / the submodule pin adjusted on merge).

### Testing

- `cargo test -p http_api` (including the 4 previously-failing spec snapshot cases) passes with the regenerated snapshots.
- `cargo check -p types -p http_api` clean.