### PR TITLE
Add builder blacklisting

### DIFF
--- a/block_producer/src/block_producer.rs
+++ b/block_producer/src/block_producer.rs
@@ -2296,8 +2296,41 @@ impl<P: Preset, W: Wait> BlockBuildContext<P, W> {
             state.latest_execution_payload_bid().parent_block_hash
         };
 
+        let withholding_builder = snapshot.builder_withholding_parent_payload(state.slot());
+
         let bid = snapshot
             .selectable_payload_bids(state.slot(), parent_block_hash, self.head_block_root)
+            .filter(|bid| {
+                let builder_index = bid.message.builder_index;
+
+                // With no local payload there is nothing to fall back to, so even a bid that may
+                // never be revealed beats missing the slot.
+                if !local_payload_available {
+                    return true;
+                }
+
+                if snapshot.is_builder_blacklisted(builder_index) {
+                    debug_with_peers!(
+                        "not selecting bid of {} Gwei from blacklisted builder {builder_index}",
+                        bid.message.value,
+                    );
+
+                    return false;
+                }
+
+                // the builder withheld payload in previous slot, so their bids should not be considered in this slot as well
+                if withholding_builder == Some(builder_index) {
+                    debug_with_peers!(
+                        "not selecting bid of {} Gwei from builder {builder_index} that did not \
+                         deliver the parent payload",
+                        bid.message.value,
+                    );
+
+                    return false;
+                }
+
+                true
+            })
             .max_by_key(|bid| bid.message.value)?;
 
         // The bid value is what the builder pays the proposer for the slot, so it is comparable to

--- a/fork_choice_control/src/queries.rs
+++ b/fork_choice_control/src/queries.rs
@@ -1506,6 +1506,16 @@ impl<P: Preset> Snapshot<'_, P> {
     pub fn builder_circuit_breaker_tripped(&self) -> bool {
         self.store_snapshot.builder_circuit_breaker_tripped()
     }
+
+    #[must_use]
+    pub fn is_builder_blacklisted(&self, builder_index: BuilderIndex) -> bool {
+        self.store_snapshot.is_builder_blacklisted(builder_index)
+    }
+
+    #[must_use]
+    pub fn builder_withholding_parent_payload(&self, slot: Slot) -> Option<BuilderIndex> {
+        self.store_snapshot.builder_withholding_parent_payload(slot)
+    }
 }
 
 #[derive(Debug, Error)]

--- a/fork_choice_store/src/builder_circuit_breaker.rs
+++ b/fork_choice_store/src/builder_circuit_breaker.rs
@@ -7,15 +7,23 @@
 
 use arithmetic::NonZeroExt as _;
 use derivative::Derivative;
+use im::hashmap::HashMap;
+use logging::{debug_with_peers, warn_with_peers};
 use typenum::Unsigned as _;
 use types::{
+    gloas::primitives::BuilderIndex,
     nonstandard::{DEFAULT_BUILDER_MAX_SKIPPED_SLOTS, DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH},
-    phase0::primitives::{Epoch, Slot},
+    phase0::primitives::{Epoch, H256, Slot},
     preset::Preset,
 };
 
 /// Epochs the node builds payloads locally for after the circuit breaker trips.
 const TRIP_PERIOD: Epoch = 1;
+
+/// Epochs a builder stays blacklisted for its first withheld payload, increase by one with
+/// every further withheld payload up to `max_blacklist_period`.
+const BLACKLIST_PERIOD: Epoch = 1;
+pub const DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD: Epoch = 8;
 
 /// Percentage of a slot's committee that must have attested a block before an untimely payload is
 /// blamed on its builder.
@@ -24,20 +32,40 @@ pub const ATTESTED_PERCENT: u64 = 60;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Derivative)]
 #[derivative(Default)]
 pub struct BuilderCircuitBreakerConfig {
-    pub disabled: bool,
-    /// Consecutive canonical blocks with withheld payloads tolerated before the node self-builds.
+    /// Whether the global tier is disabled. Independent of the per-builder tier.
+    pub global_disabled: bool,
+    /// Whether bids from blacklisted builders are skipped. Independent of the global tier.
+    pub blacklisting_enabled: bool,
     #[derivative(Default(value = "DEFAULT_BUILDER_MAX_SKIPPED_SLOTS"))]
     pub max_skipped_slots: u64,
-    /// Withheld payloads tolerated in the last rolling epoch before the node self-builds.
     #[derivative(Default(value = "DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH"))]
     pub max_skipped_slots_per_epoch: u64,
+    #[derivative(Default(value = "DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD"))]
+    pub max_blacklist_period: Epoch,
 }
 
