### PR TITLE
Fix CI build

### DIFF
--- a/bindings/c/src/containers.rs
+++ b/bindings/c/src/containers.rs
@@ -14,9 +14,14 @@ use generic_array::ArrayLength;
 use ssz::{ByteVector, ContiguousList, ContiguousVector, SszReadDefault, SszWrite};
 use try_from_iterator::TryFromIterator;
 use types::{
-    bellatrix::primitives::Transaction, deneb::primitives::Blob,
+    bellatrix::primitives::Transaction,
+    deneb::primitives::Blob,
     electra::containers::ExecutionRequests as ElectraExecutionRequests,
-    gloas::containers::ExecutionRequests as GloasExecutionRequests, preset::Mainnet,
+    gloas::{
+        containers::ExecutionRequests as GloasExecutionRequests,
+        primitives::Transaction as GloasTransaction,
+    },
+    preset::Mainnet,
 };
 
 use crate::{
@@ -880,6 +885,21 @@ impl TryInto<Transaction<Mainnet>> for CTransaction {
     fn try_into(self) -> Result<Transaction<Mainnet>, Self::Error> {
         let vec: Vec<_> = self.0.into();
         Transaction::<Mainnet>::try_from(vec)
+    }
+}
+
+impl From<GloasTransaction<Mainnet>> for CTransaction {
+    fn from(value: GloasTransaction<Mainnet>) -> Self {
+        CTransaction(value.as_bytes().into())
+    }
+}
+
+impl TryInto<GloasTransaction<Mainnet>> for CTransaction {
+    type Error = ssz::ReadError;
+
+    fn try_into(self) -> Result<GloasTransaction<Mainnet>, Self::Error> {
+        let vec: Vec<_> = self.0.into();
+        GloasTransaction::<Mainnet>::try_from(vec)
     }
 }
 

--- a/bindings/c/src/generic.rs
+++ b/bindings/c/src/generic.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Result;
 use generic_array::ArrayLength;
-use ssz::ByteList;
+use ssz::{ByteList, ProgressiveByteList};
 
 pub const GRANDINE_SUCCESS: u32 = 0;
 pub const GRANDINE_ERROR_GENERIC: u32 = 1;
@@ -377,5 +377,14 @@ impl<T: ArrayLength<u8>> TryInto<ByteList<T>> for CVec<u8> {
     fn try_into(self) -> Result<ByteList<T>, Self::Error> {
         let vec: Vec<_> = self.into();
         ByteList::try_from(vec)
+    }
+}
+
+impl<T: ArrayLength<u8>> TryInto<ProgressiveByteList<T>> for CVec<u8> {
+    type Error = ssz::ReadError;
+
+    fn try_into(self) -> Result<ProgressiveByteList<T>, Self::Error> {
+        let vec: Vec<_> = self.into();
+        ProgressiveByteList::try_from(vec)
     }
 }

--- a/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
+++ b/bindings/csharp/Grandine.NethermindPlugin/GrandineEngineApi.cs
@@ -233,7 +233,7 @@ public class GrandineEngineApi : IGrandineEngineApi
                     BlockAccessList = payload.block_access_list.AsSpan().ToArray(),
                     SlotNumber = (ulong)payload.slot_number,
                 },
-                GrandineUtils.ConvertVersionedHashes(*versionedHashesPtr),
+                GrandineUtils.ConvertVersionedHashesToHash256(*versionedHashesPtr),
                 parentBeaconBlockRootConverted,
                 executionRequestsConverted)
             .Result;

--- a/types/src/nonstandard.rs
+++ b/types/src/nonstandard.rs
@@ -10,6 +10,7 @@ use derivative::Derivative;
 use derive_more::{Constructor, From};
 use enum_iterator::Sequence;
 use enum_map::Enum;
+#[cfg(not(target_os = "zkvm"))]
 use im::{HashMap, Vector, vector::Iter as VectorIter};
 use serde::Serialize;
 use serde_with::{DeserializeFromStr, SerializeDisplay};

--- a/types/src/traits.rs
+++ b/types/src/traits.rs
@@ -10,10 +10,13 @@
 // TODO(Grandine Team): GC unused impls for pointers.
 
 use core::fmt::Debug;
+#[cfg(target_os = "zkvm")]
+use std::slice::Iter as VectorIter;
 use std::sync::Arc;
 
 use bls::{AggregateSignatureBytes, PublicKeyBytes, SignatureBytes};
 use duplicate::duplicate_item;
+#[cfg(not(target_os = "zkvm"))]
 use im::vector::Iter as VectorIter;
 use ssz::{
     BitVector, ContiguousList, Hc, IndexError, ProgressiveList, PushError, SszBitList, SszHash,


### PR DESCRIPTION
Fixes multiple issues appearing in develop, that break CI build:
  - gloas containers (like transaction) weren't handled properly in C bindings;
  - zkvm builds were failing, due to imports from `im` crate weren't gated by target;
  - EngineNewPayloadV5 implementation in C# plugin used wrong function, for converting versioned hashes param.