### PR TITLE
Replay persisted execution payload envelopes at restart

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -514,14 +514,16 @@ where
             NullVerifier,
         );
 
-        // TODO: timeliness of a payload is not persisted, so we cannot know if it was seen before
-        // the deadline. We now assume it was, but we should persist that information as well.
+        let seen_before_deadline = self
+            .storage
+            .is_execution_payload_envelope_timely(block_root)?;
+
         self.handle_execution_payload_envelope(
             wait_group.clone(),
             result,
             origin,
             payload_envelope_identifier,
-            true,
+            seen_before_deadline,
             processing_timings,
             tracing::debug_span!("handle_persisted_envelope"),
         );

--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -426,6 +426,16 @@ where
     ) -> Result<()> {
         let wait_group = W::default();
 
+        // The first unfinalized block builds on the anchor, so the anchor's payload has to be
+        // replayed as well for that block to pass `BlockAction::DelayUntilPayload`. This has to be
+        // done before unfinalized blocks exist check below
+        if self.store.anchor().is_post_gloas() {
+            self.replay_persisted_execution_payload_envelope(
+                &wait_group,
+                self.store.anchor().block_root,
+            )?;
+        }
+
         let Some(last_block) = blocks.next_back().transpose()? else {
             self.finished_loading_from_storage = true;
             return Ok(());
@@ -443,6 +453,7 @@ where
             let origin = BlockOrigin::Persisted;
             let processing_timings = ProcessingTimings::new();
             let block_root = block.message().hash_tree_root();
+            let is_post_gloas = block.phase() >= Phase::Gloas;
 
             // There is no point in spawning `BlockTask`s to validate persisted blocks.
             // State transitions within a single fork must be performed sequentially.
@@ -467,9 +478,53 @@ where
                 block_root,
                 tracing::debug_span!("handle_unfinalized_block"),
             )?;
+
+            // Envelopes are persisted separately from blocks. The envelope of a block must be
+            // applied before its child is validated.
+            if is_post_gloas {
+                self.replay_persisted_execution_payload_envelope(&wait_group, block_root)?;
+            }
         }
 
         self.finished_loading_from_storage = true;
+
+        Ok(())
+    }
+
+    fn replay_persisted_execution_payload_envelope(
+        &mut self,
+        wait_group: &W,
+        block_root: H256,
+    ) -> Result<()> {
+        let Some(envelope) = self
+            .storage
+            .execution_payload_envelope_by_root(block_root)?
+        else {
+            return Ok(());
+        };
+
+        let origin = ExecutionPayloadEnvelopeOrigin::Persisted;
+        let processing_timings = ProcessingTimings::new();
+        let payload_envelope_identifier = envelope.as_ref().into();
+
+        let result = self.store.validate_execution_payload_envelope(
+            &envelope,
+            &origin,
+            &self.execution_engine,
+            NullVerifier,
+        );
+
+        // TODO: timeliness of a payload is not persisted, so we cannot know if it was seen before
+        // the deadline. We now assume it was, but we should persist that information as well.
+        self.handle_execution_payload_envelope(
+            wait_group.clone(),
+            result,
+            origin,
+            payload_envelope_identifier,
+            true,
+            processing_timings,
+            tracing::debug_span!("handle_persisted_envelope"),
+        );
 
         Ok(())
     }
@@ -2190,13 +2245,14 @@ where
                 let block_hash = envelope.message.payload.block_hash;
                 let should_send_gossip_event = origin.should_send_gossip_event();
                 let should_generate_event = origin.should_generate_event();
+                let is_persisted = origin.is_persisted();
 
                 if self.store.is_forward_synced() {
                     debug_with_peers!(
                         "execution payload envelope accepted (\
                             block root: {beacon_block_root:?}, \
                             slot: {slot}, \
-                            seen before deadline: {seen_before_deadline} \
+                            seen before deadline: {seen_before_deadline}\
                         )",
                     );
                 } else {
@@ -2233,7 +2289,12 @@ where
                     Ok(ValidationOutcome::Accept),
                 );
 