-/// Watches the canonical chain for withheld payloads and, if they are frequent enough, has the node
-/// fall back to self-building until the builder ecosystem recovers.
+impl BuilderCircuitBreakerConfig {
+    fn blacklist_period_for(self, withheld_payloads: u8) -> Epoch {
+        BLACKLIST_PERIOD
+            .saturating_mul(withheld_payloads.into())
+            .min(self.max_blacklist_period)
+    }
+
+    fn max_withheld_payloads(self) -> u8 {
+        u8::try_from(self.max_blacklist_period.div_ceil(BLACKLIST_PERIOD)).unwrap_or(u8::MAX)
+    }
+}
+
+/// There are two independent tiers of circuit breaking:
+///
+/// - Per-builder: a builder that withholds payloads is blacklisted for a period of time, and its
+///   bids are not selected while it is.
+/// - Global: if payloads are withheld often enough on the canonical chain, no bid is selected at
+///   all and the node self-builds until the builder ecosystem recovers.
 #[derive(Clone, Debug)]
 pub struct BuilderCircuitBreaker {
     config: BuilderCircuitBreakerConfig,
+    blacklisted_builders: HashMap<BuilderIndex, BlacklistedBuilder>,
     evaluated_slot: Slot,
     consecutive_withheld: Slot,
     consecutive_delivered: Slot,
@@ -48,9 +76,10 @@ pub struct BuilderCircuitBreaker {
 
 impl BuilderCircuitBreaker {
     #[must_use]
-    pub const fn new(config: BuilderCircuitBreakerConfig, anchor_slot: Slot) -> Self {
+    pub fn new(config: BuilderCircuitBreakerConfig, anchor_slot: Slot) -> Self {
         Self {
             config,
+            blacklisted_builders: HashMap::new(),
             evaluated_slot: anchor_slot,
             consecutive_withheld: 0,
             consecutive_delivered: 0,
@@ -82,21 +111,105 @@ impl BuilderCircuitBreaker {
     }
 
     #[must_use]
-    pub const fn is_tripped(&self, current_slot: Slot) -> bool {
-        !self.config.disabled && current_slot < self.tripped_until
+    pub fn is_empty(&self) -> bool {
+        self.blacklisted_builders.is_empty()
     }
 
-    /// Judges the canonical block of `slot`.
-    ///
-    /// Returns the threshold this outcome crossed if it tripped the circuit breaker, [`None`]
-    /// otherwise. Slots must be reported in ascending order.
+    #[must_use]
+    pub fn is_builder_blacklisted(&self, current_slot: Slot, builder_index: BuilderIndex) -> bool {
+        self.config.blacklisting_enabled
+            && self
+                .blacklisted_builders
+                .get(&builder_index)
+                .is_some_and(|blacklisted_builder| {
+                    blacklisted_builder.is_blacklisted_at(current_slot)
+                })
+    }
+
+    #[must_use]
+    pub const fn is_tripped(&self, current_slot: Slot) -> bool {
+        !self.config.global_disabled && current_slot < self.tripped_until
+    }
+
+    pub fn expire_blacklists(&mut self, current_slot: Slot) {
+        self.blacklisted_builders
+            .retain(|&builder_index, blacklisted_builder| {
+                let blacklisted = blacklisted_builder.is_blacklisted_at(current_slot);
+
+                if !blacklisted {
+                    debug_with_peers!(
+                        "builder {builder_index} served its blacklist and is now whitelisted again"
+                    );
+                }
+
+                blacklisted
+            });
+    }
+
+    pub fn record_withheld_payload<P: Preset>(
+        &mut self,
+        current_slot: Slot,
+        builder_index: BuilderIndex,
+        block_root: H256,
+        block_slot: Slot,
+    ) {
+        let config = self.config;
+
+        let blacklisted_builder = self.blacklisted_builders.entry(builder_index).or_default();
+
+        blacklisted_builder.record_withheld_payload::<P>(current_slot, config);
+
+        let withheld_payloads = blacklisted_builder.withheld_payloads;
+        let blacklisted_until = blacklisted_builder.blacklisted_until;
+
+        debug_with_peers!(
+            "builder {builder_index} did not reveal the payload in time for block {block_root:?} \
+             at slot {block_slot} ({withheld_payloads} withheld payloads in a row), \
+             blacklisting it until slot {blacklisted_until}"
+        );
+    }
+
+    pub fn record_delivered_payload(
+        &mut self,
+        builder_index: BuilderIndex,
+        block_root: H256,
+        block_slot: Slot,
+    ) {
+        let Some(blacklisted_builder) = self.blacklisted_builders.get_mut(&builder_index) else {
+            return;
+        };
+
+        blacklisted_builder.record_delivered_payload();
+
+        let withheld_payloads = blacklisted_builder.withheld_payloads;
+        let blacklisted_until = blacklisted_builder.blacklisted_until;
+
+        if withheld_payloads == 0 {
+            self.blacklisted_builders.remove(&builder_index);
+
+            debug_with_peers!(
+                "builder {builder_index} delivered the payload of block {block_root:?} at slot \
+                 {block_slot} and is now whitelisted again"
+            );
+
+            return;
+        }
+
+        debug_with_peers!(
+            "builder {builder_index} delivered the payload of block {block_root:?} at slot \
+             {block_slot} (still {withheld_payloads} withheld payloads left to clear), blacklisted \
+             until slot {blacklisted_until}"
+        );
+    }
+
+    /// Judges the canonical block of `canonical_slot`.
     pub fn record_canonical_outcome<P: Preset>(
         &mut self,
-        slot: Slot,
-        outcome: PayloadOutcome,
         current_slot: Slot,
-    ) -> Option<Trip> {
-        let slot_bit = 1 << (slot % P::SlotsPerEpoch::non_zero());
+        canonical_slot: Slot,
+        outcome: PayloadOutcome,
+    ) {
+        let slot_bit = 1 << (canonical_slot % P::SlotsPerEpoch::non_zero());
 
         match outcome {
             PayloadOutcome::Delivered => {
@@ -118,16 +231,24 @@ impl BuilderCircuitBreaker {
             self.tripped_until = 0;
         }
 
-        let withheld_in_epoch = self.withheld_slots.count_ones().into();
+        let withheld_in_epoch = Slot::from(self.withheld_slots.count_ones());
 
         // Both thresholds are inclusive, like the pre-Gloas circuit breaker they are shared with.
-        let trip = if self.consecutive_withheld > self.config.max_skipped_slots {
-            Trip::ConsecutiveWithheld(self.consecutive_withheld)
+        if self.consecutive_withheld > self.config.max_skipped_slots {
+            let consecutive_withheld = self.consecutive_withheld;
+
+            warn_with_peers!(
+                "builders withheld {consecutive_withheld} payloads in a row, \
+                 building payloads locally"
+            );
         } else if withheld_in_epoch > self.config.max_skipped_slots_per_epoch {
-            Trip::WithheldInEpoch(withheld_in_epoch)
+            warn_with_peers!(
+                "builders withheld {withheld_in_epoch} payloads in the last epoch, \
+                 building payloads locally"
+            );
         } else {
-            return None;
-        };
+            return;
+        }
 
         // The trip lasts one trip period, after which it re-arms. The expiry is what clears it when
         // recovery cannot be observed: this node's own slots are no evidence about builders while it
@@ -140,8 +261,15 @@ impl BuilderCircuitBreaker {
         // every slot until it ages out of the window.
         self.consecutive_withheld = 0;
         self.withheld_slots = 0;
+    }
 
-        Some(trip)
+    /// Forgets builders that are no longer in the builder registry.
+    ///
+    /// Gloas reuses the indices of exited builders, so without this a long blacklist would punish
+    /// whichever builder inherits the index.
+    pub fn retain_active_builders(&mut self, is_active: impl Fn(BuilderIndex) -> bool) {
+        self.blacklisted_builders
+            .retain(|&builder_index, _| is_active(builder_index));
     }
 }
 
@@ -154,44 +282,250 @@ pub enum PayloadOutcome {
     Unknown,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Trip {
-    ConsecutiveWithheld(Slot),
-    WithheldInEpoch(Slot),
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct BlacklistedBuilder {
+    withheld_payloads: u8,
+    blacklisted_until: Slot,
+}
+
+impl BlacklistedBuilder {
+    const fn is_blacklisted_at(self, current_slot: Slot) -> bool {
+        current_slot < self.blacklisted_until
+    }
+
+    const fn record_delivered_payload(&mut self) {
+        self.withheld_payloads = self.withheld_payloads.saturating_sub(1);
+    }
+
+    fn record_withheld_payload<P: Preset>(
+        &mut self,
+        current_slot: Slot,
+        config: BuilderCircuitBreakerConfig,
+    ) {
+        self.withheld_payloads = self
+            .withheld_payloads
+            .saturating_add(1)
+            .min(config.max_withheld_payloads());
+
+        self.blacklisted_until = self.blacklisted_until.max(
+            current_slot.saturating_add(
+                config
+                    .blacklist_period_for(self.withheld_payloads)
+                    .saturating_mul(P::SlotsPerEpoch::U64),
+            ),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools as _;
     use types::preset::Mainnet;
 
     use super::*;
 
     const SLOTS_PER_EPOCH: u64 = <Mainnet as Preset>::SlotsPerEpoch::U64;
     const CURRENT_SLOT: Slot = 10 * SLOTS_PER_EPOCH + 7;
+    const BUILDER_INDEX: BuilderIndex = 3;
+
+    fn withhold_payload(breaker: &mut BuilderCircuitBreaker, current_slot: Slot) {
+        breaker.record_withheld_payload::<Mainnet>(
+            current_slot,
+            BUILDER_INDEX,
+            H256::zero(),
+            current_slot,
+        );
+    }
+
+    fn deliver_payload(breaker: &mut BuilderCircuitBreaker, block_slot: Slot) {
+        breaker.record_delivered_payload(BUILDER_INDEX, H256::zero(), block_slot);
+    }
+
+    /// Pins the blacklist expiry, which is the only way the withheld payload count is observable.
+    fn assert_blacklisted_until(breaker: &BuilderCircuitBreaker, expiry: Slot) {
+        assert!(breaker.is_builder_blacklisted(expiry.saturating_sub(1), BUILDER_INDEX));
+        assert!(!breaker.is_builder_blacklisted(expiry, BUILDER_INDEX));
+    }
 
     fn new_breaker() -> BuilderCircuitBreaker {
-        BuilderCircuitBreaker::new(BuilderCircuitBreakerConfig::default(), 0)
+        BuilderCircuitBreaker::new(
+            BuilderCircuitBreakerConfig {
+                blacklisting_enabled: true,
+                ..BuilderCircuitBreakerConfig::default()
+            },
+            0,
+        )
     }
 
     #[test]
-    fn disabled_circuit_breaker_never_trips() {
+    fn blacklist_period_grows_with_every_withheld_payload() {
+        let config = BuilderCircuitBreakerConfig::default();
+
+        // 1, 2, 3, 4, ... epochs, capped at `DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD`.
+        assert_eq!(config.blacklist_period_for(1), 1);
+        assert_eq!(config.blacklist_period_for(2), 2);
+        assert_eq!(config.blacklist_period_for(3), 3);
+        assert_eq!(
+            config.blacklist_period_for(8),
+            DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD,
+        );
+        assert_eq!(
+            config.blacklist_period_for(u8::MAX),
+            DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD,
+        );
+    }
+
+    #[test]
+    fn blacklist_outlives_the_epoch_it_was_recorded_in() {
+        let mut breaker = new_breaker();
+        let last_slot_of_epoch = 11 * SLOTS_PER_EPOCH - 1;
+
+        withhold_payload(&mut breaker, last_slot_of_epoch);
+
+        let expiry = last_slot_of_epoch + BLACKLIST_PERIOD * SLOTS_PER_EPOCH;
+
+        // The next epoch starts one slot later and must not lift the blacklist with it.
+        assert!(breaker.is_builder_blacklisted(last_slot_of_epoch + 1, BUILDER_INDEX));
+        assert!(breaker.is_builder_blacklisted(expiry - 1, BUILDER_INDEX));
+        assert!(!breaker.is_builder_blacklisted(expiry, BUILDER_INDEX));
+    }
+
+    #[test]
+    fn repaid_withheld_payloads_lift_a_blacklist_early() {
+        let mut breaker = new_breaker();
+
+        withhold_payload(&mut breaker, CURRENT_SLOT);
+
+        // The builder delivered as many payloads as it withheld, so the rest of the period is
+        // not served.
+        deliver_payload(&mut breaker, CURRENT_SLOT);
+
+        assert!(!breaker.is_builder_blacklisted(CURRENT_SLOT, BUILDER_INDEX));
+        assert!(breaker.is_empty());
+    }
+
+    #[test]
+    fn served_blacklists_are_lifted_with_payloads_still_owed() {
+        let mut breaker = new_breaker();
+
+        for _ in 0..3 {
+            withhold_payload(&mut breaker, CURRENT_SLOT);
+        }
+
+        let expiry = CURRENT_SLOT + 3 * SLOTS_PER_EPOCH;
+
+        breaker.expire_blacklists(expiry - 1);
+
+        assert!(!breaker.is_empty());
+
+        // Two payloads are still owed, but the period has been served.
+        breaker.expire_blacklists(expiry);
+
+        assert!(breaker.is_empty());
+
+        // The escalation starts over rather than resuming where it left off, so the next withheld
+        // payload is worth a single epoch again.
+        withhold_payload(&mut breaker, expiry);
+
+        assert_blacklisted_until(&breaker, expiry + BLACKLIST_PERIOD * SLOTS_PER_EPOCH);
+    }
+
+    #[test]
+    fn withholding_while_blacklisted_still_escalates() {
+        let mut breaker = new_breaker();
+
+        withhold_payload(&mut breaker, CURRENT_SLOT);
+
+        let expiry = CURRENT_SLOT + BLACKLIST_PERIOD * SLOTS_PER_EPOCH;
+
+        // Blacklisted builders are only skipped by this node, so other nodes can still hand them
+        // an auction to withhold, and that is what the escalation is for.
+        breaker.expire_blacklists(expiry - 1);
+        withhold_payload(&mut breaker, expiry - 1);
+
+        assert_blacklisted_until(
+            &breaker,
+            expiry - 1 + 2 * BLACKLIST_PERIOD * SLOTS_PER_EPOCH,
+        );
+    }
+
+    #[test]
+    fn delivered_payload_forgives_a_single_withheld_one() {
+        let mut breaker = new_breaker();
+
+        for _ in 0..3 {
+            withhold_payload(&mut breaker, CURRENT_SLOT);
+        }
+
+        deliver_payload(&mut breaker, CURRENT_SLOT);
+
+        assert_blacklisted_until(&breaker, CURRENT_SLOT + 3 * SLOTS_PER_EPOCH);
+
+        // Only one of the three withheld payloads was forgiven, so the escalation resumes where it
+        // left off: the next one is worth three epochs again, not one.
+        withhold_payload(&mut breaker, CURRENT_SLOT + 1);
+
+        assert_blacklisted_until(&breaker, CURRENT_SLOT + 1 + 3 * SLOTS_PER_EPOCH);
+    }
+
+    #[test]
+    fn max_withheld_payloads_covers_blacklist_periods() {
+        let config_with = |max_blacklist_period| BuilderCircuitBreakerConfig {
+            max_blacklist_period,
+            ..BuilderCircuitBreakerConfig::default()
+        };
+
+        // A blacklist period of zero never blacklists anyone, so nothing is worth counting.
+        assert_eq!(config_with(0).max_withheld_payloads(), 0);
+
+        // `builder_max_blacklist_period` is bounded to what the counter can express.
+        for max_blacklist_period in [0, 1, 2, 3, 8, 127, 128, 129, u8::MAX.into()] {
+            let config = config_with(max_blacklist_period);
+            let max_withheld_payloads = config.max_withheld_payloads();
+
+            assert_eq!(
+                config.blacklist_period_for(max_withheld_payloads),
+                max_blacklist_period,
+            );
+
+            for withheld_payloads in 1..max_withheld_payloads {
+                assert!(config.blacklist_period_for(withheld_payloads) < max_blacklist_period);
+            }
+        }
+    }
+
+    #[test]
+    fn exited_builders_are_forgotten() {
+        let mut breaker = new_breaker();
+
+        withhold_payload(&mut breaker, CURRENT_SLOT);
+        breaker.retain_active_builders(|builder_index| builder_index != BUILDER_INDEX);
+
+        assert!(breaker.is_empty());
+        assert!(!breaker.is_builder_blacklisted(CURRENT_SLOT, BUILDER_INDEX));
+    }
+
+    #[test]
+    fn disabled_global_tier_never_trips_but_still_blacklists() {
         let mut breaker = BuilderCircuitBreaker::new(
             BuilderCircuitBreakerConfig {
-                disabled: true,
+                global_disabled: true,
+                blacklisting_enabled: true,
                 ..BuilderCircuitBreakerConfig::default()
             },
             0,
         );
 
+        withhold_payload(&mut breaker, CURRENT_SLOT);
+
         for slot in 0..SLOTS_PER_EPOCH {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
         }
 
+        assert!(breaker.is_builder_blacklisted(CURRENT_SLOT, BUILDER_INDEX));
         assert!(!breaker.is_tripped(CURRENT_SLOT));
     }
 
@@ -201,24 +535,19 @@ mod tests {
         let config = breaker.config();
 
         for slot in 0..config.max_skipped_slots {
-            assert_eq!(
-                breaker.record_canonical_outcome::<Mainnet>(
-                    slot,
-                    PayloadOutcome::Withheld,
-                    CURRENT_SLOT
-                ),
-                None,
+            breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
+                slot,
+                PayloadOutcome::Withheld,
             );
+
             assert!(!breaker.is_tripped(CURRENT_SLOT));
         }
 
-        assert_eq!(
-            breaker.record_canonical_outcome::<Mainnet>(
-                config.max_skipped_slots,
-                PayloadOutcome::Withheld,
-                CURRENT_SLOT,
-            ),
-            Some(Trip::ConsecutiveWithheld(config.max_skipped_slots + 1)),
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
+            config.max_skipped_slots,
+            PayloadOutcome::Withheld,
         );
 
         assert!(breaker.is_tripped(CURRENT_SLOT));
@@ -231,47 +560,51 @@ mod tests {
         let config = breaker.config();
 
         // Alternating slots never accumulate consecutive failures.
-        let trips = (0..=(2 * config.max_skipped_slots_per_epoch))
-            .filter_map(|slot| {
-                let outcome = if slot.is_multiple_of(2) {
-                    PayloadOutcome::Withheld
-                } else {
-                    PayloadOutcome::Delivered
-                };
+        for slot in 0..(2 * config.max_skipped_slots_per_epoch) {
+            let outcome = if slot.is_multiple_of(2) {
+                PayloadOutcome::Withheld
+            } else {
+                PayloadOutcome::Delivered
+            };
 
-                breaker.record_canonical_outcome::<Mainnet>(slot, outcome, CURRENT_SLOT)
-            })
-            .collect_vec();
+            breaker.record_canonical_outcome::<Mainnet>(CURRENT_SLOT, slot, outcome);
 
-        assert_eq!(
-            trips,
-            [Trip::WithheldInEpoch(
-                config.max_skipped_slots_per_epoch + 1
-            )],
+            assert!(!breaker.is_tripped(CURRENT_SLOT));
+        }
+
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
+            2 * config.max_skipped_slots_per_epoch,
+            PayloadOutcome::Withheld,
         );
+
         assert!(breaker.is_tripped(CURRENT_SLOT));
 
         // The window is cleared on the trip, so the payloads that tripped it cannot trip it again.
-        assert_eq!(
-            breaker.record_canonical_outcome::<Mainnet>(
-                2 * config.max_skipped_slots_per_epoch + 1,
-                PayloadOutcome::Delivered,
-                CURRENT_SLOT,
-            ),
-            None,
+        // A later slot is judged, or a second trip would expire at the same slot as the first.
+        let later_slot = CURRENT_SLOT + TRIP_PERIOD * SLOTS_PER_EPOCH;
+
+        breaker.record_canonical_outcome::<Mainnet>(
+            later_slot,
+            2 * config.max_skipped_slots_per_epoch + 1,
+            PayloadOutcome::Withheld,
         );
+
+        assert!(!breaker.is_tripped(later_slot));
     }
 
     #[test]
-    fn skipped_slots_discard_evidence() {
+    fn skipped_slots_discard_global_evidence() {
         let mut breaker = new_breaker();
         let config = breaker.config();
 
+        withhold_payload(&mut breaker, CURRENT_SLOT);
+
         for slot in 0..config.max_skipped_slots {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
         }
 
@@ -280,14 +613,16 @@ mod tests {
         assert_eq!(breaker.evaluated_slot(), CURRENT_SLOT);
 
         // A run cannot continue across the gap.
-        assert_eq!(
-            breaker.record_canonical_outcome::<Mainnet>(
-                CURRENT_SLOT,
-                PayloadOutcome::Withheld,
-                CURRENT_SLOT,
-            ),
-            None,
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
+            CURRENT_SLOT,
+            PayloadOutcome::Withheld,
         );
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT));
+
+        // Per-builder evidence is not observed through the canonical chain and survives the gap.
+        assert!(breaker.is_builder_blacklisted(CURRENT_SLOT, BUILDER_INDEX));
     }
 
     #[test]
@@ -297,32 +632,29 @@ mod tests {
 
         for slot in 0..config.max_skipped_slots {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
         }
 
         breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
             config.max_skipped_slots,
             PayloadOutcome::Delivered,
-            CURRENT_SLOT,
         );
 
         for slot in 0..config.max_skipped_slots {
             let slot = slot + config.max_skipped_slots + 1;
 
-            assert_eq!(
-                breaker.record_canonical_outcome::<Mainnet>(
-                    slot,
-                    PayloadOutcome::Withheld,
-                    CURRENT_SLOT
-                ),
-                None,
+            breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
+                slot,
+                PayloadOutcome::Withheld,
             );
-        }
 
-        assert!(!breaker.is_tripped(CURRENT_SLOT));
+            assert!(!breaker.is_tripped(CURRENT_SLOT));
+        }
     }
 
     #[test]
@@ -332,9 +664,9 @@ mod tests {
 
         for slot in 0..=config.max_skipped_slots {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
         }
 
@@ -345,18 +677,18 @@ mod tests {
             let slot = slot + config.max_skipped_slots + 1;
 
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Delivered,
-                CURRENT_SLOT,
             );
 
             assert!(breaker.is_tripped(CURRENT_SLOT));
         }
 
         breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
             2 * config.max_skipped_slots + 1,
             PayloadOutcome::Delivered,
-            CURRENT_SLOT,
         );
 
         assert!(!breaker.is_tripped(CURRENT_SLOT));
@@ -369,9 +701,9 @@ mod tests {
 
         for slot in 0..=config.max_skipped_slots {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
         }
 
@@ -387,7 +719,7 @@ mod tests {
                 PayloadOutcome::Delivered
             };
 
-            breaker.record_canonical_outcome::<Mainnet>(slot, outcome, CURRENT_SLOT);
+            breaker.record_canonical_outcome::<Mainnet>(CURRENT_SLOT, slot, outcome);
 
             assert!(breaker.is_tripped(CURRENT_SLOT));
         }
@@ -400,28 +732,60 @@ mod tests {
 
         for slot in 0..config.max_skipped_slots {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 2 * slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 2 * slot + 1,
                 PayloadOutcome::Unknown,
-                CURRENT_SLOT,
             );
         }
 
         assert!(!breaker.is_tripped(CURRENT_SLOT));
 
         // Self-built and skipped slots do not mask a builder-wide failure.
-        assert_eq!(
-            breaker.record_canonical_outcome::<Mainnet>(
-                2 * config.max_skipped_slots,
-                PayloadOutcome::Withheld,
-                CURRENT_SLOT,
-            ),
-            Some(Trip::ConsecutiveWithheld(config.max_skipped_slots + 1)),
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
+            2 * config.max_skipped_slots,
+            PayloadOutcome::Withheld,
         );
+
+        assert!(breaker.is_tripped(CURRENT_SLOT));
+    }
+
+    #[test]
+    fn unknown_outcomes_age_out_of_the_rolling_epoch() {
+        let mut breaker = new_breaker();
+        let config = breaker.config();
+
+        // Alternating slots fill the window right up to the threshold.
+        for slot in 0..(2 * config.max_skipped_slots_per_epoch) {
+            let outcome = if slot.is_multiple_of(2) {
+                PayloadOutcome::Withheld
+            } else {
+                PayloadOutcome::Delivered
+            };
+
+            breaker.record_canonical_outcome::<Mainnet>(CURRENT_SLOT, slot, outcome);
+        }
+
+        // Slot 0 comes around again as a slot nobody can be blamed for, freeing its place in the
+        // window for the next withheld payload.
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
+            SLOTS_PER_EPOCH,
+            PayloadOutcome::Unknown,
+        );
+
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT,
+            SLOTS_PER_EPOCH + 1,
+            PayloadOutcome::Withheld,
+        );
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT));
     }
 
     #[test]
@@ -430,9 +794,9 @@ mod tests {
 
         for slot in 0..SLOTS_PER_EPOCH {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT,
                 slot,
                 PayloadOutcome::Withheld,
-                CURRENT_SLOT,
             );
         }
 
@@ -441,19 +805,18 @@ mod tests {
         // A full epoch of delivered payloads clears the window.
         for slot in SLOTS_PER_EPOCH..(2 * SLOTS_PER_EPOCH) {
             breaker.record_canonical_outcome::<Mainnet>(
+                CURRENT_SLOT + 1,
                 slot,
                 PayloadOutcome::Delivered,
-                CURRENT_SLOT + 1,
             );
         }
 
-        assert_eq!(
-            breaker.record_canonical_outcome::<Mainnet>(
-                2 * SLOTS_PER_EPOCH,
-                PayloadOutcome::Withheld,
-                CURRENT_SLOT + 1,
-            ),
-            None,
+        breaker.record_canonical_outcome::<Mainnet>(
+            CURRENT_SLOT + 1,
+            2 * SLOTS_PER_EPOCH,
+            PayloadOutcome::Withheld,
         );
+
+        assert!(!breaker.is_tripped(CURRENT_SLOT + 1));
     }
 }

--- a/fork_choice_store/src/lib.rs
+++ b/fork_choice_store/src/lib.rs
@@ -76,7 +76,9 @@
 //! [`proto_array`]:            https://github.com/protolambda/lmd-ghost/tree/242f0dced3b34feed0d4e9d2fd0e5e66e448c359#array-based-stateful-dag-proto_array
 
 pub use crate::{
-    builder_circuit_breaker::{BuilderCircuitBreaker, BuilderCircuitBreakerConfig},
+    builder_circuit_breaker::{
+        BuilderCircuitBreaker, BuilderCircuitBreakerConfig, DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD,
+    },
     error::Error,
     misc::{
         AggregateAndProofAction, AggregateAndProofOrigin, ApplyBlockChanges, ApplyTickChanges,

--- a/fork_choice_store/src/store.rs
+++ b/fork_choice_store/src/store.rs
@@ -87,7 +87,7 @@ use unwrap_none::UnwrapNone as _;
 use crate::{
     BlockItem, PayloadAttestationOrigin,
     blob_cache::BlobCache,
-    builder_circuit_breaker::{ATTESTED_PERCENT, BuilderCircuitBreaker, PayloadOutcome, Trip},
+    builder_circuit_breaker::{ATTESTED_PERCENT, BuilderCircuitBreaker, PayloadOutcome},
     data_column_cache::DataColumnCache,
     error::Error,
     execution_payload_envelope_cache::ExecutionPayloadEnvelopeCache,
@@ -504,6 +504,33 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
     #[must_use]
     pub const fn builder_circuit_breaker_tripped(&self) -> bool {
         self.builder_circuit_breaker.is_tripped(self.slot())
+    }
+
+    #[must_use]
+    pub fn is_builder_blacklisted(&self, builder_index: BuilderIndex) -> bool {
+        self.builder_circuit_breaker
+            .is_builder_blacklisted(self.slot(), builder_index)
+    }
+
+    #[must_use]
+    pub fn builder_withholding_parent_payload(&self, slot: Slot) -> Option<BuilderIndex> {
+        if !self.builder_circuit_breaker.config().blacklisting_enabled
+            || self.should_build_on_full(slot)
+        {
+            return None;
+        }
+
+        let head = self.head();
+
+        // Older heads were judged by the circuit breaker `is_builder_blacklisted`.
+        if head.slot().saturating_add(1) != slot {
+            return None;
+        }
+
+        head.block
+            .message()
+            .payload_bid()
+            .map(|payload_bid| payload_bid.builder_index)
     }
 
     #[must_use]
@@ -1429,7 +1456,9 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         let config = self.builder_circuit_breaker.config();
 
-        if config.disabled || self.chain_config.phase_at_slot::<P>(current_slot) < Phase::Gloas {
+        if (config.global_disabled && !config.blacklisting_enabled)
+            || self.chain_config.phase_at_slot::<P>(current_slot) < Phase::Gloas
+        {
             return;
         }
 
@@ -1438,11 +1467,12 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             return;
         }
 
-        // Payload delivery can be decided in the next slot after its block was proposed
-        let Some(last_slot) = current_slot.checked_sub(1) else {
-            return;
-        };
+        if config.blacklisting_enabled {
+            self.builder_circuit_breaker.expire_blacklists(current_slot);
+        }
 
+        // Payload delivery can be decided in the next slot after its block was proposed
+        let last_slot = current_slot.saturating_sub(1);
         let earliest_slot = last_slot.saturating_sub(P::SlotsPerEpoch::U64);
 
         if self.builder_circuit_breaker.evaluated_slot() < earliest_slot {
@@ -1455,58 +1485,99 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             .saturating_add(1);
 
         if first_slot <= last_slot {
-            self.evaluate_canonical_payloads_in(first_slot..=last_slot);
+            self.evaluate_builders_in(first_slot..=last_slot);
             self.builder_circuit_breaker.set_evaluated_slot(last_slot);
         }
-    }
 
-    /// Judges the canonical block of every slot in `slots`.
-    ///
-    /// A run of failures is only meaningful along a single chain, so blocks that lost the head race
-    /// are not counted.
-    fn evaluate_canonical_payloads_in(&mut self, slots: RangeInclusive<Slot>) {
-        let attested_threshold = self.calculate_committee_fraction(ATTESTED_PERCENT);
-        let current_slot = self.slot();
-
-        for slot in slots {
-            let outcome = self.canonical_payload_outcome(slot, attested_threshold);
-
-            match self.builder_circuit_breaker.record_canonical_outcome::<P>(
-                slot,
-                outcome,
-                current_slot,
-            ) {
-                Some(Trip::ConsecutiveWithheld(withheld_payloads)) => warn_with_peers!(
-                    "builders withheld {withheld_payloads} payloads in a row, \
-                     building payloads locally"
-                ),
-                Some(Trip::WithheldInEpoch(withheld_payloads)) => warn_with_peers!(
-                    "builders withheld {withheld_payloads} payloads in the last epoch, \
-                     building payloads locally"
-                ),
-                None => {}
-            }
+        if misc::is_epoch_start::<P>(current_slot) {
+            self.prune_builder_circuit_breaker();
         }
     }
 
-    /// Whether the builder that won the auction for the canonical block of `slot` revealed its
-    /// payload in time.
-    fn canonical_payload_outcome(&self, slot: Slot, attested_threshold: Gwei) -> PayloadOutcome {
-        let Some(unfinalized_block) = self
-            .unfinalized_block_before_or_at(slot)
-            .filter(|unfinalized_block| unfinalized_block.slot() == slot)
-        else {
-            return PayloadOutcome::Unknown;
-        };
+    /// Judges every block proposed in `slots`, including ones that are not canonical.
+    ///
+    /// A builder that withheld the payload of a well attested block is accountable for it even if
+    /// that block lost the head race. The global tier is fed the canonical blocks only, because a
+    /// run of failures is only meaningful along a single chain.
+    fn evaluate_builders_in(&mut self, slots: RangeInclusive<Slot>) {
+        let attested_threshold = self.calculate_committee_fraction(ATTESTED_PERCENT);
+        let current_slot = self.slot();
+        let config = self.builder_circuit_breaker.config();
 
+        let judgments = self
+            .unfinalized
+            .values()
+            .flat_map(IntoIterator::into_iter)
+            .filter(|unfinalized_block| {
+                unfinalized_block.non_invalid() && slots.contains(&unfinalized_block.slot())
+            })
+            .filter_map(|unfinalized_block| {
+                let (builder_index, outcome) =
+                    self.payload_outcome(unfinalized_block, attested_threshold)?;
+
+                Some((
+                    unfinalized_block.chain_link.block_root,
+                    unfinalized_block.slot(),
+                    builder_index,
+                    outcome,
+                ))
+            })
+            .sorted_unstable_by_key(|&(_, slot, ..)| slot)
+            .collect_vec();
+
+        if config.blacklisting_enabled {
+            for &(block_root, slot, builder_index, outcome) in &judgments {
+                match outcome {
+                    PayloadOutcome::Delivered => {
+                        self.builder_circuit_breaker.record_delivered_payload(
+                            builder_index,
+                            block_root,
+                            slot,
+                        );
+                    }
+                    PayloadOutcome::Withheld => {
+                        self.builder_circuit_breaker.record_withheld_payload::<P>(
+                            current_slot,
+                            builder_index,
+                            block_root,
+                            slot,
+                        );
+                    }
+                    PayloadOutcome::Unknown => {}
+                }
+            }
+        }
+
+        if config.global_disabled {
+            return;
+        }
+
+        for slot in slots {
+            let outcome = self
+                .unfinalized_block_before_or_at(slot)
+                .filter(|unfinalized_block| unfinalized_block.slot() == slot)
+                .and_then(|unfinalized_block| {
+                    judgments.iter().find(|&&(block_root, ..)| {
+                        block_root == unfinalized_block.chain_link.block_root
+                    })
+                })
+                .map_or(PayloadOutcome::Unknown, |&(.., outcome)| outcome);
+
+            self.builder_circuit_breaker
+                .record_canonical_outcome::<P>(current_slot, slot, outcome);
+        }
+    }
+
+    fn payload_outcome(
+        &self,
+        unfinalized_block: &UnfinalizedBlock<P>,
+        attested_threshold: Gwei,
+    ) -> Option<(BuilderIndex, PayloadOutcome)> {
         let chain_link = &unfinalized_block.chain_link;
+        let builder_index = chain_link.block.message().payload_bid()?.builder_index;
 
-        let Some(payload_bid) = chain_link.block.message().payload_bid() else {
-            return PayloadOutcome::Unknown;
-        };
-
-        if payload_bid.builder_index == BUILDER_INDEX_SELF_BUILD {
-            return PayloadOutcome::Unknown;
+        if builder_index == BUILDER_INDEX_SELF_BUILD {
+            return None;
         }
 
         // A PTC majority voting the payload timely stands in for this node's own view: the reveal
@@ -1514,15 +1585,38 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         if self.is_payload_present_timely(chain_link.block_root)
             || self.payload_timeliness(chain_link.block_root, true)
         {
-            return PayloadOutcome::Delivered;
+            return Some((builder_index, PayloadOutcome::Delivered));
         }
 
         // The network has attested the block, so we can blame the builder for not revealing it in time.
         if unfinalized_block.attesting_balances.pending >= attested_threshold {
-            return PayloadOutcome::Withheld;
+            return Some((builder_index, PayloadOutcome::Withheld));
         }
 
-        PayloadOutcome::Unknown
+        None
+    }
+
+    fn prune_builder_circuit_breaker(&mut self) {
+        if self.builder_circuit_breaker.is_empty() {
+            return;
+        }
+
+        let head = self.head();
+        let state = head.state(self);
+
+        let Some(state) = state.post_gloas() else {
+            return;
+        };
+
+        let finalized_epoch = state.finalized_checkpoint().epoch;
+
+        self.builder_circuit_breaker
+            .retain_active_builders(|builder_index| {
+                state
+                    .builders()
+                    .get(builder_index)
+                    .is_ok_and(|builder| predicates::is_active_builder(builder, finalized_epoch))
+            });
     }
 
     fn should_apply_proposer_boost(&self) -> bool {
@@ -2284,8 +2378,12 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
             }
 
             // > this bid is the highest value bid seen for the tuple (bid.slot, bid.parent_block_hash, bid.parent_block_root)
+            //
+            // Blacklisted builders are left out of the comparison, or their bids would suppress the
+            // bids this node is willing to select.
             if let Some(highest_bid) = self
                 .selectable_payload_bids(bid.slot, bid.parent_block_hash, bid.parent_block_root)
+                .filter(|b| !self.is_builder_blacklisted(b.message.builder_index))
                 .max_by_key(|b| b.message.value)
                 && bid.value <= highest_bid.message.value
             {
@@ -4271,6 +4369,12 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
         // > update store time
         self.tick = new_tick;
 
+        // The circuit breaker judges the blocks of earlier slots, so it is evaluated late in the
+        // slot, where the attestations and PTC votes it weight have had the most time to arrive.
+        if new_tick.kind == TickKind::AggregateFourth {
+            self.update_builder_circuit_breaker();
+        }
+
         if new_tick.slot <= old_tick.slot {
             // `new_tick` is a later tick in the same slot.
             return Ok(Some(ApplyTickChanges::TickUpdated));
@@ -4315,10 +4419,6 @@ impl<P: Preset, S: Storage<P>> Store<P, S> {
 
         self.apply_balance_differences(differences)?;
         self.update_head_segment_id();
-
-        // The circuit breaker compares attesting balances against the canonical chain, both of
-        // which are only up to date after `update_head_segment_id`.
-        self.update_builder_circuit_breaker();
 
         // Pruning the state cache requires the head slot, which depends on head_segment_id
         // pointing to the correct head. Therefore, prune state cache after the head_segment_id

--- a/runtime/src/grandine_args.rs
+++ b/runtime/src/grandine_args.rs
@@ -33,7 +33,8 @@ use eth2_libp2p::{
 use features::Feature;
 use fork_choice_control::{DEFAULT_ARCHIVAL_EPOCH_INTERVAL, DEFAULT_MAX_EVENTS};
 use fork_choice_store::{
-    BuilderCircuitBreakerConfig, DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS, StoreConfig,
+    BuilderCircuitBreakerConfig, DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD,
+    DEFAULT_CACHE_LOCK_TIMEOUT_MILLIS, StoreConfig,
 };
 use grandine_version::{APPLICATION_NAME, APPLICATION_VERSION};
 use helper_functions::misc;
@@ -902,6 +903,18 @@ struct ValidatorOptions {
     #[clap(long, default_value_t = DEFAULT_BUILDER_MAX_SKIPPED_SLOTS_PER_EPOCH)]
     builder_max_skipped_slots_per_epoch: u64,
 
+    /// Blacklisting builders that did not reveal a payload they won the auction
+    #[clap(long)]
+    builder_blacklisting_enabled: bool,
+
+    /// Number of epochs a builder can remain blacklisted for
+    #[clap(
+        long,
+        default_value_t = DEFAULT_BUILDER_MAX_BLACKLIST_PERIOD,
+        value_parser = clap::value_parser!(u64).range(1..=u64::from(u8::MAX)),
+    )]
+    builder_max_blacklist_period: Epoch,
+
     /// Percentage multiplier to apply to the builder's payload value when choosing between a builder payload header and payload from the paired execution node
     #[clap(long, default_value_t = ValidatorConfig::default().default_builder_boost_factor)]
     default_builder_boost_factor: Uint256,
@@ -1141,6 +1154,8 @@ impl GrandineArgs {
             builder_disable_checks,
             builder_max_skipped_slots,
             builder_max_skipped_slots_per_epoch,
+            builder_blacklisting_enabled,
+            builder_max_blacklist_period,
             default_builder_boost_factor,
             default_gas_limit,
             use_validator_key_cache,
@@ -1449,9 +1464,11 @@ impl GrandineArgs {
         });
 
         let builder_circuit_breaker = BuilderCircuitBreakerConfig {
-            disabled: builder_disable_checks,
+            global_disabled: builder_disable_checks,
+            blacklisting_enabled: builder_blacklisting_enabled,
             max_skipped_slots: builder_max_skipped_slots,
             max_skipped_slots_per_epoch: builder_max_skipped_slots_per_epoch,
+            max_blacklist_period: builder_max_blacklist_period,
         };
 
         let web3signer_urls = if web3signer_urls.is_empty() && !web3signer_api_urls.is_empty() {
@@ -2049,10 +2066,27 @@ mod tests {
     }
 
     #[test]
-    fn builder_disable_checks_disables_the_gloas_circuit_breaker() {
+    fn builder_disable_checks_disables_the_global_tier_only() {
         let config = config_from_args(["--builder-disable-checks"]);
 
-        assert!(config.builder_circuit_breaker.disabled);
+        assert!(config.builder_circuit_breaker.global_disabled);
+        assert!(!config.builder_circuit_breaker.blacklisting_enabled);
+    }
+
+    #[test]
+    fn builder_blacklisting_is_disabled_by_default() {
+        assert!(
+            !config_from_args([])
+                .builder_circuit_breaker
+                .blacklisting_enabled
+        );
+
+        // The two tiers are independent.
+        let config =
+            config_from_args(["--builder-blacklisting-enabled", "--builder-disable-checks"]);
+
+        assert!(config.builder_circuit_breaker.blacklisting_enabled);
+        assert!(config.builder_circuit_breaker.global_disabled);
     }
 
     #[test]


### PR DESCRIPTION
Add opt-in `--builder-blacklisting-enabled` flag to enable per-builder blacklisting in Gloas circuit breaker, independent of `--builder-disable-checks` flag. The existing breaker is only triggered by consecutive withheld payloads on the canonical chain. 

With this feature enabled builder is tracked individually, a builder that fails to deliver a payload is blacklisted for an epoch, escalating by another epoch per further withholding, up to `--builder-max-blacklisted-period` config value (default to `8` epochs) and decrease the counter when the builder reveal the payload timely, eventually clear the name from the blacklist entries. Once blacklisted, their bid will not be considered until slot `blacklisted_until` as the punishment for withholding the payload.