### PR TITLE
Key attestation packer candidates by committee, not AttestationData alone

### DIFF
--- a/operation_pools/src/attestation_agg_pool/attestation_packer.rs
+++ b/operation_pools/src/attestation_agg_pool/attestation_packer.rs
@@ -77,8 +77,14 @@ impl<P: Preset> AttestationPacker<P> {
         // TODO(Grandine Team): Storing candidates in a map allows for quick lookups during
         //                      aggregation without having to manage an index, but prevents the
         //                      algorithm from packing multiple aggregates with the same
-        //                      `AttestationData`.
+        //                      `AttestationKey`.
 
+        // Candidates are keyed by `AttestationKey` (`AttestationData` + committee index), not by
+        // `AttestationData` alone. Post-Electra, `data.index` no longer identifies the committee
+        // (Gloas even uses it for the payload presence vote), so aggregates from all committees of
+        // a slot share the same `AttestationData` and keying by it alone would keep only one
+        // committee per slot.
+        //
         // Use `BTreeMap` to make attestation packing deterministic for snapshot testing.
         let mut candidates = BTreeMap::new();
 
@@ -108,10 +114,10 @@ impl<P: Preset> AttestationPacker<P> {
                     // may speed up block processing by producing smaller aggregates later.
                     *added_weight > 0
                 })
-                .into_grouping_map_by(|(aggregate, _)| aggregate.data)
+                .into_grouping_map_by(|(aggregate, _)| aggregate.key())
                 .max_by_key(|_, (_, added_weight)| *added_weight)
                 .into_values()
-                .map(|(aggregate, _)| (aggregate.data, aggregate.clone())),
+                .map(|(aggregate, _)| (aggregate.key(), aggregate.clone())),
         );
 
         let mut candidates = candidates.into_values().collect_vec();


### PR DESCRIPTION
## What

`AttestationPacker::pack_proposable_attestations_greedily` de-duplicates candidate aggregates keyed on `AttestationData` alone — in the `into_grouping_map_by(|(aggregate, _)| aggregate.data)` pass and in the `candidates` `BTreeMap`. Post-Electra `data.index` no longer identifies the committee (and in Gloas it carries the payload-presence vote), so every committee's aggregate for a slot shares the same `AttestationData`, and the grouping keeps only the single highest-weight committee. The block producer then receives one committee per slot and packs a single-committee on-chain aggregate.

This PR keys both collections by `PoolAttestation::key()` (`AttestationKey { data, committee_index }`) instead. `attesting_indices`, `added_weight` and `add_attestation` already operate per committee via `committee_index`, and the block producer already merges same-`data` attestations across committees with `compute_on_chain_aggregate`, so nothing else needs to change.

## Why

The keying dates from 2024 and was masked until recently: pre-Electra `data.index` *is* the committee index, and after 63806e0e ("Store attestations with pristine data in the aggregate pool") the pool still emitted a scratch representation with `data.index = committee_index` for the packer. f83d952c ("Attestation pool refactor for epbs") removed that shim and moved the packer onto `PoolAttestation`, but left the `data`-keyed collapse in place. The packer's own tests didn't catch it because they use pre-Electra Goerli/Holesky fixtures and build `PoolAttestation { committee_index: data.index, .. }`, where `data` is unique per committee.

Observed on glamsterdam-devnet-8 (image at 8700067d): every Grandine-proposed block contains exactly one attestation covering one committee (~132 of ~2636 votes for the slot), while every other CL packs the full 20-committee aggregate. Over 4 epochs, 95% of previous-slot votes are left out whenever Grandine proposes the next block, versus ~0% for the other clients; network-wide that's ~16% of all attestations landing at inclusion distance 2 and an average inclusion distance of 1.21 on every client's dashboard row. Grandine's own `attestation packer candidates count` log line shows 4–7 candidates per block on a 20-committee network — the number of distinct `AttestationData` values.

Example (slot / proposer / attestations as `{inclusion delay: (count, committees, bits)}`):

```
92246  lodestar-ethrex-1    atts=1  {-1: (1, 20, 2634)}
92247  grandine-nimbusel-2  atts=1  {-1: (1,  1,  132)}
92248  grandine-nimbusel-1  atts=2  {-2: (1,  1,  132), -1: (1, 1, 132)}
92249  nimbus-reth-2        atts=3  {-3: (1, 18, 2371), -2: (1, 19, 2504), -1: (1, 20, 2635)}
```

This affects any post-Electra network running this branch, not only Gloas.

## Testing

`cargo fmt --check` and `cargo check -p grandine --no-default-features --features default-networks,bls/blst,kzg_utils/blst`. (`cargo clippy` currently fails on this branch before reaching `operation_pools` with a pre-existing `lint_groups_priority` error in the workspace `Cargo.toml` lints table — unrelated to this change.) No new unit test: the packer tests are gated on `eth2-cache` fixtures that are all pre-Electra, so a regression test needs an Electra/Gloas fixture — happy to add one if you can point me at the preferred way to build such a state in tests. Targeting `glamsterdam-devnet-8` per the devnet image; happy to retarget or forward-port.