-                self.accept_execution_payload_envelope(&wait_group, envelope, seen_before_deadline);
+                self.accept_execution_payload_envelope(
+                    &wait_group,
+                    envelope,
+                    seen_before_deadline,
+                    is_persisted,
+                );
 
                 if should_generate_event
                     && let Some(chain_link) = self.store.chain_link(beacon_block_root)
@@ -3614,11 +3675,15 @@ where
         wait_group: &W,
         envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
         is_before_deadline: bool,
+        is_persisted: bool,
     ) {
         let beacon_block_root = envelope.block_root();
 
-        self.store_mut()
-            .apply_execution_payload_envelope(envelope, is_before_deadline);
+        self.store_mut().apply_execution_payload_envelope(
+            envelope,
+            is_before_deadline,
+            is_persisted,
+        );
 
         self.update_store_snapshot();
 
@@ -3632,7 +3697,9 @@ where
             self.retry_delayed(delayed, wait_group);
         }
 
-        if !self.storage.prune_storage_enabled() {
+        // Envelopes replayed from storage are already persisted. They are marked as such once
+        // replay is over, so that a single task does not write all of them back.
+        if !self.storage.prune_storage_enabled() && self.finished_loading_from_storage {
             self.spawn(PersistExecutionPayloadEnvelopesTask {
                 store_snapshot: self.owned_store(),
                 storage: self.storage.clone_arc(),

--- a/fork_choice_control/src/storage.rs
+++ b/fork_choice_control/src/storage.rs
@@ -637,17 +637,24 @@ impl<P: Preset> Storage<P> {
 
     pub(crate) fn append_execution_payload_envelopes(
         &self,
-        envelopes: impl IntoIterator<Item = Arc<SignedExecutionPayloadEnvelope<P>>>,
+        envelopes: impl IntoIterator<Item = (Arc<SignedExecutionPayloadEnvelope<P>>, bool)>,
     ) -> Result<Vec<H256>> {
         let mut batch = vec![];
         let mut persisted_block_roots = vec![];
 
-        for envelope in envelopes {
+        for (envelope, is_timely) in envelopes {
             let block_root = envelope.block_root();
             let slot = envelope.slot();
 
             batch.push(serialize(EnvelopeByBlockRoot(block_root), envelope)?);
             batch.push(serialize(EnvelopeRootBySlot(slot, block_root), block_root)?);
+
+            if is_timely {
+                batch.push(serialize(
+                    TimelyEnvelopeByBlockRoot(block_root),
+                    block_root,
+                )?);
+            }
 
             persisted_block_roots.push(block_root);
         }
@@ -671,6 +678,10 @@ impl<P: Preset> Storage<P> {
         block_root: H256,
     ) -> Result<Option<Arc<SignedExecutionPayloadEnvelope<P>>>> {
         self.get(EnvelopeByBlockRoot(block_root))
+    }
+
+    pub(crate) fn is_execution_payload_envelope_timely(&self, block_root: H256) -> Result<bool> {
+        self.contains_key(TimelyEnvelopeByBlockRoot(block_root))
     }
 
     pub(crate) fn prune_old_data_column_sidecars(&self, up_to_slot: Slot) -> Result<()> {
@@ -734,6 +745,7 @@ impl<P: Preset> Storage<P> {
             let block_root = H256::from_ssz_default(value_bytes)?;
 
             keys_to_remove.push(EnvelopeByBlockRoot(block_root).to_string().into());
+            keys_to_remove.push(TimelyEnvelopeByBlockRoot(block_root).to_string().into());
         }
 
         self.database.delete_batch(keys_to_remove)
@@ -1468,6 +1480,14 @@ impl PrefixableKey for EnvelopeRootBySlot {
     fn has_prefix(bytes: &[u8]) -> bool {
         bytes.starts_with(Self::PREFIX.as_bytes())
     }
+}
+
+#[derive(Display)]
+#[display("{}{_0:x}", Self::PREFIX)]
+pub struct TimelyEnvelopeByBlockRoot(pub H256);
+
+impl PrefixableKey for TimelyEnvelopeByBlockRoot {
+    const PREFIX: &'static str = "y";
 }
 
 #[derive(Debug, Error)]

--- a/fork_choice_control/src/storage_back_sync.rs
+++ b/fork_choice_control/src/storage_back_sync.rs
@@ -179,7 +179,13 @@ impl<P: Preset> Storage<P> {
         &self,
         execution_payload_envelopes: impl IntoIterator<Item = Arc<SignedExecutionPayloadEnvelope<P>>>,
     ) -> Result<()> {
-        self.append_execution_payload_envelopes(execution_payload_envelopes)?;
+        // Back-synced envelopes were never observed at reveal time, so none of them count as
+        // timely.
+        self.append_execution_payload_envelopes(
+            execution_payload_envelopes
+                .into_iter()
+                .map(|envelope| (envelope, false)),
+        )?;
         Ok(())
     }
 }

--- a/fork_choice_control/src/tasks.rs
+++ b/fork_choice_control/src/tasks.rs
@@ -961,7 +961,10 @@ impl<P: Preset, W> Run for PersistExecutionPayloadEnvelopesTask<P, W> {
                 .start_timer()
         });
 
-        let envelopes = store_snapshot.unpersisted_envelopes();
+        let envelopes = store_snapshot.unpersisted_envelopes().map(|envelope| {
+            let is_timely = store_snapshot.is_payload_present_timely(envelope.block_root());
+            (envelope, is_timely)
+        });
 
         match storage.append_execution_payload_envelopes(envelopes) {
             Ok(persisted_block_roots) => {

--- a/fork_choice_store/src/error.rs
+++ b/fork_choice_store/src/error.rs
@@ -255,6 +255,14 @@ pub enum Error<P: Preset> {
     #[error("execution payload envelope slot mismatch: expected {expected}, actual {actual}")]
     ExecutionPayloadEnvelopeSlotMismatch { expected: Slot, actual: Slot },
     #[error(
+        "execution payload envelope slot does not match the slot of its block: \
+         block slot {block_slot}, envelope slot {envelope_slot}"
+    )]
+    ExecutionPayloadEnvelopeBlockSlotMismatch {
+        block_slot: Slot,
+        envelope_slot: Slot,
+    },
+    #[error(
         "execution payload timestamp mismatch (envelope: {envelope:?}, expected: {expected:?})"
     )]
     ExecutionPayloadTimestampMismatch {
@@ -268,6 +276,8 @@ pub enum Error<P: Preset> {
         envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
         expected: Box<PayloadExpectedWithdrawals>,
     },
+    #[error("execution payload has too many withdrawals: {in_payload} > {maximum}")]
+    ExecutionPayloadTooManyWithdrawals { in_payload: usize, maximum: usize },
     #[error("proposer preferences has invalid proposal slot: {signed_preferences:?}")]
     InvalidProposerPreferencesProposalSlot {
         signed_preferences: Arc<SignedProposerPreferences>,

--- a/fork_choice_store/src/execution_payload_envelope_cache.rs
+++ b/fork_choice_store/src/execution_payload_envelope_cache.rs
@@ -16,11 +16,12 @@ impl<P: Preset> ExecutionPayloadEnvelopeCache<P> {
         Some(&self.envelopes.get(&block_root)?.0)
     }
 
-    pub fn insert(&mut self, envelope: Arc<SignedExecutionPayloadEnvelope<P>>) {
+    pub fn insert(&mut self, envelope: Arc<SignedExecutionPayloadEnvelope<P>>, persisted: bool) {
         let slot = envelope.slot();
         let block_root = envelope.block_root();
 
-        self.envelopes.insert(block_root, (envelope, slot, false));
+        self.envelopes
+            .insert(block_root, (envelope, slot, persisted));
     }
 
     pub fn prune_finalized(&mut self, finalized_slot: Slot) {

--- a/fork_choice_store/src/misc.rs
+++ b/fork_choice_store/src/misc.rs
@@ -1274,6 +1274,7 @@ pub enum ExecutionPayloadEnvelopeOrigin {
     Gossip(GossipId),
     Requested(PeerId),
     Own,
+    Persisted,
     Api(Option<Sender<Result<ValidationOutcome>>>),
     Test(BlsSetting),
 }
@@ -1284,7 +1285,7 @@ impl ExecutionPayloadEnvelopeOrigin {
         match self {
             Self::Gossip(gossip_id) => (Some(gossip_id), None),
             Self::Api(sender) => (None, sender),
-            Self::BackSync | Self::Requested(_) | Self::Own => (None, None),
+            Self::BackSync | Self::Requested(_) | Self::Own | Self::Persisted => (None, None),
             Self::Test(_) => (Some(GossipId::default()), None),
         }
     }
@@ -1293,7 +1294,9 @@ impl ExecutionPayloadEnvelopeOrigin {
     pub fn gossip_id(&self) -> Option<GossipId> {
         match self {
             Self::Gossip(gossip_id) => Some(gossip_id.clone()),
-            Self::BackSync | Self::Requested(_) | Self::Own | Self::Api(_) => None,
+            Self::BackSync | Self::Requested(_) | Self::Own | Self::Persisted | Self::Api(_) => {
+                None
+            }
             Self::Test(_) => Some(GossipId::default()),
         }
     }
@@ -1302,7 +1305,12 @@ impl ExecutionPayloadEnvelopeOrigin {
     pub const fn gossip_id_ref(&self) -> Option<&GossipId> {
         match self {
             Self::Gossip(gossip_id) => Some(gossip_id),
-            Self::BackSync | Self::Requested(_) | Self::Own | Self::Api(_) | Self::Test(_) => None,
+            Self::BackSync
+            | Self::Requested(_)
+            | Self::Own
+            | Self::Persisted
+            | Self::Api(_)
+            | Self::Test(_) => None,
         }
     }
 
@@ -1320,14 +1328,45 @@ impl ExecutionPayloadEnvelopeOrigin {
     pub const fn verify_signatures(&self) -> bool {
         match self {
             Self::BackSync | Self::Gossip(_) | Self::Requested(_) | Self::Api(_) => true,
-            Self::Own => false,
+            Self::Own | Self::Persisted => false,
             Self::Test(bls_setting) => !matches!(bls_setting, BlsSetting::Ignored),
+        }
+    }
+
+    #[must_use]
+    pub const fn state_root_policy(&self) -> StateRootPolicy {
+        match self {
+            Self::BackSync
+            | Self::Gossip(_)
+            | Self::Requested(_)
+            | Self::Own
+            | Self::Api(_)
+            | Self::Test(_) => StateRootPolicy::Verify,
+            Self::Persisted => StateRootPolicy::Trust,
+        }
+    }
+
+    #[must_use]
+    pub const fn data_availability_policy(&self) -> DataAvailabilityPolicy {
+        match self {
+            Self::BackSync
+            | Self::Gossip(_)
+            | Self::Requested(_)
+            | Self::Own
+            | Self::Api(_)
+            | Self::Test(_) => DataAvailabilityPolicy::Check,
+            Self::Persisted => DataAvailabilityPolicy::Trust,
         }
     }
 
     #[must_use]
     pub const fn is_own(&self) -> bool {
         matches!(self, Self::Own)
+    }
+
+    #[must_use]
+    pub const fn is_persisted(&self) -> bool {
+        matches!(self, Self::Persisted)
     }
 
     #[must_use]
@@ -1388,7 +1427,7 @@ impl ProposerPreferencesOrigin {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, AsRefStr)]
 pub enum ExecutionPayloadEnvelopeAction<P: Preset> {
     Accept(Arc<SignedExecutionPayloadEnvelope<P>>),
     Ignore(Publishable),

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -42,6 +42,7 @@ use tap::Pipe as _;
 use tracing::{debug_span, instrument};
 use transition_functions::{
     combined,
+    gloas::verify_execution_requests_limits,
     unphased::{self, ProcessSlots, StateRootPolicy},
 };
 use typenum::Unsigned as _;
@@ -3905,6 +3906,15 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             .into());
         };
 
+        // [REJECT] block.slot == payload.slot_number
+        ensure!(
+            block.message().slot() == slot,
+            Error::<P>::ExecutionPayloadEnvelopeBlockSlotMismatch {
+                block_slot: block.message().slot(),
+                envelope_slot: slot,
+            },
+        );
+
         // [REJECT] envelope.builder_index == bid.builder_index
         ensure!(
             builder_index == bid.builder_index,
@@ -3941,7 +3951,8 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         // > Check if blob data is available
         // > If not, this payload MAY be queued and subsequently considered when blob data becomes available
-        if self.should_check_data_availability_at_slot(slot)
+        if origin.data_availability_policy().check()
+            && self.should_check_data_availability_at_slot(slot)
             && !self.indices_of_missing_data_columns(&block).is_empty()
         {
             return Ok(ExecutionPayloadEnvelopeAction::DelayUntilData(
@@ -3957,7 +3968,6 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             ));
         };
 
-        // [REJECT] block.slot equals envelope.slot
         ensure!(
             state.slot() == slot,
             Error::<P>::ExecutionPayloadEnvelopeSlotMismatch {
@@ -3966,19 +3976,21 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             },
         );
 
-        let mut header = state.latest_block_header();
+        if matches!(origin.state_root_policy(), StateRootPolicy::Verify) {
+            let mut header = state.latest_block_header();
 
-        header.state_root = state.hash_tree_root();
+            header.state_root = state.hash_tree_root();
 
-        let header_root = header.hash_tree_root();
+            let header_root = header.hash_tree_root();
 
-        ensure!(
-            envelope.message.beacon_block_root == header_root,
-            Error::<P>::ExecutionPayloadBeaconBlockRootMismatch {
-                envelope,
-                expected: Box::new(header_root),
-            },
-        );
+            ensure!(
+                envelope.message.beacon_block_root == header_root,
+                Error::<P>::ExecutionPayloadBeaconBlockRootMismatch {
+                    envelope,
+                    expected: Box::new(header_root),
+                },
+            );
+        }
 
         let parent_beacon_block_root = state.latest_block_header().parent_root;
 
@@ -3987,6 +3999,20 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             Error::<P>::ExecutionPayloadParentBeaconBlockRootMismatch {
                 envelope,
                 expected: Box::new(parent_beacon_block_root),
+            },
+        );
+
+        // [REJECT] The execution request counts are within their limits
+        verify_execution_requests_limits(&envelope.message.execution_requests)?;
+
+        // [REJECT] The number of withdrawals is within the limit
+        let withdrawal_count = envelope.message.payload.withdrawals.len_usize();
+
+        ensure!(
+            withdrawal_count <= P::MaxWithdrawalsPerPayload::USIZE,
+            Error::<P>::ExecutionPayloadTooManyWithdrawals {
+                in_payload: withdrawal_count,
+                maximum: P::MaxWithdrawalsPerPayload::USIZE,
             },
         );
 
@@ -4694,6 +4720,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         &mut self,
         envelope: Arc<SignedExecutionPayloadEnvelope<P>>,
         is_before_deadline: bool,
+        is_persisted: bool,
     ) {
         let slot = envelope.slot();
         let beacon_block_root = envelope.block_root();
@@ -4708,7 +4735,8 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         self.accepted_execution_payload_envelopes
             .insert((slot, beacon_block_root, builder_index));
 
-        self.execution_payload_envelope_cache.insert(envelope);
+        self.execution_payload_envelope_cache
+            .insert(envelope, is_persisted);
     }
 
     pub fn apply_blob_sidecar(&mut self, blob_sidecar: Arc<BlobSidecar<P>>) {

--- a/p2p/src/block_sync_service.rs
+++ b/p2p/src/block_sync_service.rs
@@ -1110,7 +1110,14 @@ impl<P: Preset> BlockSyncService<P> {
             .is_peerdas_activated();
 
         // Batch request data columns by root for missing columns if any
-        if !self.is_forward_synced && is_peerdas_activated {
+        if is_peerdas_activated
+            && (!self.is_forward_synced
+                || self
+                    .controller
+                    .snapshot()
+                    .earliest_data_unavailable_slot()
+                    .is_some())
+        {
             self.batch_request_missing_data_columns().await?;
         }
 

--- a/p2p/src/sync_manager.rs
+++ b/p2p/src/sync_manager.rs
@@ -1259,7 +1259,9 @@ impl<P: Preset> SyncManager<P> {
         );
     }
 
-    pub fn find_available_custodial_peers(&self) -> Vec<PeerId> {
+    pub fn find_available_custodial_peers(&mut self) -> Vec<PeerId> {
+        self.refresh_unknown_peer_custody_columns();
+
         let busy_peers = self.busy_peers();
 
         self.peers_custodial
@@ -1269,6 +1271,8 @@ impl<P: Preset> SyncManager<P> {
     }
 
     fn find_peers_to_sync(&mut self, use_black_list: bool) -> Option<Vec<PeerId>> {
+        self.refresh_unknown_peer_custody_columns();
+
         self.find_chain_to_sync(use_black_list).map(|chain_id| {
             let peers_to_sync = self.chain_peers_shuffled(&chain_id, use_black_list);
 
@@ -1387,12 +1391,7 @@ impl<P: Preset> SyncManager<P> {
     }
 
     fn update_peer_columns_custody(&mut self, peer_id: PeerId) {
-        let custody_columns = (0..P::NumberOfColumns::U64)
-            .filter(|column_index| {
-                self.network_globals
-                    .is_custody_peer_of(*column_index, &peer_id)
-            })
-            .collect();
+        let custody_columns = self.peer_custody_columns(peer_id);
 
         self.log(
             Level::Debug,
@@ -1400,6 +1399,41 @@ impl<P: Preset> SyncManager<P> {
         );
 
         self.peers_custodial.insert(peer_id, custody_columns);
+    }
+
+    fn peer_custody_columns(&self, peer_id: PeerId) -> HashSet<ColumnIndex> {
+        (0..P::NumberOfColumns::U64)
+            .filter(|column_index| {
+                self.network_globals
+                    .is_custody_peer_of(*column_index, &peer_id)
+            })
+            .collect()
+    }
+
+    fn refresh_unknown_peer_custody_columns(&mut self) {
+        let peers_with_unknown_custody = self
+            .peers_custodial
+            .iter()
+            .filter(|(_, custody_columns)| custody_columns.is_empty())
+            .map(|(peer_id, _)| *peer_id)
+            .collect_vec();
+
+        for peer_id in peers_with_unknown_custody {
+            let custody_columns = self.peer_custody_columns(peer_id);
+
+            if custody_columns.is_empty() {
+                continue;
+            }
+
+            self.log(
+                Level::Debug,
+                format_args!(
+                    "peer custody columns (peer: {peer_id}, columns: {custody_columns:?})"
+                ),
+            );
+
+            self.peers_custodial.insert(peer_id, custody_columns);
+        }
     }
 
     pub async fn missing_column_indices_by_root(

--- a/runtime/src/schema.rs
+++ b/runtime/src/schema.rs
@@ -54,7 +54,11 @@ const META_FILE_NAME: &str = "meta.json";
 // ## 0.2.3
 //
 // Added state_root to slot indexing to storage to enable loading archived states by state root.
-const SCHEMA_VERSION: &str = "0.2.3";
+//
+// ## 0.2.4
+//
+// Persist execution payload envelope timeliness.
+const SCHEMA_VERSION: &str = "0.2.4";
 
 // Semantic Versioning by itself only achieves forward compatibility.
 // Backward compatibility is achieved using a version requirement separate from the schema version.

--- a/transition_functions/src/gloas/block_processing.rs
+++ b/transition_functions/src/gloas/block_processing.rs
@@ -739,26 +739,7 @@ pub fn apply_parent_execution_payload<P: Preset>(
     // > [New in Gloas:EIP7688] Progressive lists are unbounded at the SSZ level.
     // > Request counts are validated during processing instead.
     // > Note that `deposits` intentionally has no limit in the spec.
-    ensure_operation_count::<P>(
-        "withdrawal requests",
-        execution_requests.withdrawals.len_usize(),
-        P::MaxWithdrawalRequestsPerPayload::USIZE,
-    )?;
-    ensure_operation_count::<P>(
-        "consolidation requests",
-        execution_requests.consolidations.len_usize(),
-        P::MaxConsolidationRequestsPerPayload::USIZE,
-    )?;
-    ensure_operation_count::<P>(
-        "builder deposit requests",
-        execution_requests.builder_deposits.len_usize(),
-        P::MaxBuilderDepositRequestsPerPayload::USIZE,
-    )?;
-    ensure_operation_count::<P>(
-        "builder exit requests",
-        execution_requests.builder_exits.len_usize(),
-        P::MaxBuilderExitRequestsPerPayload::USIZE,
-    )?;
+    verify_execution_requests_limits(execution_requests)?;
 
     process_execution_requests(config, pubkey_cache, state, execution_requests)?;
 
@@ -859,6 +840,31 @@ pub fn process_execution_payload_bid<P: Preset>(
     *state.latest_execution_payload_bid_mut() = signed_bid.message.clone();
 
     Ok(parent_slot)
+}
+
+pub fn verify_execution_requests_limits<P: Preset>(
+    execution_requests: &ExecutionRequests<P>,
+) -> Result<()> {
+    ensure_operation_count::<P>(
+        "withdrawal requests",
+        execution_requests.withdrawals.len_usize(),
+        P::MaxWithdrawalRequestsPerPayload::USIZE,
+    )?;
+    ensure_operation_count::<P>(
+        "consolidation requests",
+        execution_requests.consolidations.len_usize(),
+        P::MaxConsolidationRequestsPerPayload::USIZE,
+    )?;
+    ensure_operation_count::<P>(
+        "builder deposit requests",
+        execution_requests.builder_deposits.len_usize(),
+        P::MaxBuilderDepositRequestsPerPayload::USIZE,
+    )?;
+    ensure_operation_count::<P>(
+        "builder exit requests",
+        execution_requests.builder_exits.len_usize(),
+        P::MaxBuilderExitRequestsPerPayload::USIZE,
+    )
 }
 
 fn ensure_operation_count<P: Preset>(

--- a/transition_functions/src/lib.rs
+++ b/transition_functions/src/lib.rs
@@ -239,7 +239,9 @@ pub mod fulu {
 }
 
 pub mod gloas {
-    pub use block_processing::{apply_parent_execution_payload, get_expected_withdrawals};
+    pub use block_processing::{
+        apply_parent_execution_payload, get_expected_withdrawals, verify_execution_requests_limits,
+    };
 
     pub(crate) use block_processing::{process_block, process_block_for_gossip};
     pub(crate) use epoch_processing::process_epoch;


### PR DESCRIPTION
Close #886 

This commit also add SSZ limits check on execution request operations and withdrawals length check in execution payload envelope validation. In p2p changes, fix stale peer custody info and request missing columns after forward synced at restart.