### PR TITLE
Prepare next slot execution payload again after PTC votes

### DIFF
--- a/fork_choice_control/src/mutator.rs
+++ b/fork_choice_control/src/mutator.rs
@@ -659,7 +659,11 @@ where
             }
         }
 
-        if tick.kind == TickKind::AggregateFourth {
+        // `TickKind::PayloadAttestFourth` is the last tick before the next slot in post-Gloas
+        if matches!(
+            tick.kind,
+            TickKind::AggregateFourth | TickKind::PayloadAttestFourth
+        ) {
             let store = &self.store;
 
             if let Some(state) = self.state_cache.existing_state_at_slot(
@@ -669,7 +673,9 @@ where
             ) {
                 self.prepare_execution_payload_for_next_slot(&state);
             }
+        }
 
+        if tick.kind == TickKind::AggregateFourth {
             self.track_collection_metrics();
         }
 


### PR DESCRIPTION
At proposing slot, Grandine only call FCU to EL to prepare payload at `AggregateFourth`, which is the last tick in pre-Gloas. But for post-Gloas, the tick is just a tick before PTC votes, so EL won't know whether the payload reveal in time or not. This fix is to prepare the payload again at `PayloadAttestFourth`, at that point beacon node has received PTC votes from the committee, which allow it to allow it to build on correct branch based the votes.