### PR TITLE
Move execution payload location insertion to when the payload envelope arrives

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -3546,13 +3546,33 @@ where
         is_before_deadline: bool,
     ) {
         let beacon_block_root = envelope.block_root();
+        let execution_block_hash = envelope.message.payload.block_hash;
 
         self.store_mut()
             .apply_execution_payload_envelope(envelope, is_before_deadline);
 
         self.update_store_snapshot();
 
+        // `notify_new_payload` is called after the envelope validated, so the payload status
+        // may arrive before the payload is even handled in the mutator
+        if let Some(payload_statuses) = self.delayed_until_payload.remove(&execution_block_hash) {
+            for (payload_status, _) in payload_statuses {
+                self.handle_notified_new_payload(
+                    wait_group,
+                    beacon_block_root,
+                    execution_block_hash,
+                    payload_status,
+                );
+            }
+        }
+
         self.notify_forkchoice_updated(self.store.head());
+
+        // The next slot's payload attributes depend on the head's payload presence,
+        // which this envelope has just changed.
+        if beacon_block_root == self.store.head().block_root {
+            self.spawn_preprocess_head_state_for_next_slot_task();
+        }
 
         if let Some(delayed) = self.take_delayed_until_envelope(beacon_block_root) {
             self.retry_delayed(delayed, wait_group);
@@ -3756,8 +3776,14 @@ where
         let safe_block_hash = store.safe_execution_payload_hash();
         let finalized_block_hash = store.finalized_execution_payload_hash();
 
-        let head_block_hash = if let Some(post_gloas_state) = new_head.state(store).post_gloas() {
-            post_gloas_state.latest_block_hash()
+        let head_block_hash = if let Some(post_gloas_state) = new_head_state.post_gloas() {
+            // `latest_block_hash` is still the parent's payload until the head's envelope
+            // is processed in `apply_parent_execution_payload` of the child block.
+            if store.is_payload_verified(new_head.block_root) {
+                post_gloas_state.latest_execution_payload_bid().block_hash
+            } else {
+                post_gloas_state.latest_block_hash()
+            }
         } else {
             state.latest_execution_payload_header().block_hash()
         };

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -2336,8 +2336,9 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         };
 
         // > the `bid.parent_block_hash` is the block hash of a known execution payload in fork choice
-        let Some(parent_payload_chain_link) =
-            self.unfinalized_chain_link_by_execution_block_hash(bid.parent_block_hash)
+        let Some(parent_gas_limit) = self
+            .unfinalized_chain_link_by_execution_block_hash(bid.parent_block_hash)
+            .and_then(|chain_link| chain_link.block.execution_gas_limit())
         else {
             return Ok(ExecutionPayloadBidAction::Ignore(
                 "the `bid.parent_block_hash` is the block hash of a known execution payload in fork choice",
@@ -2351,20 +2352,6 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         // (envelopes must match their bid's `gas_limit`). This is not necessarily the payload of
         // `bid.parent_block_root`: a bid may build on the parent's parent payload when the parent
         // block's payload was withheld. Pre-Gloas blocks carry the payload itself.
-        let parent_payload_block_body = parent_payload_chain_link.block.message().body();
-        let Some(parent_gas_limit) = parent_payload_block_body
-            .with_payload_bid()
-            .map(|body| body.signed_execution_payload_bid().message.gas_limit)
-            .or_else(|| {
-                parent_payload_block_body
-                    .with_execution_payload()
-                    .map(|body| body.execution_payload().gas_limit())
-            })
-        else {
-            return Ok(ExecutionPayloadBidAction::Ignore(
-                "the `bid.parent_block_hash` is the block hash of a known execution payload in fork choice",
-            ));
-        };
         if !predicates::is_gas_limit_target_compatible(
             parent_gas_limit,
             bid.gas_limit,
@@ -4712,6 +4699,11 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         self.accepted_execution_payload_envelopes
             .insert((slot, beacon_block_root, builder_index));
 
+        if let Some(location) = self.unfinalized_locations.get(&beacon_block_root).copied() {
+            self.execution_payload_locations
+                .insert(envelope.message.payload.block_hash, location);
+        }
+
         self.execution_payload_envelope_cache.insert(envelope);
     }
 
@@ -4864,6 +4856,7 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         let block_root = chain_link.block_root;
         let block = &chain_link.block;
         let parent_root = block.message().parent_root();
+        let is_post_gloas = chain_link.is_post_gloas();
         let execution_block_hash = block.execution_block_hash();
 
         let new_block_location;
@@ -4917,7 +4910,12 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             .insert(block_root, new_block_location)
             .unwrap_none();
 
-        if let Some(block_hash) = execution_block_hash {
+        // Post-Gloas blocks only contain a commitment to a payload, the full payload is propagated
+        // separately in `ExecutionPayloadEnvelope`. So by the time a block is imported, we can't
+        // decide its payload availability yet.
+        if let Some(block_hash) = execution_block_hash
+            && !is_post_gloas
+        {
             self.execution_payload_locations
                 .insert(block_hash, new_block_location);
         }
@@ -5061,11 +5059,19 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
     fn remove_orphaned(&mut self, orphaned_blocks: Vector<UnfinalizedBlock<P>>) {
         for block in orphaned_blocks {
-            self.unfinalized_locations
+            let location = self
+                .unfinalized_locations
                 .remove(&block.block_root())
                 .expect(
                     "roots of unfinalized blocks should be present in self.unfinalized_locations",
                 );
+
+            // equivocating blocks can share an execution block hash
+            if let Some(block_hash) = block.chain_link.execution_block_hash()
+                && self.execution_payload_locations.get(&block_hash) == Some(&location)
+            {
+                self.execution_payload_locations.remove(&block_hash);
+            }
         }
     }
 

--- a/types/src/combined.rs
+++ b/types/src/combined.rs
@@ -721,6 +721,19 @@ impl<P: Preset> SignedBeaconBlock<P> {
             })
     }
 
+    pub fn execution_gas_limit(&self) -> Option<Gas> {
+        self.message()
+            .body()
+            .with_payload_bid()
+            .map(|body| body.signed_execution_payload_bid().message.gas_limit)
+            .or_else(|| {
+                self.message()
+                    .body()
+                    .with_execution_payload()
+                    .map(|body| body.execution_payload().gas_limit())
+            })
+    }
+
     pub fn to_header(&self) -> SignedBeaconBlockHeader {
         self.message().to_header().with_signature(self.signature())
     }


### PR DESCRIPTION
Post-Gloas, `execution_payload_locations` was populated from the bid's block hash at block insert, so fork choice treated a payload that was only committed to, possibly never revealed; as one it had seen. This PR update to only insert the payload location when its envelope is verified and cleanup the location if its block has became orphaned, and retry payload status from delayed when EL respond `notify_new_payload` before the actual payload is handled.

This PR also correct `head_block_hash` in FCU engine call after envelope accepted, since `latest_block_hash` will be updated in `apply_parent_execution_payload` during process the child beacon block, so EL was 1 block away from the actual head.

Closes #888 