### PR TITLE
Validate bid gas limit against the payload at bid.parent_block_hash

### DIFF
--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2336,17 +2336,35 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         };
 
         // > the `bid.parent_block_hash` is the block hash of a known execution payload in fork choice
-        if !self
-            .execution_payload_locations
-            .contains_key(&bid.parent_block_hash)
-        {
+        let Some(parent_payload_chain_link) =
+            self.unfinalized_chain_link_by_execution_block_hash(bid.parent_block_hash)
+        else {
             return Ok(ExecutionPayloadBidAction::Ignore(
                 "the `bid.parent_block_hash` is the block hash of a known execution payload in fork choice",
             ));
-        }
+        };
 
         // > Check `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, target_gas_limit)` is True.
-        let parent_gas_limit = post_gloas_state.latest_execution_payload_bid().gas_limit;
+        //
+        // `parent_gas_limit` is the `gas_limit` of the execution payload identified by
+        // `bid.parent_block_hash`, which is committed to by the bid of the block that carries it
+        // (envelopes must match their bid's `gas_limit`). This is not necessarily the payload of
+        // `bid.parent_block_root`: a bid may build on the parent's parent payload when the parent
+        // block's payload was withheld. Pre-Gloas blocks carry the payload itself.
+        let parent_payload_block_body = parent_payload_chain_link.block.message().body();
+        let Some(parent_gas_limit) = parent_payload_block_body
+            .with_payload_bid()
+            .map(|body| body.signed_execution_payload_bid().message.gas_limit)
+            .or_else(|| {
+                parent_payload_block_body
+                    .with_execution_payload()
+                    .map(|body| body.execution_payload().gas_limit())
+            })
+        else {
+            return Ok(ExecutionPayloadBidAction::Ignore(
+                "the `bid.parent_block_hash` is the block hash of a known execution payload in fork choice",
+            ));
+        };
         if !predicates::is_gas_limit_target_compatible(
             parent_gas_limit,
             bid.gas_limit,

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -40,6 +40,7 @@ use crate::{
             ExecutionPayload as BellatrixExecutionPayload,
             ExecutionPayloadHeader as BellatrixExecutionPayloadHeader,
         },
+        primitives::Gas,
     },
     cache::Cache,
     capella::{
@@ -1816,6 +1817,7 @@ pub trait ExecutionPayload<P: Preset>: SszHash<PackingFactor = U1> {
     fn block_hash(&self) -> ExecutionBlockHash;
     fn block_number(&self) -> Option<ExecutionBlockNumber>;
     fn parent_hash(&self) -> ExecutionBlockHash;
+    fn gas_limit(&self) -> Gas;
 
     fn is_default_payload(&self) -> bool;
     fn to_header(&self) -> CombinedExecutionPayloadHeader<P>;
@@ -1832,6 +1834,10 @@ impl<P: Preset> ExecutionPayload<P> for BellatrixExecutionPayload<P> {
 
     fn parent_hash(&self) -> ExecutionBlockHash {
         self.parent_hash
+    }
+
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
     }
 
     fn is_default_payload(&self) -> bool {
@@ -1856,6 +1862,10 @@ impl<P: Preset> ExecutionPayload<P> for BellatrixExecutionPayloadHeader<P> {
         self.parent_hash
     }
 
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
+    }
+
     fn is_default_payload(&self) -> bool {
         self.is_default()
     }
@@ -1876,6 +1886,10 @@ impl<P: Preset> ExecutionPayload<P> for CapellaExecutionPayload<P> {
 
     fn parent_hash(&self) -> ExecutionBlockHash {
         self.parent_hash
+    }
+
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
     }
 
     fn is_default_payload(&self) -> bool {
@@ -1900,6 +1914,10 @@ impl<P: Preset> ExecutionPayload<P> for CapellaExecutionPayloadHeader<P> {
         self.parent_hash
     }
 
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
+    }
+
     fn is_default_payload(&self) -> bool {
         self.is_default()
     }
@@ -1920,6 +1938,10 @@ impl<P: Preset> ExecutionPayload<P> for DenebExecutionPayload<P> {
 
     fn parent_hash(&self) -> ExecutionBlockHash {
         self.parent_hash
+    }
+
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
     }
 
     fn is_default_payload(&self) -> bool {
@@ -1944,6 +1966,10 @@ impl<P: Preset> ExecutionPayload<P> for DenebExecutionPayloadHeader<P> {
         self.parent_hash
     }
 
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
+    }
+
     fn is_default_payload(&self) -> bool {
         self.is_default()
     }
@@ -1964,6 +1990,10 @@ impl<P: Preset> ExecutionPayload<P> for ExecutionPayloadBid<P> {
 
     fn parent_hash(&self) -> ExecutionBlockHash {
         self.parent_block_hash
+    }
+
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
     }
 
     fn is_default_payload(&self) -> bool {


### PR DESCRIPTION
## What

`Store::validate_execution_payload_bid` derived `parent_gas_limit` from `state_at(bid.parent_block_root).latest_execution_payload_bid().gas_limit` — the parent block's own bid — regardless of which payload the bid builds on. The spec keys the check on the payload the bid actually extends:

```python
parent_gas_limit = seen.execution_payloads[bid.parent_block_hash].gas_limit
```
(https://github.com/ethereum/consensus-specs/blob/a670e0193446474bb1775ec94a93ca6fbaa11a89/specs/gloas/p2p-interface.md#L995-L1000)

A bid with `parent_block_root = head` and `parent_block_hash = head_bid.parent_block_hash` (head payload treated as withheld — which `is_bid_compatible_with_head` permits when `should_build_on_full` is false) must be checked against the grandparent payload's gas limit. Whenever the gas limit is moving, that differs from the head bid's gas limit by one EIP-1559 step, so a spec-correct bid was dropped with `bid gas_limit is not compatible with target_gas_limit` — on gossip, and via `POST /eth/v1/beacon/execution_payload_bids`, where it results in a 200 with an `Ignore` and no broadcast.

This PR resolves the chain link carrying the payload identified by `bid.parent_block_hash` through the existing `execution_payload_locations` index (replacing the bare `contains_key` existence check) and uses the gas limit committed by that block: its bid post-Gloas, the execution payload itself for a pre-Gloas block at the fork boundary. Envelopes must match their bid's `gas_limit` (already enforced at envelope processing), so the bid value is the payload value. `ExecutionPayload::gas_limit` is added to the trait for the pre-Gloas case.

## Why

Seen on glamsterdam-devnet-8 (gas limit ramping under EIP-8261). Slot 85165: payload at 85163 had gas limit 199411976, payload at 85164 (head) had 199606713, target 200000000. A builder's parent-empty bid carried 199606713 = 199411976 + 199411976/1024 − 1, correct for the payload it builds on; comparing against the head bid (199606713) makes it look like it failed to step toward the target.

Same class of bug was found in prysm (https://github.com/OffchainLabs/prysm/pull/17405), lighthouse (https://github.com/sigp/lighthouse/pull/9905) and nimbus (https://github.com/status-im/nimbus-eth2/pull/8941); lodestar and teku are correct. The spec gossip test vectors don't cover empty-head bids yet (every case uses the head's own payload as `parent_block_hash`); a vector PR is in progress.

## Testing

`cargo check` / `cargo clippy -p grandine --no-default-features --features default-networks,bls/blst,kzg_utils/blst` and `cargo fmt --check` on the changed crates. Targeting `glamsterdam-devnet-8` per the devnet image; happy to retarget or forward-port.