### PR TITLE
Raise limits for progressive containers

### DIFF
--- a/ssz/src/persistent_progressive_list.rs
+++ b/ssz/src/persistent_progressive_list.rs
@@ -30,7 +30,7 @@ use crate::{
     shared,
 };
 
-type PrettyBigU = typenum::U1048576;
+type PrettyBigU = typenum::U4294967296;
 
 // Unlike `PersistentList`, this does not support bundle sizes other than the minimum.
 // EIP-7916 partitions the chunk sequence at absolute positions (1, 4, 16, ... chunks),

--- a/ssz/src/progressive_list.rs
+++ b/ssz/src/progressive_list.rs
@@ -12,7 +12,7 @@ use crate::{
     merkle_tree::{self, ProgressiveMerkleTree},
 };
 
-type PrettyBigU = typenum::U1048576;
+type PrettyBigU = typenum::U4294967296;
 
 // TODO(gloas): in spec, ProgressiveList is unbounded container, and its limits
 // are enforced in user-site. This would require careful refactoring, so for


### PR DESCRIPTION
Progressive lists are unlimited by design, but our implementation currently caps their sizes. Increased `PrettyBigU` to `4294967296`, what should be enough to index smallest possible item (u8) in ssz container, size of which is capped to 4 gigabytes.