### PR TITLE
Add InclusionList and SignedInclusionList SSZ containers

### DIFF
--- a/types/src/heze/containers.rs
+++ b/types/src/heze/containers.rs
@@ -1,0 +1,31 @@
+//! Heze containers from [`consensus-specs`].
+//!
+//! [`consensus-specs`]: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.14/specs/heze/beacon-chain.md#containers
+
+use bls::SignatureBytes;
+use serde::{Deserialize, Serialize};
+use ssz::{ProgressiveList, Ssz};
+
+use crate::{
+    gloas::primitives::Transaction,
+    phase0::primitives::{H256, Slot, ValidatorIndex},
+    preset::Preset,
+};
+
+#[derive(Clone, PartialEq, Eq, Debug, Default, Deserialize, Serialize, Ssz)]
+#[serde(bound = "", deny_unknown_fields)]
+pub struct InclusionList<P: Preset> {
+    #[serde(with = "serde_utils::string_or_native")]
+    pub slot: Slot,
+    #[serde(with = "serde_utils::string_or_native")]
+    pub validator_index: ValidatorIndex,
+    pub dependent_root: H256,
+    pub transactions: ProgressiveList<Transaction<P>>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Default, Deserialize, Serialize, Ssz)]
+#[serde(bound = "", deny_unknown_fields)]
+pub struct SignedInclusionList<P: Preset> {
+    pub message: InclusionList<P>,
+    pub signature: SignatureBytes,
+}

--- a/types/src/heze/spec_tests.rs
+++ b/types/src/heze/spec_tests.rs
@@ -1,0 +1,46 @@
+use spec_test_utils::Case;
+use test_generator::test_resources;
+
+use crate::{
+    preset::{Mainnet, Minimal},
+    unphased::spec_tests,
+};
+
+mod tested_types {
+    pub use crate::heze::containers::*;
+}
+
+macro_rules! tests_for_type {
+    (
+        $type: ident $(<_ $bracket: tt)?,
+        $mainnet_glob: literal,
+        $minimal_glob: literal,
+    ) => {
+        #[expect(non_snake_case)]
+        mod $type {
+            use super::*;
+
+            #[test_resources($mainnet_glob)]
+            fn mainnet(case: Case) {
+                spec_tests::run_spec_test_case::<tested_types::$type$(<Mainnet $bracket)?>(case);
+            }
+
+            #[test_resources($minimal_glob)]
+            fn minimal(case: Case) {
+                spec_tests::run_spec_test_case::<tested_types::$type$(<Minimal $bracket)?>(case);
+            }
+        }
+    };
+}
+
+tests_for_type! {
+    InclusionList<_>,
+    "consensus-spec-tests/tests/mainnet/heze/ssz_static/InclusionList/*/*",
+    "consensus-spec-tests/tests/minimal/heze/ssz_static/InclusionList/*/*",
+}
+
+tests_for_type! {
+    SignedInclusionList<_>,
+    "consensus-spec-tests/tests/mainnet/heze/ssz_static/SignedInclusionList/*/*",
+    "consensus-spec-tests/tests/minimal/heze/ssz_static/SignedInclusionList/*/*",
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -102,6 +102,13 @@ pub mod gloas {
     mod spec_tests;
 }
 
+pub mod heze {
+    pub mod containers;
+
+    #[cfg(test)]
+    mod spec_tests;
+}
+
 pub use collections::{
     DepositSignatureCache, PayloadExpectedWithdrawals, PendingDeposits, ProposerLookahead, Ptc,
     PtcWindow, Validators,


### PR DESCRIPTION
Closes #240.

The containers pasted in the issue are stale. FOCIL has since moved out of `specs/_features/eip7805` into the `heze` fork, where the third field is `dependent_root` rather than `inclusion_list_committee_root` and `transactions` is a `ProgressiveList` inherited from gloas rather than a length-bounded list. I followed the current spec. Worth noting the old EIP text also assigns the IL committee domain `0x0C000000`, which gloas already uses for `DOMAIN_PTC_ATTESTER`; the current spec moved it to `0x10000000`.

We already download the heze `ssz_static` vectors and ignore them wholesale in the coverage script, so both containers are wired to the real fixtures instead of hand-rolled round trips. I left the ignore glob alone since it still covers everything and narrowing it would only churn. No fork wiring, no preset or config constants, no `Phase` variant, so nothing outside the new module changes.
